### PR TITLE
LPD-84614 Support rootDescendantNode in bulk and folder searches

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/odata/entity/v1_0/BulkActionEntityModel.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/odata/entity/v1_0/BulkActionEntityModel.java
@@ -33,6 +33,8 @@ public class BulkActionEntityModel implements EntityModel {
 	public BulkActionEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField("cmsRoot", locale -> "cms_root"),
+			new BooleanEntityField(
+				"rootDescendantNode", locale -> "rootDescendantNode"),
 			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -54,6 +54,7 @@ public class ObjectEntryFolderModelDocumentContributor
 
 		document.addLocalizedKeyword(
 			"localized_label", objectEntryFolder.getLabelMap(), true, true);
+		document.addKeyword("rootDescendantNode", false);
 	}
 
 	private String _getCMSSection(String[] parts) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84614

## What Is Being Fixed

The entire CMS Playwright suite on the `[master] ci:test:cms` routine regressed at build 7222 (all 75 tests, including bulkActions tickets LPD-95856–LPD-95873). Symptoms: bulk-action confirmation modals, "action started" alerts, and folder rows/destination pickers never appear, timing out at 90s. LPD-84614 introduced a `rootDescendantNode eq false` predicate into the CMS list, folder picker, and bulk-action scope filters, registered the property in `SearchResultEntityModel`, and indexed it on every object entry — but missed two consumers of that same filter, so every CMS-list and bulk query either failed or returned no folders.

## How It Is Being Fixed

The bulk REST endpoint's `BulkActionEntityModel` never declared `rootDescendantNode`, so every filtered call to `/o/bulk/v1.0/bulk-action-item` was rejected by the OData parser with HTTP 400 ("A property used in the filter criteria is not supported"), which broke the whole CMS bulk-action and list layer. The property is now registered on that entity model, mirroring `SearchResultEntityModel`. Separately, object entry folders are indexed by `ObjectEntryFolderModelDocumentContributor`, which never added the keyword, so the `rootDescendantNode eq false` term excluded every folder from CMS lists and destination pickers. A folder is a container hierarchy and is never a nested object-tree descendant, so it is now indexed with `rootDescendantNode` false.

## Why Are There No Tests?

The CMS Playwright suite already covers this behavior end to end: `bulkActions.spec.ts` (18 tests) and the broader `site-cms-site-initializer` suite reproduced the regression (all red on build 7222) and return to green with the fix. The change registers an OData entity field and indexes a search keyword; the existing functional tests exercise both code paths, so a new unit test would add no meaningful coverage. Verified locally: full `bulkActions.spec.ts` went 0/18 → 18/18 after deploying both modules.

## PR Check

**pr-check: PASS** — tested on `86649d2be02766377fae22b150b1837a90cba61b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "86649d2be02766377fae22b150b1837a90cba61b"} -->
