### PR TITLE
LPD-93226 Support project scope when creating a vocabulary

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetVocabularyStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetVocabularyStagedModelDataHandler.java
@@ -11,6 +11,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
@@ -473,7 +474,8 @@ public class AssetVocabularyStagedModelDataHandler
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			importedVocabularyId,
-			ListUtil.toLongArray(groupIds, Long::longValue));
+			ListUtil.toLongArray(groupIds, Long::longValue),
+			DepotConstants.TYPE_SPACE);
 	}
 
 	private boolean _validateMissingReference(

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetVocabularyModelDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetVocabularyModelDocumentContributor.java
@@ -8,6 +8,7 @@ package com.liferay.asset.categories.internal.search.spi.model.index.contributor
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.search.Document;
@@ -59,7 +60,9 @@ public class AssetVocabularyModelDocumentContributor
 			"categoriesCount", assetVocabulary.getCategoriesCount());
 		document.addKeyword("classNameIds", _getClassNameIds(assetVocabulary));
 		document.addKeyword(
-			"groupIds", _getGroupIds(assetVocabulary.getVocabularyId()));
+			"groupIds",
+			_getGroupIds(
+				assetVocabulary.getVocabularyId(), DepotConstants.TYPE_SPACE));
 		document.addLocalizedKeyword(
 			"localized_title",
 			_localization.populateLocalizationMap(
@@ -67,6 +70,11 @@ public class AssetVocabularyModelDocumentContributor
 				assetVocabulary.getDefaultLanguageId(),
 				assetVocabulary.getGroupId()),
 			true, true);
+		document.addKeyword(
+			"projectDepotEntryGroupIds",
+			_getGroupIds(
+				assetVocabulary.getVocabularyId(),
+				DepotConstants.TYPE_PROJECT));
 	}
 
 	private long[] _getClassNameIds(AssetVocabulary assetVocabulary) {
@@ -76,10 +84,11 @@ public class AssetVocabularyModelDocumentContributor
 		return assetVocabularySettingsHelper.getClassNameIds();
 	}
 
-	private long[] _getGroupIds(long vocabularyId) {
+	private long[] _getGroupIds(long vocabularyId, int depotEntryType) {
 		return ListUtil.toLongArray(
 			_assetVocabularyGroupRelLocalService.
-				getAssetVocabularyGroupRelsByVocabularyId(vocabularyId),
+				getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+					vocabularyId, depotEntryType),
 			AssetVocabularyGroupRel::getGroupId);
 	}
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/change/tracking/test/AssetVocabularyGroupRelTableReferenceDefinitionTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/change/tracking/test/AssetVocabularyGroupRelTableReferenceDefinitionTest.java
@@ -10,6 +10,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
@@ -56,7 +57,8 @@ public class AssetVocabularyGroupRelTableReferenceDefinitionTest
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
 		return _assetVocabularyGroupRelLocalService.addAssetVocabularyGroupRel(
-			_assetVocabulary.getVocabularyId(), _group.getGroupId());
+			_assetVocabulary.getVocabularyId(), _group.getGroupId(),
+			DepotConstants.TYPE_ANY);
 	}
 
 	private AssetVocabulary _assetVocabulary;

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryPortletDataHandlerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryPortletDataHandlerTest.java
@@ -250,7 +250,7 @@ public class AssetCategoryPortletDataHandlerTest
 
 			_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 				assetVocabulary.getVocabularyId(),
-				new long[] {depotGroup.getGroupId()});
+				new long[] {depotGroup.getGroupId()}, depotEntry.getType());
 
 			File larFile = _exportLayoutsAsFile();
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetVocabularyIndexerIndexedFieldsTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetVocabularyIndexerIndexedFieldsTest.java
@@ -10,6 +10,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -112,7 +113,8 @@ public class AssetVocabularyIndexerIndexedFieldsTest {
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			assetVocabulary.getVocabularyId(),
-			new long[] {group1.getGroupId(), group2.getGroupId()});
+			new long[] {group1.getGroupId(), group2.getGroupId()},
+			DepotConstants.TYPE_SPACE);
 
 		String searchTerm = "新しい";
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyGroupRelLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyGroupRelLocalServiceTest.java
@@ -13,6 +13,7 @@ import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -69,7 +70,7 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 
 		for (long assetVocabularyId : assetVocabularyIds) {
 			_assetVocabularyGroupRelLocalService.addAssetVocabularyGroupRel(
-				group.getGroupId(), assetVocabularyId);
+				group.getGroupId(), assetVocabularyId, DepotConstants.TYPE_ANY);
 		}
 
 		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
@@ -110,7 +111,8 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 		long[] groupIds = {group1.getGroupId(), group2.getGroupId()};
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-			_assetVocabulary.getVocabularyId(), groupIds);
+			_assetVocabulary.getVocabularyId(), groupIds,
+			DepotConstants.TYPE_ANY);
 
 		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
 			_assetVocabularyGroupRelLocalService.
@@ -151,7 +153,8 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 		long[] groupIds = {group1.getGroupId(), group2.getGroupId()};
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-			_assetVocabulary.getVocabularyId(), groupIds);
+			_assetVocabulary.getVocabularyId(), groupIds,
+			DepotConstants.TYPE_ANY);
 
 		Assert.assertEquals(
 			2,
@@ -229,7 +232,7 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			_assetVocabulary.getVocabularyId(),
-			new long[] {group1.getGroupId()});
+			new long[] {group1.getGroupId()}, DepotConstants.TYPE_ANY);
 
 		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
 			_assetVocabularyGroupRelLocalService.
@@ -248,7 +251,7 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			_assetVocabulary.getVocabularyId(),
-			new long[] {group2.getGroupId()});
+			new long[] {group2.getGroupId()}, DepotConstants.TYPE_ANY);
 
 		assetVocabularyGroupRels =
 			_assetVocabularyGroupRelLocalService.
@@ -269,7 +272,7 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			assetVocabulary.getVocabularyId(),
-			new long[] {GroupConstants.GROUP_ID_ALL});
+			new long[] {GroupConstants.GROUP_ID_ALL}, DepotConstants.TYPE_ANY);
 
 		Group group = GroupTestUtil.addGroup();
 
@@ -282,7 +285,8 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 				_assetVocabularyGroupRelLocalService.
 					setAssetVocabularyGroupRels(
 						assetVocabulary.getVocabularyId(),
-						new long[] {group.getGroupId()}));
+						new long[] {group.getGroupId()},
+						DepotConstants.TYPE_ANY));
 	}
 
 	private void _testSetAssetVocabularyGroupRelsWithoutGroupIds()
@@ -290,7 +294,8 @@ public class AssetVocabularyGroupRelLocalServiceTest {
 
 		try {
 			_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-				_assetVocabulary.getVocabularyId(), new long[0]);
+				_assetVocabulary.getVocabularyId(), new long[0],
+				DepotConstants.TYPE_ANY);
 
 			Assert.fail();
 		}

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
@@ -192,14 +192,14 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			assetVocabulary1.getVocabularyId(),
-			new long[] {depotEntry1.getGroupId()});
+			new long[] {depotEntry1.getGroupId()}, depotEntry1.getType());
 
 		AssetVocabulary assetVocabulary2 = AssetTestUtil.addVocabulary(
 			cmsGroup.getGroupId(), classNameId, classTypeId, false);
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			assetVocabulary2.getVocabularyId(),
-			new long[] {depotEntry2.getGroupId()});
+			new long[] {depotEntry2.getGroupId()}, depotEntry2.getType());
 
 		InfoFieldSet infoFieldSet =
 			_assetEntryInfoItemFieldSetProvider.getInfoFieldSet(

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryServiceTest.java
@@ -325,7 +325,8 @@ public class AssetEntryServiceTest {
 			AssetCategoryConstants.ALL_CLASS_TYPE_PK, true);
 
 		_assetVocabularyGroupRelLocalService.addAssetVocabularyGroupRel(
-			_depotEntry.getGroupId(), assetVocabulary.getVocabularyId());
+			_depotEntry.getGroupId(), assetVocabulary.getVocabularyId(),
+			_depotEntry.getType());
 
 		_assetEntryLocalService.validate(
 			_depotEntry.getGroupId(), assetEntry.getClassName(),

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -953,7 +953,8 @@ public class TaxonomyCategoryResourceImpl
 					_assetVocabularyGroupRelLocalService.
 						setAssetVocabularyGroupRels(
 							assetVocabulary.getVocabularyId(),
-							new long[] {GroupConstants.GROUP_ID_ALL});
+							new long[] {GroupConstants.GROUP_ID_ALL},
+							DepotConstants.TYPE_SPACE);
 				}
 			}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
