### PR TITLE
LPD-87681 Support dropping files onto folders in the Gallery view

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
@@ -41,6 +41,13 @@
 	.fds-gallery-view__thumbnail {
 		max-width: 20%;
 
+		&.drop-target {
+			.card {
+				background-color: $info-l2;
+				box-shadow: 0 0 0 2px $info;
+			}
+		}
+
 		&.selected {
 			.card {
 				box-shadow: 0 0 0 2px $primary-l1;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFilesDropFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFilesDropFDSPropsTransformer.ts
@@ -36,6 +36,20 @@ export default function AssetsFilesDropFDSPropsTransformer({
 
 	const isCreationMenuEmpty = !creationMenu?.primaryItems?.length;
 
+	const fileDropSettings = {
+		enabled: !isCreationMenuEmpty,
+		isDropTarget: ({item}: {item: any}) => {
+			return item.entryClassName.includes(OBJECT_ENTRY_FOLDER_CLASS_NAME);
+		},
+		onFileDrop: (droppedFiles: any, dropTarget?: any) => {
+			if (isCreationMenuEmpty) {
+				return;
+			}
+
+			return fileDropAction(additionalProps, droppedFiles, dropTarget);
+		},
+	};
+
 	return {
 		...assetsData,
 		atom: allFDSAtom,
@@ -61,25 +75,24 @@ export default function AssetsFilesDropFDSPropsTransformer({
 				};
 			}
 		),
-		fileDropSettings: {
-			enabled: !isCreationMenuEmpty,
-			isDropTarget: ({item}: {item: any}) => {
-				return item.entryClassName.includes(
-					OBJECT_ENTRY_FOLDER_CLASS_NAME
-				);
-			},
-			onFileDrop: (droppedFiles: any, dropTarget?: any) => {
-				if (isCreationMenuEmpty) {
-					return;
-				}
-
-				return fileDropAction(
-					additionalProps,
-					droppedFiles,
-					dropTarget
-				);
-			},
-		},
+		fileDropSettings,
 		snapshotsEnabled: true,
+
+		// The gallery renders outside the FDS drop context, so it gets the
+		// drop settings directly.
+
+		views: (assetsData.views || []).map((view: IView) => {
+			const {component} = view;
+
+			if (view.name !== 'gallery' || !component) {
+				return view;
+			}
+
+			return {
+				...view,
+				component: (props: any) =>
+					component({...props, fileDropSettings}),
+			};
+		}),
 	};
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFilesDropFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFilesDropFDSPropsTransformer.ts
@@ -78,21 +78,11 @@ export default function AssetsFilesDropFDSPropsTransformer({
 		fileDropSettings,
 		snapshotsEnabled: true,
 
-		// The gallery renders outside the FDS drop context, so it gets the
-		// drop settings directly.
+		// Custom views do not receive the top-level drop settings, so they are
+		// attached to the gallery view.
 
-		views: (assetsData.views || []).map((view: IView) => {
-			const {component} = view;
-
-			if (view.name !== 'gallery' || !component) {
-				return view;
-			}
-
-			return {
-				...view,
-				component: (props: any) =>
-					component({...props, fileDropSettings}),
-			};
-		}),
+		views: (assetsData.views || []).map((view: IView) =>
+			view.name === 'gallery' ? {...view, fileDropSettings} : view
+		),
 	};
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
@@ -112,6 +112,10 @@ const GalleryView = ({
 	};
 
 	const handleKeyDown = (event: React.KeyboardEvent, index: number) => {
+		if (event.target !== event.currentTarget) {
+			return;
+		}
+
 		if (event.key === 'Enter' || event.key === ' ') {
 			event.preventDefault();
 			handleItemClick(index);

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
@@ -19,6 +19,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 // eslint-disable-next-line
 import {IFrontendDataSetContext} from '@liferay/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext';
 import classNames from 'classnames';
+import {getObjectValueFromPath, sub} from 'frontend-js-web';
 
 import AssetPreview from '../../../common/components/AssetPreview';
 
@@ -244,9 +245,18 @@ function GalleryThumbnail({
 		},
 	});
 
+	const title = schema.title
+		? getObjectValueFromPath({object: item, path: schema.title})
+		: '';
+
 	return (
 		<div
 			{...getRootProps()}
+			aria-label={
+				title
+					? sub(Liferay.Language.get('preview-x'), title)
+					: undefined
+			}
 			className={classNames('fds-gallery-view__thumbnail', {
 				'drop-target': isDragActive,
 				selected,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
@@ -4,8 +4,13 @@
  */
 
 import ClayEmptyState from '@clayui/empty-state';
-import {Card, ICardSchema} from '@liferay/frontend-data-set-web';
+import {
+	Card,
+	ICardSchema,
+	IFileDropSettings,
+} from '@liferay/frontend-data-set-web';
 import React, {Context, useContext, useMemo, useState} from 'react';
+import {useDropzone} from 'react-dropzone';
 
 import '../../../../css/props_transformer/GalleryView.scss';
 
@@ -22,11 +27,13 @@ const MAX_VISIBLE_INDEX = (itemsLength: number) =>
 	Math.max(0, itemsLength - VISIBLE_ITEMS_COUNT);
 
 const GalleryView = ({
+	fileDropSettings,
 	frontendDataSetContext,
 	items,
 	schema,
 	...otherProps
 }: {
+	fileDropSettings?: IFileDropSettings;
 	frontendDataSetContext: Context<IFrontendDataSetContext>;
 	items: any[];
 	schema: ICardSchema;
@@ -165,33 +172,22 @@ const GalleryView = ({
 				<div className="c-gap-3 d-flex fds-gallery-view__thumbnails flex-grow-1">
 					{visibleItems.map((item, index) => {
 						const actualIndex = visibleStartIndex + index;
-						const classes = classNames(
-							'fds-gallery-view__thumbnail',
-							{
-								selected: actualIndex === selectedIndex,
-							}
-						);
 
 						return (
-							<div
-								className={classes}
+							<GalleryThumbnail
+								cardWidth={cardWidth}
+								fileDropSettings={fileDropSettings}
+								item={item}
+								items={items}
 								key={actualIndex}
 								onClick={() => handleItemClick(actualIndex)}
 								onKeyDown={(event) =>
 									handleKeyDown(event, actualIndex)
 								}
-								style={{
-									width: cardWidth,
-								}}
-								tabIndex={0}
-							>
-								<Card
-									item={item}
-									items={items}
-									schema={schema}
-									{...otherProps}
-								/>
-							</div>
+								schema={schema}
+								selected={actualIndex === selectedIndex}
+								{...otherProps}
+							/>
 						);
 					})}
 				</div>
@@ -211,3 +207,58 @@ const GalleryView = ({
 };
 
 export default GalleryView;
+
+function GalleryThumbnail({
+	cardWidth,
+	fileDropSettings,
+	item,
+	items,
+	onClick,
+	onKeyDown,
+	schema,
+	selected,
+	...otherProps
+}: {
+	cardWidth: string;
+	fileDropSettings?: IFileDropSettings;
+	item: any;
+	items: any[];
+	onClick: () => void;
+	onKeyDown: (event: React.KeyboardEvent) => void;
+	schema: ICardSchema;
+	selected: boolean;
+}) {
+	const isDropTarget = Boolean(
+		fileDropSettings?.enabled && fileDropSettings.isDropTarget({item})
+	);
+
+	// Only folders accept drops
+
+	const {getRootProps, isDragActive} = useDropzone({
+		disabled: !isDropTarget,
+		noClick: true,
+		noDragEventsBubbling: true,
+		noKeyboard: true,
+		onDrop: (droppedFiles) => {
+			fileDropSettings?.onFileDrop?.(droppedFiles, item);
+		},
+	});
+
+	return (
+		<div
+			{...getRootProps()}
+			className={classNames('fds-gallery-view__thumbnail', {
+				'drop-target': isDragActive,
+				selected,
+			})}
+			onClick={onClick}
+			onKeyDown={onKeyDown}
+			style={{
+				width: cardWidth,
+			}}
+			tabIndex={0}
+		>
+			<Card item={item} items={items} schema={schema} {...otherProps} />
+		</div>
+	);
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
@@ -4,7 +4,9 @@
  */
 
 import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
 import fs from 'fs/promises';
+import path from 'path';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
@@ -869,6 +871,100 @@ test(
 			await apiHelpers.objectEntry.deleteObjectEntry(
 				applicationName,
 				String(objectEntry2.id)
+			);
+		}
+	}
+);
+
+test(
+	'Uploads a file dropped onto a folder into that folder in Gallery View',
+	{tag: '@LPD-87681'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const fileName = 'file_upload_image_1.jpeg';
+		const parentFolderTitle = getRandomString();
+		const targetFolderTitle = getRandomString();
+
+		const parentFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				scopeKey: 'Default',
+				title: parentFolderTitle,
+			});
+
+		const targetFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode:
+					parentFolder.externalReferenceCode,
+				scopeKey: 'Default',
+				title: targetFolderTitle,
+			});
+
+		try {
+			await test.step('Open the parent folder in Gallery View', async () => {
+				await assetsPage.gotoFiles();
+
+				await page.getByRole('link', {name: parentFolderTitle}).click();
+
+				await expect(
+					page.getByRole('combobox', {
+						name: 'Gallery View Selected',
+					})
+				).toBeVisible();
+			});
+
+			const folderThumbnail = assetsPage.galleryThumbnails.locator(
+				'.fds-gallery-view__thumbnail',
+				{hasText: targetFolderTitle}
+			);
+
+			const dataTransfer = await page.evaluateHandle(
+				(data) => {
+					const dataTransfer = new DataTransfer();
+
+					dataTransfer.items.add(
+						new File(
+							[data.toString('hex')],
+							'file_upload_image_1.jpeg',
+							{type: 'image/jpg'}
+						)
+					);
+
+					return dataTransfer;
+				},
+				readFileSync(
+					path.join(
+						__dirname,
+						'/dependencies/file_upload_image_1.jpg'
+					)
+				)
+			);
+
+			await test.step('Highlight the folder as the drop target', async () => {
+				await folderThumbnail.dispatchEvent('dragenter', {
+					dataTransfer,
+				});
+				await folderThumbnail.dispatchEvent('dragover', {dataTransfer});
+
+				await expect(folderThumbnail).toHaveClass(/drop-target/);
+			});
+
+			await test.step('Drop the file onto the folder', async () => {
+				await folderThumbnail.dispatchEvent('drop', {dataTransfer});
+
+				await expect(assetsPage.modal.container).toBeVisible();
+
+				await expect(assetsPage.modal.title).toContainText(
+					'Upload Multiple Files'
+				);
+
+				await expect(assetsPage.modal.body).toContainText(fileName);
+			});
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(
+				targetFolder.id
+			);
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(
+				parentFolder.id
 			);
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87681

## What Is Being Fixed

In the CMS Files Gallery view, dragging a file from the OS file browser onto a folder uploaded the file into the root folder instead of into the target folder — the folder did not register the drop. This worked correctly in the Card and Table views but not in Gallery. This affects external file drops only; dragging existing items into folders is unsupported by design.

## How It Is Being Fixed

The Gallery is a custom component view that renders outside the Frontend Data Set's drag-and-drop context, so it could not reuse the built-in per-item drop wiring that the Card, Table, and List views rely on. Each gallery thumbnail now handles the native file drop with react-dropzone — the same library already used elsewhere in the portal — enabled only for folders. The drop settings (which item accepts a drop and the upload handler) are injected into the Gallery view from the CMS props transformer, and noDragEventsBubbling prevents the drop from falling through to the data set wrapper, which would otherwise upload to the root folder. A drop-target highlight matching the Card and Table views was added, the focusable thumbnail now exposes a "Preview x" aria-label with the file name, and a pre-existing issue where the thumbnail intercepted the selection checkbox's keyboard events was fixed so the checkbox can be toggled with the keyboard.

## PR Check

**pr-check: PASS** — tested on `2e46c37bc2727b49bf318973a89f8a4658b8fbf1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2e46c37bc2727b49bf318973a89f8a4658b8fbf1"} -->
