### PR TITLE
LPD-95805 Fix blog tests

### DIFF
--- a/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
@@ -726,7 +726,7 @@ test(
 			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=${encodeURIComponent(payload)}&coverImageURL=https://example.com/image.png`
 		);
 
-		await expect(page.getByRole('img')).toHaveCount(0);
+		await expect(page.locator('img')).toHaveCount(0);
 	}
 );
 

--- a/modules/test/playwright/tests/blogs-web/main/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/main/pages/BlogsEditBlogEntryPage.ts
@@ -115,18 +115,20 @@ export class BlogsEditBlogEntryPage {
 
 		await fieldset.getByLabel(`Select ${vocabularyName}`).click();
 
-		const categoriesSelectorIframe = await this.page.frameLocator(
-			`iframe[title="Select ${vocabularyName}"]`
-		);
+		const categoriesSelectorModal = this.page.getByRole('dialog', {
+			name: `Select ${vocabularyName}`,
+		});
 
 		for (const {name} of categories) {
-			await categoriesSelectorIframe
+			await categoriesSelectorModal
 				.locator('.treeview-item', {hasText: name})
 				.getByRole('checkbox')
 				.check();
 		}
 
-		await this.page.getByRole('button', {name: 'Done'}).click();
+		await categoriesSelectorModal
+			.getByRole('button', {name: 'Done'})
+			.click();
 	}
 
 	private async editBlogEntryAddfriendlyUrl({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95805

## What Is Being Fixed

The blogs-web Playwright tests were failing after UI changes. The category selector in the blog entry editor is now rendered as a modal dialog instead of an iframe, so the page object could no longer locate it or its controls. Separately, the cover image caption test asserted that no images were rendered using `getByRole('img')`, which does not match every `<img>` element.

## How It Is Being Fixed

The `BlogsEditBlogEntryPage` page object now targets the category selector as a dialog via `getByRole('dialog', {name: ...})` and scopes the category checkboxes and the "Done" button to that modal, replacing the previous `frameLocator` iframe lookup. The cover image caption assertion now uses `page.locator('img')` so it counts all image elements.

## Why Are There No Tests?

This change only fixes existing Playwright tests to match the current UI; there is no product code change, so no new tests are added.

## PR Check

**pr-check: PASS** — tested on `d0fb26102d71fdc67936de15ae786c14586f9ab9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "d0fb26102d71fdc67936de15ae786c14586f9ab9"} -->