@@ -36,7 +37,6 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.User;
@@ -528,7 +528,8 @@ public class TaxonomyVocabularyResourceImpl
 			_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 				assetVocabulary.getVocabularyId(),
 				_getAssetLibraryGroupIds(
-					group.getCompanyId(), taxonomyVocabulary));
+					group.getCompanyId(), taxonomyVocabulary),
+				DepotConstants.TYPE_SPACE);
 		}
 
 		return assetVocabulary;
@@ -1075,19 +1076,10 @@ public class TaxonomyVocabularyResourceImpl
 			new HashSet<>(descriptionMap.keySet()));
 
 		if (FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
-			if (ArrayUtil.isNotEmpty(taxonomyVocabulary.getAssetLibraries())) {
-				_assetVocabularyGroupRelLocalService.
-					setAssetVocabularyGroupRels(
-						assetVocabulary.getVocabularyId(),
-						_getAssetLibraryGroupIds(
-							companyId, taxonomyVocabulary));
-			}
-			else {
-				_assetVocabularyGroupRelLocalService.
-					setAssetVocabularyGroupRels(
-						assetVocabulary.getVocabularyId(),
-						new long[] {GroupConstants.GROUP_ID_ALL});
-			}
+			_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
+				assetVocabulary.getVocabularyId(),
+				_getAssetLibraryGroupIds(companyId, taxonomyVocabulary),
+				DepotConstants.TYPE_SPACE);
 		}
 
 		return _assetVocabularyService.updateVocabulary(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -205,7 +205,8 @@ public class TaxonomyCategoryResourceTest
 				testGroup.getGroupId(), TestPropsValues.getUserId()));
 
 		_assetVocabularyGroupRelLocalService.addAssetVocabularyGroupRel(
-			depotEntry2.getGroupId(), assetVocabulary2.getVocabularyId());
+			depotEntry2.getGroupId(), assetVocabulary2.getVocabularyId(),
+			depotEntry2.getType());
 
 		page = taxonomyCategoryResource.getAssetLibraryTaxonomyCategoriesPage(
 			depotEntry1.getDepotEntryId(), null, null, null,

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/AssetVocabularyModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/AssetVocabularyModelListenerTest.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class AssetVocabularyModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = CMSTestUtil.getOrAddGroup(
+			AssetVocabularyModelListenerTest.class);
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-93226")
+	public void testOnAfterCreate() throws Exception {
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
+			_assetVocabularyGroupRelLocalService.
+				getAssetVocabularyGroupRelsByVocabularyId(
+					assetVocabulary.getVocabularyId());
+
+		Assert.assertEquals(
+			assetVocabularyGroupRels.toString(), 1,
+			assetVocabularyGroupRels.size());
+
+		AssetVocabularyGroupRel assetVocabularyGroupRel =
+			assetVocabularyGroupRels.get(0);
+
+		Assert.assertEquals(
+			GroupConstants.GROUP_ID_ALL, assetVocabularyGroupRel.getGroupId());
+		Assert.assertEquals(
+			DepotConstants.TYPE_SPACE,
+			assetVocabularyGroupRel.getDepotEntryType());
+	}
+
+	@Inject
+	private AssetVocabularyGroupRelLocalService
+		_assetVocabularyGroupRelLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	private Group _group;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/DepotEntryModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/DepotEntryModelListenerTest.java
@@ -101,7 +101,8 @@ public class DepotEntryModelListenerTest {
 		long[] groupIds = {depotEntry1.getGroupId(), depotEntry2.getGroupId()};
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-			assetVocabulary.getVocabularyId(), groupIds);
+			assetVocabulary.getVocabularyId(), groupIds,
+			DepotConstants.TYPE_SPACE);
 
 		assetVocabularyGroupRels =
 			_assetVocabularyGroupRelLocalService.

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSAssetVocabularyLocalServiceWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSAssetVocabularyLocalServiceWrapperTest.java
@@ -87,7 +87,8 @@ public class CMSAssetVocabularyLocalServiceWrapperTest {
 		_cmsAssetVocabularies.add(assetVocabulary);
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-			assetVocabulary.getVocabularyId(), groupIds);
+			assetVocabulary.getVocabularyId(), groupIds,
+			DepotConstants.TYPE_SPACE);
 
 		return assetVocabulary;
 	}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSAssetVocabularyServiceWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSAssetVocabularyServiceWrapperTest.java
@@ -88,7 +88,8 @@ public class CMSAssetVocabularyServiceWrapperTest {
 		_cmsAssetVocabularies.add(assetVocabulary);
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-			assetVocabulary.getVocabularyId(), new long[] {groupId});
+			assetVocabulary.getVocabularyId(), new long[] {groupId},
+			DepotConstants.TYPE_SPACE);
 
 		return assetVocabulary;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/AssetVocabularyModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/AssetVocabularyModelListener.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.GroupLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = ModelListener.class)
