### PR TITLE
LPD-95855 Fix ViewAllSectionDisplayContextTest for rootDescendantNode

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -194,7 +194,7 @@ public class ViewAllSectionDisplayContextTest
 	@Override
 	protected String getFilterString() {
 		return "cmsKind eq 'object' and (cmsSection eq 'contents' or " +
-			"cmsSection eq 'files')";
+			"cmsSection eq 'files') and rootDescendantNode eq false";
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95855

## What Is Being Fixed

`ViewAllSectionDisplayContextTest` fails on master: its expected filter string no longer matches the additional API URL parameters the All section display context produces.

## How It Is Being Fixed

LPD-84614 began excluding nested tree children from the CMS lists by appending `rootDescendantNode eq false` to the section filters, including the All section filter built by `ViewAllSectionSystemFDSEntry`, and updated the Contents, Files, and Recycle Bin section display context tests to expect the new predicate — but missed `ViewAllSectionDisplayContextTest`. This aligns its expected filter with production and the sibling section tests.

## Why Are There No Tests?

This change is itself a test fix: it corrects an outdated assertion in an existing integration test to match the production filter introduced by LPD-84614. There is no production code change, so no additional test is warranted.

## PR Check

**pr-check: PASS** — tested on `501e351fc0ff912d2c19ca99424d5f88b6e73ce2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "501e351fc0ff912d2c19ca99424d5f88b6e73ce2"} -->