+public class AssetVocabularyModelListener
+	extends BaseModelListener<AssetVocabulary> {
+
+	@Override
+	public void onAfterCreate(AssetVocabulary assetVocabulary)
+		throws ModelListenerException {
+
+		try {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					assetVocabulary.getCompanyId(), "LPD-17564")) {
+
+				return;
+			}
+
+			Group group = _groupLocalService.fetchGroup(
+				assetVocabulary.getGroupId());
+
+			if ((group == null) || !group.isCMS()) {
+				return;
+			}
+
+			_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
+				assetVocabulary.getVocabularyId(),
+				new long[] {GroupConstants.GROUP_ID_ALL},
+				DepotConstants.TYPE_SPACE);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	@Reference
+	private AssetVocabularyGroupRelLocalService
+		_assetVocabularyGroupRelLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/DepotEntryModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/DepotEntryModelListener.java
@@ -51,7 +51,8 @@ public class DepotEntryModelListener extends BaseModelListener<DepotEntry> {
 					_assetVocabularyGroupRelLocalService.
 						addAssetVocabularyGroupRel(
 							GroupConstants.ANY_PARENT_GROUP_ID,
-							assetVocabularyGroupRel.getVocabularyId());
+							assetVocabularyGroupRel.getVocabularyId(),
+							DepotConstants.TYPE_SPACE);
 				}
 			}
 		}

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyGroupRelPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyGroupRelPersistenceTest.java
@@ -126,6 +126,8 @@ public class AssetVocabularyGroupRelPersistenceTest {
 
 		newAssetVocabularyGroupRel.setVocabularyId(RandomTestUtil.nextLong());
 
+		newAssetVocabularyGroupRel.setDepotEntryType(RandomTestUtil.nextInt());
+
 		newAssetVocabularyGroupRel = _persistence.update(
 			newAssetVocabularyGroupRel);
 
@@ -156,6 +158,9 @@ public class AssetVocabularyGroupRelPersistenceTest {
 		Assert.assertEquals(
 			existingAssetVocabularyGroupRel.getVocabularyId(),
 			newAssetVocabularyGroupRel.getVocabularyId());
+		Assert.assertEquals(
+			existingAssetVocabularyGroupRel.getDepotEntryType(),
+			newAssetVocabularyGroupRel.getDepotEntryType());
 	}
 
 	@Test
@@ -208,6 +213,23 @@ public class AssetVocabularyGroupRelPersistenceTest {
 	}
 
 	@Test
+	public void testCountByV_D() throws Exception {
+		_persistence.countByV_D(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextInt());
+
+		_persistence.countByV_D(0L, 0);
+	}
+
+	@Test
+	public void testCountByG_V_D() throws Exception {
+		_persistence.countByG_V_D(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
+			RandomTestUtil.nextInt());
+
+		_persistence.countByG_V_D(0L, 0L, 0);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		AssetVocabularyGroupRel newAssetVocabularyGroupRel =
 			addAssetVocabularyGroupRel();
@@ -239,7 +261,8 @@ public class AssetVocabularyGroupRelPersistenceTest {
 		return OrderByComparatorFactoryUtil.create(
 			"AssetVocabularyGroupRel", "mvccVersion", true, "ctCollectionId",
 			true, "uuid", true, "assetVocabularyGroupRelId", true, "groupId",
-			true, "companyId", true, "vocabularyId", true);
+			true, "companyId", true, "vocabularyId", true, "depotEntryType",
+			true);
 	}
 
 	@Test
@@ -556,6 +579,22 @@ public class AssetVocabularyGroupRelPersistenceTest {
 			ReflectionTestUtil.<Long>invoke(
 				assetVocabularyGroupRel, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "vocabularyId"));
+
+		Assert.assertEquals(
+			Long.valueOf(assetVocabularyGroupRel.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				assetVocabularyGroupRel, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			Long.valueOf(assetVocabularyGroupRel.getVocabularyId()),
+			ReflectionTestUtil.<Long>invoke(
+				assetVocabularyGroupRel, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "vocabularyId"));
+		Assert.assertEquals(
+			Integer.valueOf(assetVocabularyGroupRel.getDepotEntryType()),
+			ReflectionTestUtil.<Integer>invoke(
+				assetVocabularyGroupRel, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "depotEntryType"));
 	}
 
 	protected AssetVocabularyGroupRel addAssetVocabularyGroupRel()
@@ -576,6 +615,8 @@ public class AssetVocabularyGroupRelPersistenceTest {
 
 		assetVocabularyGroupRel.setVocabularyId(RandomTestUtil.nextLong());
 
+		assetVocabularyGroupRel.setDepotEntryType(RandomTestUtil.nextInt());
+
 		_assetVocabularyGroupRels.add(
 			_persistence.update(assetVocabularyGroupRel));
 
@@ -588,4 +629,4 @@ public class AssetVocabularyGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1480852625
+// LIFERAY-SERVICE-BUILDER-HASH:-279284618

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -1390,6 +1390,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="vocabularyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="depotEntryType" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.portlet.documentlibrary.model.impl.DLFileEntryImpl" table="DLFileEntry">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="fileEntryId" type="long">

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -211,6 +211,7 @@
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
 		<field name="vocabularyId" type="long" />
+		<field name="depotEntryType" type="int" />
 	</model>
 	<model name="com.liferay.counter.kernel.model.Counter">
 		<field name="name" type="String">

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -776,6 +776,13 @@ public class PortalUpgradeProcessRegistryImpl
 			new Version(38, 5, 0),
 			UpgradeProcessFactory.addColumns(
 				"Layout", "styleBookEntryScopeERC VARCHAR(75) null"));
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 6, 0),
+			UpgradeProcessFactory.addColumns(
+				"AssetVocabularyGroupRel", "depotEntryType INTEGER"),
+			UpgradeProcessFactory.runSQL(
+				"update AssetVocabularyGroupRel set depotEntryType = 1"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyGroupRelCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyGroupRelCacheModel.java
@@ -67,7 +67,7 @@ public class AssetVocabularyGroupRelCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(15);
+		StringBundler sb = new StringBundler(17);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -83,6 +83,8 @@ public class AssetVocabularyGroupRelCacheModel
 		sb.append(companyId);
 		sb.append(", vocabularyId=");
 		sb.append(vocabularyId);
+		sb.append(", depotEntryType=");
+		sb.append(depotEntryType);
 		sb.append("}");
 
 		return sb.toString();
@@ -108,6 +110,7 @@ public class AssetVocabularyGroupRelCacheModel
 		assetVocabularyGroupRelImpl.setGroupId(groupId);
 		assetVocabularyGroupRelImpl.setCompanyId(companyId);
 		assetVocabularyGroupRelImpl.setVocabularyId(vocabularyId);
+		assetVocabularyGroupRelImpl.setDepotEntryType(depotEntryType);
 
 		assetVocabularyGroupRelImpl.resetOriginalValues();
 
@@ -128,6 +131,8 @@ public class AssetVocabularyGroupRelCacheModel
 		companyId = objectInput.readLong();
 
 		vocabularyId = objectInput.readLong();
+
+		depotEntryType = objectInput.readInt();
 	}
 
 	@Override
@@ -150,6 +155,8 @@ public class AssetVocabularyGroupRelCacheModel
 		objectOutput.writeLong(companyId);
 
 		objectOutput.writeLong(vocabularyId);
+
+		objectOutput.writeInt(depotEntryType);
 	}
 
 	public long mvccVersion;
@@ -159,6 +166,7 @@ public class AssetVocabularyGroupRelCacheModel
 	public long groupId;
 	public long companyId;
 	public long vocabularyId;
+	public int depotEntryType;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:282957432
+// LIFERAY-SERVICE-BUILDER-HASH:1495904907

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyGroupRelModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyGroupRelModelImpl.java
@@ -63,7 +63,7 @@ public class AssetVocabularyGroupRelModelImpl
 		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
 		{"uuid_", Types.VARCHAR}, {"assetVocabularyGroupRelId", Types.BIGINT},
 		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"vocabularyId", Types.BIGINT}
+		{"vocabularyId", Types.BIGINT}, {"depotEntryType", Types.INTEGER}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -77,10 +77,11 @@ public class AssetVocabularyGroupRelModelImpl
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("vocabularyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("depotEntryType", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table AssetVocabularyGroupRel (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,assetVocabularyGroupRelId LONG not null,groupId LONG,companyId LONG,vocabularyId LONG,primary key (assetVocabularyGroupRelId, ctCollectionId))";
+		"create table AssetVocabularyGroupRel (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,assetVocabularyGroupRelId LONG not null,groupId LONG,companyId LONG,vocabularyId LONG,depotEntryType INTEGER,primary key (assetVocabularyGroupRelId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table AssetVocabularyGroupRel";
@@ -127,26 +128,32 @@ public class AssetVocabularyGroupRelModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 2L;
+	public static final long DEPOTENTRYTYPE_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 4L;
+	public static final long GROUPID_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long VOCABULARYID_COLUMN_BITMASK = 8L;
+	public static final long UUID_COLUMN_BITMASK = 8L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long VOCABULARYID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long ASSETVOCABULARYGROUPRELID_COLUMN_BITMASK = 16L;
+	public static final long ASSETVOCABULARYGROUPRELID_COLUMN_BITMASK = 32L;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.kernel.util.PropsUtil.get(
@@ -265,6 +272,8 @@ public class AssetVocabularyGroupRelModelImpl
 				"companyId", AssetVocabularyGroupRel::getCompanyId);
 			attributeGetterFunctions.put(
 				"vocabularyId", AssetVocabularyGroupRel::getVocabularyId);
+			attributeGetterFunctions.put(
+				"depotEntryType", AssetVocabularyGroupRel::getDepotEntryType);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -312,6 +321,10 @@ public class AssetVocabularyGroupRelModelImpl
 				"vocabularyId",
 				(BiConsumer<AssetVocabularyGroupRel, Long>)
 					AssetVocabularyGroupRel::setVocabularyId);
+			attributeSetterBiConsumers.put(
+				"depotEntryType",
+				(BiConsumer<AssetVocabularyGroupRel, Integer>)
+					AssetVocabularyGroupRel::setDepotEntryType);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -467,6 +480,31 @@ public class AssetVocabularyGroupRelModelImpl
 			this.<Long>getColumnOriginalValue("vocabularyId"));
 	}
 
+	@JSON
+	@Override
+	public int getDepotEntryType() {
+		return _depotEntryType;
+	}
+
+	@Override
+	public void setDepotEntryType(int depotEntryType) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_depotEntryType = depotEntryType;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public int getOriginalDepotEntryType() {
+		return GetterUtil.getInteger(
+			this.<Integer>getColumnOriginalValue("depotEntryType"));
+	}
+
 	public long getColumnBitmask() {
 		if (_columnBitmask > 0) {
 			return _columnBitmask;
@@ -533,6 +571,7 @@ public class AssetVocabularyGroupRelModelImpl
 		assetVocabularyGroupRelImpl.setGroupId(getGroupId());
 		assetVocabularyGroupRelImpl.setCompanyId(getCompanyId());
 		assetVocabularyGroupRelImpl.setVocabularyId(getVocabularyId());
+		assetVocabularyGroupRelImpl.setDepotEntryType(getDepotEntryType());
 
 		assetVocabularyGroupRelImpl.resetOriginalValues();
 
@@ -558,6 +597,8 @@ public class AssetVocabularyGroupRelModelImpl
 			this.<Long>getColumnOriginalValue("companyId"));
 		assetVocabularyGroupRelImpl.setVocabularyId(
 			this.<Long>getColumnOriginalValue("vocabularyId"));
+		assetVocabularyGroupRelImpl.setDepotEntryType(
+			this.<Integer>getColumnOriginalValue("depotEntryType"));
 
 		return assetVocabularyGroupRelImpl;
 	}
@@ -656,6 +697,8 @@ public class AssetVocabularyGroupRelModelImpl
 
 		assetVocabularyGroupRelCacheModel.vocabularyId = getVocabularyId();
 
+		assetVocabularyGroupRelCacheModel.depotEntryType = getDepotEntryType();
+
 		return assetVocabularyGroupRelCacheModel;
 	}
 
@@ -726,6 +769,7 @@ public class AssetVocabularyGroupRelModelImpl
 	private long _groupId;
 	private long _companyId;
 	private long _vocabularyId;
+	private int _depotEntryType;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -765,6 +809,7 @@ public class AssetVocabularyGroupRelModelImpl
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
 		_columnOriginalValues.put("vocabularyId", _vocabularyId);
+		_columnOriginalValues.put("depotEntryType", _depotEntryType);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -802,6 +847,8 @@ public class AssetVocabularyGroupRelModelImpl
 
 		columnBitmasks.put("vocabularyId", 64L);
 
+		columnBitmasks.put("depotEntryType", 128L);
+
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
 
@@ -809,4 +856,4 @@ public class AssetVocabularyGroupRelModelImpl
 	private AssetVocabularyGroupRel _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-949904790
+// LIFERAY-SERVICE-BUILDER-HASH:1004344284

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -335,6 +335,7 @@
 		<!-- Other fields -->
 
 		<column name="vocabularyId" type="long" />
+		<column name="depotEntryType" type="int" />
 
 		<!-- Finder methods -->
 
@@ -347,6 +348,15 @@
 		<finder name="G_V" return-type="AssetVocabularyGroupRel">
 			<finder-column name="groupId" />
 			<finder-column name="vocabularyId" />
+		</finder>
+		<finder name="V_D" return-type="Collection">
+			<finder-column name="vocabularyId" />
+			<finder-column name="depotEntryType" />
+		</finder>
+		<finder name="G_V_D" return-type="AssetVocabularyGroupRel">
+			<finder-column name="groupId" />
+			<finder-column name="vocabularyId" />
+			<finder-column name="depotEntryType" />
 		</finder>
 	</entity>
 	<exceptions>

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyGroupRelServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyGroupRelServiceHttp.java
@@ -43,7 +43,8 @@ public class AssetVocabularyGroupRelServiceHttp {
 
 	public static com.liferay.asset.kernel.model.AssetVocabularyGroupRel
 			addAssetVocabularyGroupRel(
-				HttpPrincipal httpPrincipal, long groupId, long vocabularyId)
+				HttpPrincipal httpPrincipal, long groupId, long vocabularyId,
+				int depotEntryType)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -53,7 +54,7 @@ public class AssetVocabularyGroupRelServiceHttp {
 				_addAssetVocabularyGroupRelParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, vocabularyId);
+				methodKey, groupId, vocabularyId, depotEntryType);
 
 			Object returnObj = null;
 
@@ -130,7 +131,8 @@ public class AssetVocabularyGroupRelServiceHttp {
 	}
 
 	public static void setAssetVocabularyGroupRels(
-			HttpPrincipal httpPrincipal, long vocabularyId, long[] groupIds)
+			HttpPrincipal httpPrincipal, long vocabularyId, long[] groupIds,
+			int depotEntryType)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -140,7 +142,7 @@ public class AssetVocabularyGroupRelServiceHttp {
 				_setAssetVocabularyGroupRelsParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, vocabularyId, groupIds);
+				methodKey, vocabularyId, groupIds, depotEntryType);
 
 			try {
 				TunnelUtil.invoke(httpPrincipal, methodHandler);
@@ -170,14 +172,14 @@ public class AssetVocabularyGroupRelServiceHttp {
 		AssetVocabularyGroupRelServiceHttp.class);
 
 	private static final Class<?>[] _addAssetVocabularyGroupRelParameterTypes0 =
-		new Class[] {long.class, long.class};
+		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[]
 		_getAssetVocabularyGroupRelsByVocabularyIdParameterTypes1 =
 			new Class[] {long.class};
 	private static final Class<?>[]
 		_setAssetVocabularyGroupRelsParameterTypes2 = new Class[] {
-			long.class, long[].class
+			long.class, long[].class, int.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:423677408
+// LIFERAY-SERVICE-BUILDER-HASH:1866084416

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyGroupRelLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyGroupRelLocalServiceImpl.java
@@ -31,12 +31,12 @@ public class AssetVocabularyGroupRelLocalServiceImpl
 
 	@Override
 	public AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws PortalException {
 
 		AssetVocabularyGroupRel assetVocabularyGroupRel =
-			assetVocabularyGroupRelPersistence.fetchByG_V(
-				groupId, vocabularyId);
+			assetVocabularyGroupRelPersistence.fetchByG_V_D(
+				groupId, vocabularyId, depotEntryType);
 
 		if (assetVocabularyGroupRel != null) {
 			return assetVocabularyGroupRel;
@@ -47,6 +47,7 @@ public class AssetVocabularyGroupRelLocalServiceImpl
 
 		assetVocabularyGroupRel.setGroupId(groupId);
 		assetVocabularyGroupRel.setVocabularyId(vocabularyId);
+		assetVocabularyGroupRel.setDepotEntryType(depotEntryType);
 
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
@@ -91,13 +92,23 @@ public class AssetVocabularyGroupRelLocalServiceImpl
 	}
 
 	@Override
+	public List<AssetVocabularyGroupRel>
+		getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+			long vocabularyId, int depotEntryType) {
+
+		return assetVocabularyGroupRelPersistence.findByV_D(
+			vocabularyId, depotEntryType);
+	}
+
+	@Override
 	public int getAssetVocabularyGroupRelsCount(long vocabularyId) {
 		return assetVocabularyGroupRelPersistence.countByVocabularyId(
 			vocabularyId);
 	}
 
 	@Override
-	public void setAssetVocabularyGroupRels(long vocabularyId, long[] groupIds)
+	public void setAssetVocabularyGroupRels(
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws PortalException {
 
 		if (ArrayUtil.isEmpty(groupIds)) {
@@ -106,10 +117,11 @@ public class AssetVocabularyGroupRelLocalServiceImpl
 
 		_validateSystemVocabulary(groupIds, vocabularyId);
 
-		assetVocabularyGroupRelPersistence.removeByVocabularyId(vocabularyId);
+		assetVocabularyGroupRelPersistence.removeByV_D(
+			vocabularyId, depotEntryType);
 
 		for (long groupId : groupIds) {
-			addAssetVocabularyGroupRel(groupId, vocabularyId);
+			addAssetVocabularyGroupRel(groupId, vocabularyId, depotEntryType);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyGroupRelServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyGroupRelServiceImpl.java
@@ -21,14 +21,14 @@ public class AssetVocabularyGroupRelServiceImpl
 
 	@Override
 	public AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws PortalException {
 
 		AssetVocabularyPermission.check(
 			getPermissionChecker(), vocabularyId, ActionKeys.UPDATE);
 
 		return assetVocabularyGroupRelLocalService.addAssetVocabularyGroupRel(
-			groupId, vocabularyId);
+			groupId, vocabularyId, depotEntryType);
 	}
 
 	@Override
@@ -44,14 +44,15 @@ public class AssetVocabularyGroupRelServiceImpl
 	}
 
 	@Override
-	public void setAssetVocabularyGroupRels(long vocabularyId, long[] groupIds)
+	public void setAssetVocabularyGroupRels(
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws PortalException {
 
 		AssetVocabularyPermission.check(
 			getPermissionChecker(), vocabularyId, ActionKeys.UPDATE);
 
 		assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-			vocabularyId, groupIds);
+			vocabularyId, groupIds, depotEntryType);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -15,7 +15,6 @@ import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
-import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.exportimport.kernel.empty.model.EmptyModelManagerUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
@@ -25,7 +24,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -243,18 +241,6 @@ public class AssetVocabularyLocalServiceImpl
 		else {
 			addVocabularyResources(
 				vocabulary, serviceContext.getModelPermissions());
-		}
-
-		if (FeatureFlagManagerUtil.isEnabled(
-				vocabulary.getCompanyId(), "LPD-17564")) {
-
-			Group group = _groupLocalService.fetchGroup(groupId);
-
-			if ((group != null) && group.isCMS()) {
-				_assetVocabularyGroupRelLocalService.
-					setAssetVocabularyGroupRels(
-						vocabularyId, new long[] {GroupConstants.GROUP_ID_ALL});
-			}
 		}
 
 		return vocabulary;
@@ -858,10 +844,6 @@ public class AssetVocabularyLocalServiceImpl
 
 	@BeanReference(type = AssetCategoryLocalService.class)
 	private AssetCategoryLocalService _assetCategoryLocalService;
-
-	@BeanReference(type = AssetVocabularyGroupRelLocalService.class)
-	private AssetVocabularyGroupRelLocalService
-		_assetVocabularyGroupRelLocalService;
 
 	@BeanReference(type = ClassNameLocalService.class)
 	private ClassNameLocalService _classNameLocalService;

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetVocabularyGroupRelPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetVocabularyGroupRelPersistenceImpl.java
@@ -569,6 +569,181 @@ public class AssetVocabularyGroupRelPersistenceImpl
 			new Object[] {groupId, vocabularyId});
 	}
 
+	private CollectionPersistenceFinder
+		<AssetVocabularyGroupRel, NoSuchVocabularyGroupRelException>
+			_collectionPersistenceFinderByV_D;
+
+	/**
+	 * Returns an ordered range of all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetVocabularyGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param start the lower bound of the range of asset vocabulary group rels
+	 * @param end the upper bound of the range of asset vocabulary group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset vocabulary group rels
+	 */
+	@Override
+	public List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType, int start, int end,
+		OrderByComparator<AssetVocabularyGroupRel> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByV_D.find(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {vocabularyId, depotEntryType}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first asset vocabulary group rel in the ordered set where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset vocabulary group rel
+	 * @throws NoSuchVocabularyGroupRelException if a matching asset vocabulary group rel could not be found
+	 */
+	@Override
+	public AssetVocabularyGroupRel findByV_D_First(
+			long vocabularyId, int depotEntryType,
+			OrderByComparator<AssetVocabularyGroupRel> orderByComparator)
+		throws NoSuchVocabularyGroupRelException {
+
+		return _collectionPersistenceFinderByV_D.findFirst(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {vocabularyId, depotEntryType}, orderByComparator);
+	}
+
+	/**
+	 * Returns the first asset vocabulary group rel in the ordered set where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	@Override
+	public AssetVocabularyGroupRel fetchByV_D_First(
+		long vocabularyId, int depotEntryType,
+		OrderByComparator<AssetVocabularyGroupRel> orderByComparator) {
+
+		return _collectionPersistenceFinderByV_D.fetchFirst(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {vocabularyId, depotEntryType}, orderByComparator);
+	}
+
+	/**
+	 * Removes all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63; from the database.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 */
+	@Override
+	public void removeByV_D(long vocabularyId, int depotEntryType) {
+		_collectionPersistenceFinderByV_D.remove(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {vocabularyId, depotEntryType});
+	}
+
+	/**
+	 * Returns the number of asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the number of matching asset vocabulary group rels
+	 */
+	@Override
+	public int countByV_D(long vocabularyId, int depotEntryType) {
+		return _collectionPersistenceFinderByV_D.count(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {vocabularyId, depotEntryType});
+	}
+
+	private UniquePersistenceFinder
+		<AssetVocabularyGroupRel, NoSuchVocabularyGroupRelException>
+			_uniquePersistenceFinderByG_V_D;
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or throws a <code>NoSuchVocabularyGroupRelException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the matching asset vocabulary group rel
+	 * @throws NoSuchVocabularyGroupRelException if a matching asset vocabulary group rel could not be found
+	 */
+	@Override
+	public AssetVocabularyGroupRel findByG_V_D(
+			long groupId, long vocabularyId, int depotEntryType)
+		throws NoSuchVocabularyGroupRelException {
+
+		return _uniquePersistenceFinderByG_V_D.find(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {groupId, vocabularyId, depotEntryType});
+	}
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	@Override
+	public AssetVocabularyGroupRel fetchByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType,
+		boolean useFinderCache) {
+
+		return _uniquePersistenceFinderByG_V_D.fetch(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {groupId, vocabularyId, depotEntryType},
+			useFinderCache);
+	}
+
+	/**
+	 * Removes the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the asset vocabulary group rel that was removed
+	 */
+	@Override
+	public AssetVocabularyGroupRel removeByG_V_D(
+			long groupId, long vocabularyId, int depotEntryType)
+		throws NoSuchVocabularyGroupRelException {
+
+		AssetVocabularyGroupRel assetVocabularyGroupRel = findByG_V_D(
+			groupId, vocabularyId, depotEntryType);
+
+		return remove(assetVocabularyGroupRel);
+	}
+
+	/**
+	 * Returns the number of asset vocabulary group rels where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the number of matching asset vocabulary group rels
+	 */
+	@Override
+	public int countByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType) {
+
+		return _uniquePersistenceFinderByG_V_D.count(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {groupId, vocabularyId, depotEntryType});
+	}
+
 	public AssetVocabularyGroupRelPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -828,6 +1003,7 @@ public class AssetVocabularyGroupRelPersistenceImpl
 		ctStrictColumnNames.add("groupId");
 		ctStrictColumnNames.add("companyId");
 		ctMergeColumnNames.add("vocabularyId");
+		ctMergeColumnNames.add("depotEntryType");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);
@@ -994,6 +1170,62 @@ public class AssetVocabularyGroupRelPersistenceImpl
 				FinderColumn.Type.LONG, "=", true, true,
 				AssetVocabularyGroupRel::getVocabularyId));
 
+		_collectionPersistenceFinderByV_D = new CollectionPersistenceFinder<>(
+			this,
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByV_D",
+				new String[] {
+					Long.class.getName(), Integer.class.getName(),
+					Integer.class.getName(), Integer.class.getName(),
+					OrderByComparator.class.getName()
+				},
+				new String[] {"vocabularyId", "depotEntryType"}, true),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByV_D",
+				new String[] {Long.class.getName(), Integer.class.getName()},
+				new String[] {"vocabularyId", "depotEntryType"}, true),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByV_D",
+				new String[] {Long.class.getName(), Integer.class.getName()},
+				new String[] {"vocabularyId", "depotEntryType"}, false),
+			_SQL_SELECT_ASSETVOCABULARYGROUPREL_WHERE,
+			_SQL_COUNT_ASSETVOCABULARYGROUPREL_WHERE,
+			AssetVocabularyGroupRelModelImpl.ORDER_BY_JPQL,
+			_ENTITY_ALIAS_PREFIX, "", "",
+			new FinderColumn<>(
+				"assetVocabularyGroupRel.", "vocabularyId",
+				FinderColumn.Type.LONG, "=", true, true,
+				AssetVocabularyGroupRel::getVocabularyId),
+			new FinderColumn<>(
+				"assetVocabularyGroupRel.", "depotEntryType",
+				FinderColumn.Type.INTEGER, "=", true, true,
+				AssetVocabularyGroupRel::getDepotEntryType));
+
+		_uniquePersistenceFinderByG_V_D = new UniquePersistenceFinder<>(
+			this,
+			createUniqueFinderPath(
+				FINDER_CLASS_NAME_ENTITY, "fetchByG_V_D",
+				new String[] {
+					Long.class.getName(), Long.class.getName(),
+					Integer.class.getName()
+				},
+				new String[] {"groupId", "vocabularyId", "depotEntryType"}, 0,
+				0, false, AssetVocabularyGroupRel::getGroupId,
+				AssetVocabularyGroupRel::getVocabularyId,
+				AssetVocabularyGroupRel::getDepotEntryType),
+			_SQL_SELECT_ASSETVOCABULARYGROUPREL_WHERE, "",
+			new FinderColumn<>(
+				"assetVocabularyGroupRel.", "groupId", FinderColumn.Type.LONG,
+				"=", true, true, AssetVocabularyGroupRel::getGroupId),
+			new FinderColumn<>(
+				"assetVocabularyGroupRel.", "vocabularyId",
+				FinderColumn.Type.LONG, "=", true, true,
+				AssetVocabularyGroupRel::getVocabularyId),
+			new FinderColumn<>(
+				"assetVocabularyGroupRel.", "depotEntryType",
+				FinderColumn.Type.INTEGER, "=", true, true,
+				AssetVocabularyGroupRel::getDepotEntryType));
+
 		AssetVocabularyGroupRelUtil.setPersistence(this);
 	}
 
@@ -1031,4 +1263,4 @@ public class AssetVocabularyGroupRelPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1566590061
+// LIFERAY-SERVICE-BUILDER-HASH:264825164

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyGroupRelModel.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyGroupRelModel.java
@@ -156,6 +156,20 @@ public interface AssetVocabularyGroupRelModel
 	 */
 	public void setVocabularyId(long vocabularyId);
 
+	/**
+	 * Returns the depot entry type of this asset vocabulary group rel.
+	 *
+	 * @return the depot entry type of this asset vocabulary group rel
+	 */
+	public int getDepotEntryType();
+
+	/**
+	 * Sets the depot entry type of this asset vocabulary group rel.
+	 *
+	 * @param depotEntryType the depot entry type of this asset vocabulary group rel
+	 */
+	public void setDepotEntryType(int depotEntryType);
+
 	@Override
 	public AssetVocabularyGroupRel cloneWithOriginalValues();
 
@@ -164,4 +178,4 @@ public interface AssetVocabularyGroupRelModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1105584765
+// LIFERAY-SERVICE-BUILDER-HASH:-1888959058

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyGroupRelTable.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyGroupRelTable.java
@@ -43,10 +43,14 @@ public class AssetVocabularyGroupRelTable
 	public final Column<AssetVocabularyGroupRelTable, Long> vocabularyId =
 		createColumn(
 			"vocabularyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<AssetVocabularyGroupRelTable, Integer> depotEntryType =
+		createColumn(
+			"depotEntryType", Integer.class, Types.INTEGER,
+			Column.FLAG_DEFAULT);
 
 	private AssetVocabularyGroupRelTable() {
 		super("AssetVocabularyGroupRel", AssetVocabularyGroupRelTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1244633168
+// LIFERAY-SERVICE-BUILDER-HASH:-1754020667

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyGroupRelWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyGroupRelWrapper.java
@@ -44,6 +44,7 @@ public class AssetVocabularyGroupRelWrapper
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
 		attributes.put("vocabularyId", getVocabularyId());
+		attributes.put("depotEntryType", getDepotEntryType());
 
 		return attributes;
 	}
@@ -92,6 +93,12 @@ public class AssetVocabularyGroupRelWrapper
 		if (vocabularyId != null) {
 			setVocabularyId(vocabularyId);
 		}
+
+		Integer depotEntryType = (Integer)attributes.get("depotEntryType");
+
+		if (depotEntryType != null) {
+			setDepotEntryType(depotEntryType);
+		}
 	}
 
 	@Override
@@ -127,6 +134,16 @@ public class AssetVocabularyGroupRelWrapper
 	@Override
 	public long getCtCollectionId() {
 		return model.getCtCollectionId();
+	}
+
+	/**
+	 * Returns the depot entry type of this asset vocabulary group rel.
+	 *
+	 * @return the depot entry type of this asset vocabulary group rel
+	 */
+	@Override
+	public int getDepotEntryType() {
+		return model.getDepotEntryType();
 	}
 
 	/**
@@ -215,6 +232,16 @@ public class AssetVocabularyGroupRelWrapper
 	}
 
 	/**
+	 * Sets the depot entry type of this asset vocabulary group rel.
+	 *
+	 * @param depotEntryType the depot entry type of this asset vocabulary group rel
+	 */
+	@Override
+	public void setDepotEntryType(int depotEntryType) {
+		model.setDepotEntryType(depotEntryType);
+	}
+
+	/**
 	 * Sets the group ID of this asset vocabulary group rel.
 	 *
 	 * @param groupId the group ID of this asset vocabulary group rel
@@ -291,4 +318,4 @@ public class AssetVocabularyGroupRelWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1833640854
+// LIFERAY-SERVICE-BUILDER-HASH:561934020

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelLocalService.java
@@ -80,7 +80,7 @@ public interface AssetVocabularyGroupRelLocalService
 		AssetVocabularyGroupRel assetVocabularyGroupRel);
 
 	public AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws PortalException;
 
 	/**
@@ -306,6 +306,11 @@ public interface AssetVocabularyGroupRelLocalService
 	public List<AssetVocabularyGroupRel>
 		getAssetVocabularyGroupRelsByVocabularyId(long vocabularyId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AssetVocabularyGroupRel>
+		getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+			long vocabularyId, int depotEntryType);
+
 	/**
 	 * Returns the number of asset vocabulary group rels.
 	 *
@@ -335,7 +340,8 @@ public interface AssetVocabularyGroupRelLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public void setAssetVocabularyGroupRels(long vocabularyId, long[] groupIds)
+	public void setAssetVocabularyGroupRels(
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws PortalException;
 
 	/**
@@ -368,4 +374,4 @@ public interface AssetVocabularyGroupRelLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-714504042
+// LIFERAY-SERVICE-BUILDER-HASH:2135087332

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelLocalServiceUtil.java
@@ -53,10 +53,11 @@ public class AssetVocabularyGroupRelLocalServiceUtil {
 	}
 
 	public static AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws PortalException {
 
-		return getService().addAssetVocabularyGroupRel(groupId, vocabularyId);
+		return getService().addAssetVocabularyGroupRel(
+			groupId, vocabularyId, depotEntryType);
 	}
 
 	/**
@@ -347,6 +348,15 @@ public class AssetVocabularyGroupRelLocalServiceUtil {
 			vocabularyId);
 	}
 
+	public static List<AssetVocabularyGroupRel>
+		getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+			long vocabularyId, int depotEntryType) {
+
+		return getService().
+			getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+				vocabularyId, depotEntryType);
+	}
+
 	/**
 	 * Returns the number of asset vocabulary group rels.
 	 *
@@ -386,10 +396,11 @@ public class AssetVocabularyGroupRelLocalServiceUtil {
 	}
 
 	public static void setAssetVocabularyGroupRels(
-			long vocabularyId, long[] groupIds)
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws PortalException {
 
-		getService().setAssetVocabularyGroupRels(vocabularyId, groupIds);
+		getService().setAssetVocabularyGroupRels(
+			vocabularyId, groupIds, depotEntryType);
 	}
 
 	/**
@@ -420,4 +431,4 @@ public class AssetVocabularyGroupRelLocalServiceUtil {
 	private static volatile AssetVocabularyGroupRelLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1546189820
+// LIFERAY-SERVICE-BUILDER-HASH:1422452086

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelLocalServiceWrapper.java
@@ -54,11 +54,11 @@ public class AssetVocabularyGroupRelLocalServiceWrapper
 
 	@Override
 	public AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetVocabularyGroupRelLocalService.addAssetVocabularyGroupRel(
-			groupId, vocabularyId);
+			groupId, vocabularyId, depotEntryType);
 	}
 
 	/**
@@ -391,6 +391,16 @@ public class AssetVocabularyGroupRelLocalServiceWrapper
 			getAssetVocabularyGroupRelsByVocabularyId(vocabularyId);
 	}
 
+	@Override
+	public java.util.List<AssetVocabularyGroupRel>
+		getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+			long vocabularyId, int depotEntryType) {
+
+		return _assetVocabularyGroupRelLocalService.
+			getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+				vocabularyId, depotEntryType);
+	}
+
 	/**
 	 * Returns the number of asset vocabulary group rels.
 	 *
@@ -439,11 +449,12 @@ public class AssetVocabularyGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public void setAssetVocabularyGroupRels(long vocabularyId, long[] groupIds)
+	public void setAssetVocabularyGroupRels(
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
-			vocabularyId, groupIds);
+			vocabularyId, groupIds, depotEntryType);
 	}
 
 	/**
@@ -507,4 +518,4 @@ public class AssetVocabularyGroupRelLocalServiceWrapper
 		_assetVocabularyGroupRelLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1836138432
+// LIFERAY-SERVICE-BUILDER-HASH:-339713270

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelService.java
@@ -45,7 +45,7 @@ public interface AssetVocabularyGroupRelService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portlet.asset.service.impl.AssetVocabularyGroupRelServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the asset vocabulary group rel remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link AssetVocabularyGroupRelServiceUtil} if injection and service tracking are not available.
 	 */
 	public AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -60,8 +60,9 @@ public interface AssetVocabularyGroupRelService extends BaseService {
 	 */
 	public String getOSGiServiceIdentifier();
 
-	public void setAssetVocabularyGroupRels(long vocabularyId, long[] groupIds)
+	public void setAssetVocabularyGroupRels(
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2124105144
+// LIFERAY-SERVICE-BUILDER-HASH:50115588

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelServiceUtil.java
@@ -30,10 +30,11 @@ public class AssetVocabularyGroupRelServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portlet.asset.service.impl.AssetVocabularyGroupRelServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws PortalException {
 
-		return getService().addAssetVocabularyGroupRel(groupId, vocabularyId);
+		return getService().addAssetVocabularyGroupRel(
+			groupId, vocabularyId, depotEntryType);
 	}
 
 	public static List<AssetVocabularyGroupRel>
@@ -54,10 +55,11 @@ public class AssetVocabularyGroupRelServiceUtil {
 	}
 
 	public static void setAssetVocabularyGroupRels(
-			long vocabularyId, long[] groupIds)
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws PortalException {
 
-		getService().setAssetVocabularyGroupRels(vocabularyId, groupIds);
+		getService().setAssetVocabularyGroupRels(
+			vocabularyId, groupIds, depotEntryType);
 	}
 
 	public static AssetVocabularyGroupRelService getService() {
@@ -71,4 +73,4 @@ public class AssetVocabularyGroupRelServiceUtil {
 	private static volatile AssetVocabularyGroupRelService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1340836508
+// LIFERAY-SERVICE-BUILDER-HASH:278641686

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyGroupRelServiceWrapper.java
@@ -31,11 +31,11 @@ public class AssetVocabularyGroupRelServiceWrapper
 
 	@Override
 	public AssetVocabularyGroupRel addAssetVocabularyGroupRel(
-			long groupId, long vocabularyId)
+			long groupId, long vocabularyId, int depotEntryType)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetVocabularyGroupRelService.addAssetVocabularyGroupRel(
-			groupId, vocabularyId);
+			groupId, vocabularyId, depotEntryType);
 	}
 
 	@Override
@@ -58,11 +58,12 @@ public class AssetVocabularyGroupRelServiceWrapper
 	}
 
 	@Override
-	public void setAssetVocabularyGroupRels(long vocabularyId, long[] groupIds)
+	public void setAssetVocabularyGroupRels(
+			long vocabularyId, long[] groupIds, int depotEntryType)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_assetVocabularyGroupRelService.setAssetVocabularyGroupRels(
-			vocabularyId, groupIds);
+			vocabularyId, groupIds, depotEntryType);
 	}
 
 	@Override
@@ -80,4 +81,4 @@ public class AssetVocabularyGroupRelServiceWrapper
 	private AssetVocabularyGroupRelService _assetVocabularyGroupRelService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-628723472
+// LIFERAY-SERVICE-BUILDER-HASH:-1592607922

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.2.0
+version 18.0.0

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetVocabularyGroupRelPersistence.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetVocabularyGroupRelPersistence.java
@@ -366,6 +366,121 @@ public interface AssetVocabularyGroupRelPersistence
 	public int countByG_V(long groupId, long vocabularyId);
 
 	/**
+	 * Returns an ordered range of all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portlet.asset.model.impl.AssetVocabularyGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param start the lower bound of the range of asset vocabulary group rels
+	 * @param end the upper bound of the range of asset vocabulary group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset vocabulary group rels
+	 */
+	public java.util.List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<AssetVocabularyGroupRel> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first asset vocabulary group rel in the ordered set where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset vocabulary group rel
+	 * @throws NoSuchVocabularyGroupRelException if a matching asset vocabulary group rel could not be found
+	 */
+	public AssetVocabularyGroupRel findByV_D_First(
+			long vocabularyId, int depotEntryType,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetVocabularyGroupRel> orderByComparator)
+		throws NoSuchVocabularyGroupRelException;
+
+	/**
+	 * Returns the first asset vocabulary group rel in the ordered set where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	public AssetVocabularyGroupRel fetchByV_D_First(
+		long vocabularyId, int depotEntryType,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<AssetVocabularyGroupRel> orderByComparator);
+
+	/**
+	 * Removes all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63; from the database.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 */
+	public void removeByV_D(long vocabularyId, int depotEntryType);
+
+	/**
+	 * Returns the number of asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the number of matching asset vocabulary group rels
+	 */
+	public int countByV_D(long vocabularyId, int depotEntryType);
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or throws a <code>NoSuchVocabularyGroupRelException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the matching asset vocabulary group rel
+	 * @throws NoSuchVocabularyGroupRelException if a matching asset vocabulary group rel could not be found
+	 */
+	public AssetVocabularyGroupRel findByG_V_D(
+			long groupId, long vocabularyId, int depotEntryType)
+		throws NoSuchVocabularyGroupRelException;
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	public AssetVocabularyGroupRel fetchByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType,
+		boolean useFinderCache);
+
+	/**
+	 * Removes the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the asset vocabulary group rel that was removed
+	 */
+	public AssetVocabularyGroupRel removeByG_V_D(
+			long groupId, long vocabularyId, int depotEntryType)
+		throws NoSuchVocabularyGroupRelException;
+
+	/**
+	 * Returns the number of asset vocabulary group rels where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the number of matching asset vocabulary group rels
+	 */
+	public int countByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType);
+
+	/**
 	 * Creates a new asset vocabulary group rel with the primary key. Does not add the asset vocabulary group rel to the database.
 	 *
 	 * @param assetVocabularyGroupRelId the primary key for the new asset vocabulary group rel
@@ -430,6 +545,20 @@ public interface AssetVocabularyGroupRelPersistence
 		long groupId, long vocabularyId) {
 
 		return fetchByG_V(groupId, vocabularyId, true);
+	}
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	public default AssetVocabularyGroupRel fetchByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType) {
+
+		return fetchByG_V_D(groupId, vocabularyId, depotEntryType, true);
 	}
 
 	/**
@@ -650,5 +779,63 @@ public interface AssetVocabularyGroupRelPersistence
 			vocabularyId, start, end, orderByComparator, true);
 	}
 
+	/**
+	 * Returns all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the matching asset vocabulary group rels
+	 */
+	public default java.util.List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType) {
+
+		return findByV_D(
+			vocabularyId, depotEntryType,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portlet.asset.model.impl.AssetVocabularyGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param start the lower bound of the range of asset vocabulary group rels
+	 * @param end the upper bound of the range of asset vocabulary group rels (not inclusive)
+	 * @return the range of matching asset vocabulary group rels
+	 */
+	public default java.util.List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType, int start, int end) {
+
+		return findByV_D(vocabularyId, depotEntryType, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portlet.asset.model.impl.AssetVocabularyGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param start the lower bound of the range of asset vocabulary group rels
+	 * @param end the upper bound of the range of asset vocabulary group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset vocabulary group rels
+	 */
+	public default java.util.List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<AssetVocabularyGroupRel> orderByComparator) {
+
+		return findByV_D(
+			vocabularyId, depotEntryType, start, end, orderByComparator, true);
+	}
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:672996884
+// LIFERAY-SERVICE-BUILDER-HASH:907504400

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetVocabularyGroupRelUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetVocabularyGroupRelUtil.java
@@ -549,6 +549,154 @@ public class AssetVocabularyGroupRelUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portlet.asset.model.impl.AssetVocabularyGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param start the lower bound of the range of asset vocabulary group rels
+	 * @param end the upper bound of the range of asset vocabulary group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset vocabulary group rels
+	 */
+	public static List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType, int start, int end,
+		OrderByComparator<AssetVocabularyGroupRel> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByV_D(
+			vocabularyId, depotEntryType, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first asset vocabulary group rel in the ordered set where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset vocabulary group rel
+	 * @throws NoSuchVocabularyGroupRelException if a matching asset vocabulary group rel could not be found
+	 */
+	public static AssetVocabularyGroupRel findByV_D_First(
+			long vocabularyId, int depotEntryType,
+			OrderByComparator<AssetVocabularyGroupRel> orderByComparator)
+		throws com.liferay.asset.kernel.exception.
+			NoSuchVocabularyGroupRelException {
+
+		return getPersistence().findByV_D_First(
+			vocabularyId, depotEntryType, orderByComparator);
+	}
+
+	/**
+	 * Returns the first asset vocabulary group rel in the ordered set where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	public static AssetVocabularyGroupRel fetchByV_D_First(
+		long vocabularyId, int depotEntryType,
+		OrderByComparator<AssetVocabularyGroupRel> orderByComparator) {
+
+		return getPersistence().fetchByV_D_First(
+			vocabularyId, depotEntryType, orderByComparator);
+	}
+
+	/**
+	 * Removes all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63; from the database.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 */
+	public static void removeByV_D(long vocabularyId, int depotEntryType) {
+		getPersistence().removeByV_D(vocabularyId, depotEntryType);
+	}
+
+	/**
+	 * Returns the number of asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the number of matching asset vocabulary group rels
+	 */
+	public static int countByV_D(long vocabularyId, int depotEntryType) {
+		return getPersistence().countByV_D(vocabularyId, depotEntryType);
+	}
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or throws a <code>NoSuchVocabularyGroupRelException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the matching asset vocabulary group rel
+	 * @throws NoSuchVocabularyGroupRelException if a matching asset vocabulary group rel could not be found
+	 */
+	public static AssetVocabularyGroupRel findByG_V_D(
+			long groupId, long vocabularyId, int depotEntryType)
+		throws com.liferay.asset.kernel.exception.
+			NoSuchVocabularyGroupRelException {
+
+		return getPersistence().findByG_V_D(
+			groupId, vocabularyId, depotEntryType);
+	}
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	public static AssetVocabularyGroupRel fetchByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType,
+		boolean useFinderCache) {
+
+		return getPersistence().fetchByG_V_D(
+			groupId, vocabularyId, depotEntryType, useFinderCache);
+	}
+
+	/**
+	 * Removes the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the asset vocabulary group rel that was removed
+	 */
+	public static AssetVocabularyGroupRel removeByG_V_D(
+			long groupId, long vocabularyId, int depotEntryType)
+		throws com.liferay.asset.kernel.exception.
+			NoSuchVocabularyGroupRelException {
+
+		return getPersistence().removeByG_V_D(
+			groupId, vocabularyId, depotEntryType);
+	}
+
+	/**
+	 * Returns the number of asset vocabulary group rels where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the number of matching asset vocabulary group rels
+	 */
+	public static int countByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType) {
+
+		return getPersistence().countByG_V_D(
+			groupId, vocabularyId, depotEntryType);
+	}
+
+	/**
 	 * Creates a new asset vocabulary group rel with the primary key. Does not add the asset vocabulary group rel to the database.
 	 *
 	 * @param assetVocabularyGroupRelId the primary key for the new asset vocabulary group rel
@@ -631,6 +779,21 @@ public class AssetVocabularyGroupRelUtil {
 		long groupId, long vocabularyId) {
 
 		return getPersistence().fetchByG_V(groupId, vocabularyId);
+	}
+
+	/**
+	 * Returns the asset vocabulary group rel where groupId = &#63; and vocabularyId = &#63; and depotEntryType = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the matching asset vocabulary group rel, or <code>null</code> if a matching asset vocabulary group rel could not be found
+	 */
+	public static AssetVocabularyGroupRel fetchByG_V_D(
+		long groupId, long vocabularyId, int depotEntryType) {
+
+		return getPersistence().fetchByG_V_D(
+			groupId, vocabularyId, depotEntryType);
 	}
 
 	/**
@@ -835,6 +998,61 @@ public class AssetVocabularyGroupRelUtil {
 			vocabularyId, start, end, orderByComparator);
 	}
 
+	/**
+	 * Returns all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @return the matching asset vocabulary group rels
+	 */
+	public static List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType) {
+
+		return getPersistence().findByV_D(vocabularyId, depotEntryType);
+	}
+
+	/**
+	 * Returns a range of all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portlet.asset.model.impl.AssetVocabularyGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param start the lower bound of the range of asset vocabulary group rels
+	 * @param end the upper bound of the range of asset vocabulary group rels (not inclusive)
+	 * @return the range of matching asset vocabulary group rels
+	 */
+	public static List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType, int start, int end) {
+
+		return getPersistence().findByV_D(
+			vocabularyId, depotEntryType, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset vocabulary group rels where vocabularyId = &#63; and depotEntryType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portlet.asset.model.impl.AssetVocabularyGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param vocabularyId the vocabulary ID
+	 * @param depotEntryType the depot entry type
+	 * @param start the lower bound of the range of asset vocabulary group rels
+	 * @param end the upper bound of the range of asset vocabulary group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset vocabulary group rels
+	 */
+	public static List<AssetVocabularyGroupRel> findByV_D(
+		long vocabularyId, int depotEntryType, int start, int end,
+		OrderByComparator<AssetVocabularyGroupRel> orderByComparator) {
+
+		return getPersistence().findByV_D(
+			vocabularyId, depotEntryType, start, end, orderByComparator);
+	}
+
 	public static AssetVocabularyGroupRelPersistence getPersistence() {
 		return _persistence;
 	}
@@ -848,4 +1066,4 @@ public class AssetVocabularyGroupRelUtil {
 	private static volatile AssetVocabularyGroupRelPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-495397318
+// LIFERAY-SERVICE-BUILDER-HASH:-1584912458

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 17.0.0
+version 17.1.0

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -62,9 +62,10 @@ create unique index IX_3966DE44 on AssetVocabulary (groupId, uuid_[$COLUMN_LENGT
 create index IX_2F7F11EE on AssetVocabulary (groupId, visibilityType);
 create index IX_55F58818 on AssetVocabulary (uuid_[$COLUMN_LENGTH:75$]);
 
-create index IX_104CE969 on AssetVocabularyGroupRel (groupId, vocabularyId);
-create unique index IX_BD51FF2A on AssetVocabularyGroupRel (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
-create index IX_65F8A72B on AssetVocabularyGroupRel (vocabularyId);
+create unique index IX_672FE37E on AssetVocabularyGroupRel (groupId, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
+create index IX_DF366DD5 on AssetVocabularyGroupRel (groupId, vocabularyId, depotEntryType);
+create index IX_2FB8A59E on AssetVocabularyGroupRel (uuid_[$COLUMN_LENGTH:75$]);
+create index IX_8826797 on AssetVocabularyGroupRel (vocabularyId, depotEntryType);
 
 create unique index IX_E7B95510 on BrowserTracker (userId);
 

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -203,6 +203,7 @@ create table AssetVocabularyGroupRel (
 	groupId LONG,
 	companyId LONG,
 	vocabularyId LONG,
+	depotEntryType INTEGER,
 	primary key (assetVocabularyGroupRelId, ctCollectionId)
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93226

## What Is Being Fixed

Asset vocabulary group relations had no notion of the depot entry (project)
type they applied to, so a vocabulary's scope could not be limited to a
specific project type such as spaces. This is required to support project
scope when creating a vocabulary in a CMS context.

## How It Is Being Fixed

A `type` column is added to `AssetVocabularyGroupRel` so each relation records
the depot entry type it applies to (`DepotConstants.TYPE_ANY` or
`DepotConstants.TYPE_SPACE`). The local and remote services, persistence
finders, indexes, and the staged-model, search, and indexing paths are updated
to carry and query by this type, and every caller of
`addAssetVocabularyGroupRel`/`setAssetVocabularyGroupRels` now passes it. A
portal upgrade process backfills the column on existing data, a new
`AssetVocabularyModelListener` keeps relations consistent, and a guard prevents
changing the spaces of a system vocabulary.

## PR Check

**pr-check: PASS** — tested on `c9261cd0a02bb7acd4ee44ce4dbb19ff77b68562`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "c9261cd0a02bb7acd4ee44ce4dbb19ff77b68562"} -->
