### PR TITLE
LPD-66606 Replace the dashboard filter dropdowns with pickers

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/TagService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/TagService.ts
@@ -52,6 +52,12 @@ async function createTag({
 	return ApiHelper.post<Tag>(url, requestBody);
 }
 
+async function getTags(siteId: number | string) {
+	return ApiHelper.get<{
+		items: {assetLibraries: {id: number}[]; id: string; name: string}[];
+	}>(`/o/headless-admin-taxonomy/v1.0/sites/${siteId}/keywords`);
+}
+
 async function getCommonTags(selectedData: IBulkActionFDSData) {
 	return await ApiHelper.post<any>(
 		`/o/bulk/v1.0/keywords/common`,
@@ -66,4 +72,5 @@ async function getCommonTags(selectedData: IBulkActionFDSData) {
 export default {
 	createTag,
 	getCommonTags,
+	getTags,
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/VocabularyService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/VocabularyService.ts
@@ -21,6 +21,12 @@ async function fetchVocabulary(vocabularyId: number) {
 	);
 }
 
+async function getVocabularies(siteId: number | string) {
+	return ApiHelper.get<{
+		items: {assetLibraries: {id: number}[]; id: string; name: string}[];
+	}>(`/o/headless-admin-taxonomy/v1.0/sites/${siteId}/taxonomy-vocabularies`);
+}
+
 async function getRequiredVocabularies({
 	assetLibraryId,
 	assetTypeId,
@@ -78,5 +84,6 @@ export default {
 	fetchVocabulary,
 	getCommonCategories,
 	getRequiredVocabularies,
+	getVocabularies,
 	updateVocabulary,
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllStructureTypesDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllStructureTypesDropdown.tsx
@@ -3,14 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {Option, Picker} from '@clayui/core';
 import {buildQueryString} from '@liferay/analytics-reports-js-components-web';
-import React, {useContext, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 
 import ApiHelper from '../../../common/services/ApiHelper';
 import getLocalizedValue from '../../../common/utils/getLocalizedValue';
 import {ViewDashboardContext} from '../ViewDashboardContext';
-import {FilterDropdown, Item} from './FilterDropdown';
+import {Item} from './FilterDropdown';
 import {IAllFiltersDropdown, initialFilters} from './InventoryAnalysisCard';
+import PickerTrigger from './PickerTrigger';
 
 const AllStructureTypesDropdown: React.FC<IAllFiltersDropdown> = ({
 	className,
@@ -22,76 +24,70 @@ const AllStructureTypesDropdown: React.FC<IAllFiltersDropdown> = ({
 	const [structures, setStructures] = useState<Item[]>([
 		initialFilters.structure,
 	]);
-	const [loading, setLoading] = useState(false);
-	const [dropdownActive, setDropdownActive] = useState(false);
 
-	const fetchStructures = async (search: string = '') => {
-		const queryParams = buildQueryString({
-			filter: `(objectFolderExternalReferenceCode eq '${constants.ercContentStructures}' or objectFolderExternalReferenceCode eq '${constants.ercFileTypes}')`,
-			search,
-		});
+	useEffect(() => {
+		const fetchStructures = async () => {
+			const queryParams = buildQueryString({
+				filter: `(objectFolderExternalReferenceCode eq '${constants.ercContentStructures}' or objectFolderExternalReferenceCode eq '${constants.ercFileTypes}')`,
+			});
 
-		const endpoint = `/o/object-admin/v1.0/object-definitions${queryParams}`;
+			const {data, error} = await ApiHelper.get<{
+				items: {id: string; label: Record<string, string>}[];
+			}>(`/o/object-admin/v1.0/object-definitions${queryParams}`);
 
-		const {data, error} = await ApiHelper.get<{
-			items: {id: string; label: Record<string, string>}[];
-		}>(endpoint);
+			if (error) {
+				console.error(error);
 
-		if (data) {
-			return data.items.map(({id, label}) => ({
-				label:
-					getLocalizedValue(label) ||
-					getLocalizedValue(label, 'en_US'),
-				value: String(id),
-			}));
-		}
+				return;
+			}
 
-		if (error) {
-			console.error(error);
-		}
+			if (data) {
+				setStructures([
+					initialFilters.structure,
+					...data.items.map(({id, label}) => ({
+						label:
+							getLocalizedValue(label) ||
+							getLocalizedValue(label, 'en_US'),
+						value: String(id),
+					})),
+				]);
+			}
+		};
 
-		return [];
-	};
+		fetchStructures();
+	}, [constants.ercContentStructures, constants.ercFileTypes]);
 
 	return (
-		<FilterDropdown
-			active={dropdownActive}
-			className={className}
-			filterByValue="structures"
-			icon="edit-layout"
+		<Picker
+			aria-label={Liferay.Language.get(
+				'filter-by-content-structure-type'
+			)}
+			as={PickerTrigger}
+			borderless
+			filterKey="label"
 			items={structures}
-			loading={loading}
-			onActiveChange={() => setDropdownActive((prevState) => !prevState)}
-			onSearch={async (value) => {
-				setLoading(true);
-
-				const structures = await fetchStructures(value);
-
-				setStructures(
-					value
-						? structures
-						: [initialFilters.structure, ...structures]
+			messages={{
+				noResultsFound: Liferay.Language.get('no-results-were-found'),
+				searchPlaceholder: Liferay.Language.get('search'),
+			}}
+			onSelectionChange={(key) => {
+				const selectedStructure = structures.find(
+					({value}) => value === String(key)
 				);
 
-				setLoading(false);
+				if (selectedStructure) {
+					onSelectItem(selectedStructure);
+				}
 			}}
-			onSelectItem={(item) => {
-				onSelectItem(item);
-
-				setDropdownActive(false);
-			}}
-			onTrigger={async () => {
-				setLoading(true);
-
-				const structures = await fetchStructures();
-
-				setStructures([initialFilters.structure, ...structures]);
-
-				setLoading(false);
-			}}
-			selectedItem={item}
-			title={Liferay.Language.get('filter-by-content-structure-type')}
-		/>
+			searchable
+			selectedKey={item.value}
+			triggerClassName={className}
+			triggerIcon="edit-layout"
+		>
+			{(structure: Item) => (
+				<Option key={structure.value}>{structure.label}</Option>
+			)}
+		</Picker>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllTagsDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllTagsDropdown.tsx
@@ -3,17 +3,18 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {buildQueryString} from '@liferay/analytics-reports-js-components-web';
-import React, {useContext, useState} from 'react';
+import {Option, Picker} from '@clayui/core';
+import React, {useContext, useEffect, useState} from 'react';
 
-import ApiHelper from '../../../common/services/ApiHelper';
+import TagService from '../../../common/services/TagService';
 import {ViewDashboardContext} from '../ViewDashboardContext';
-import {FilterDropdown, Item} from './FilterDropdown';
+import {Item} from './FilterDropdown';
 import {
 	IAllFiltersDropdown,
 	filterBySpaces,
 	initialFilters,
 } from './InventoryAnalysisCard';
+import PickerTrigger from './PickerTrigger';
 
 const AllTagsDropdown: React.FC<IAllFiltersDropdown> = ({
 	className,
@@ -27,77 +28,63 @@ const AllTagsDropdown: React.FC<IAllFiltersDropdown> = ({
 
 	const [tags, setTags] = useState<Item[]>([initialFilters.tag]);
 
-	const [dropdownActive, setDropdownActive] = useState(false);
-	const [loading, setLoading] = useState(false);
+	useEffect(() => {
+		const fetchTags = async () => {
+			const {data, error} = await TagService.getTags(cmsGroupId);
 
-	const fetchTags = async (search: string = '') => {
-		const queryParams = buildQueryString({
-			search,
-		});
+			if (error) {
+				console.error(error);
 
-		const endpoint = `/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords${queryParams}`;
+				return;
+			}
 
-		const {data, error} = await ApiHelper.get<{
-			items: {assetLibraries: {id: number}[]; id: string; name: string}[];
-		}>(endpoint);
+			if (data) {
+				setTags([
+					initialFilters.tag,
+					...data.items
+						.filter(
+							({assetLibraries}) =>
+								space.value === 'all' ||
+								filterBySpaces(assetLibraries, space.value)
+						)
+						.map(({id, name}) => ({
+							label: name,
+							value: String(id),
+						})),
+				]);
+			}
+		};
 
-		if (data) {
-			return data.items
-				.filter(({assetLibraries}) => {
-					if (space.value === 'all') {
-						return true;
-					}
-
-					return filterBySpaces(assetLibraries, space.value);
-				})
-				.map(({id, name}) => ({
-					label: name,
-					value: String(id),
-				}));
-		}
-
-		if (error) {
-			console.error(error);
-		}
-
-		return [];
-	};
+		fetchTags();
+	}, [cmsGroupId, space.value]);
 
 	return (
-		<FilterDropdown
-			active={dropdownActive}
-			className={className}
-			filterByValue="tags"
-			icon="tag"
+		<Picker
+			aria-label={Liferay.Language.get('filter-by-tag')}
+			as={PickerTrigger}
+			borderless
+			filterKey="label"
 			items={tags}
-			loading={loading}
-			onActiveChange={() => setDropdownActive((prevState) => !prevState)}
-			onSearch={async (value) => {
-				setLoading(true);
-
-				const tags = await fetchTags(value);
-
-				setTags(value ? tags : [initialFilters.tag, ...tags]);
-
-				setLoading(false);
+			messages={{
+				noResultsFound: Liferay.Language.get('no-results-were-found'),
+				searchPlaceholder: Liferay.Language.get('search'),
 			}}
-			onSelectItem={(item) => {
-				onSelectItem(item);
+			onSelectionChange={(key) => {
+				const selectedTag = tags.find(
+					({value}) => value === String(key)
+				);
 
-				setDropdownActive(false);
+				if (selectedTag) {
+					onSelectItem(selectedTag);
+				}
 			}}
-			onTrigger={async () => {
-				setLoading(true);
-
-				const tags = await fetchTags();
-
-				setTags([initialFilters.tag, ...tags]);
-
-				setLoading(false);
-			}}
-			selectedItem={item}
-			title={Liferay.Language.get('filter-by-tag')}
-		/>
+			searchable
+			selectedKey={item.value}
+			triggerClassName={className}
+			triggerIcon="tag"
+		>
+			{(tag: Item) => <Option key={tag.value}>{tag.label}</Option>}
+		</Picker>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllTagsDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllTagsDropdown.tsx
@@ -4,7 +4,7 @@
  */
 
 import {Option, Picker} from '@clayui/core';
-import React, {useContext, useEffect, useState} from 'react';
+import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import TagService from '../../../common/services/TagService';
 import {ViewDashboardContext} from '../ViewDashboardContext';
@@ -16,6 +16,8 @@ import {
 } from './InventoryAnalysisCard';
 import PickerTrigger from './PickerTrigger';
 
+type Keyword = {assetLibraries: {id: number}[]; id: string; name: string};
+
 const AllTagsDropdown: React.FC<IAllFiltersDropdown> = ({
 	className,
 	item,
@@ -26,7 +28,7 @@ const AllTagsDropdown: React.FC<IAllFiltersDropdown> = ({
 		filters: {space},
 	} = useContext(ViewDashboardContext);
 
-	const [tags, setTags] = useState<Item[]>([initialFilters.tag]);
+	const [keywords, setKeywords] = useState<Keyword[]>([]);
 
 	useEffect(() => {
 		const fetchTags = async () => {
@@ -39,24 +41,29 @@ const AllTagsDropdown: React.FC<IAllFiltersDropdown> = ({
 			}
 
 			if (data) {
-				setTags([
-					initialFilters.tag,
-					...data.items
-						.filter(
-							({assetLibraries}) =>
-								space.value === 'all' ||
-								filterBySpaces(assetLibraries, space.value)
-						)
-						.map(({id, name}) => ({
-							label: name,
-							value: String(id),
-						})),
-				]);
+				setKeywords(data.items);
 			}
 		};
 
 		fetchTags();
-	}, [cmsGroupId, space.value]);
+	}, [cmsGroupId]);
+
+	const tags: Item[] = useMemo(
+		() => [
+			initialFilters.tag,
+			...keywords
+				.filter(
+					({assetLibraries}) =>
+						space.value === 'all' ||
+						filterBySpaces(assetLibraries, space.value)
+				)
+				.map(({id, name}) => ({
+					label: name,
+					value: String(id),
+				})),
+		],
+		[keywords, space.value]
+	);
 
 	return (
 		<Picker

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllVocabulariesDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllVocabulariesDropdown.tsx
@@ -3,17 +3,18 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {buildQueryString} from '@liferay/analytics-reports-js-components-web';
-import React, {useContext, useState} from 'react';
+import {Option, Picker} from '@clayui/core';
+import React, {useContext, useEffect, useState} from 'react';
 
-import ApiHelper from '../../../common/services/ApiHelper';
+import VocabularyService from '../../../common/services/VocabularyService';
 import {ViewDashboardContext} from '../ViewDashboardContext';
-import {FilterDropdown, Item} from './FilterDropdown';
+import {Item} from './FilterDropdown';
 import {
 	IAllFiltersDropdown,
 	filterBySpaces,
 	initialFilters,
 } from './InventoryAnalysisCard';
+import PickerTrigger from './PickerTrigger';
 
 const AllVocabulariesDropdown: React.FC<IAllFiltersDropdown> = ({
 	className,
@@ -29,81 +30,66 @@ const AllVocabulariesDropdown: React.FC<IAllFiltersDropdown> = ({
 		initialFilters.vocabulary,
 	]);
 
-	const [dropdownActive, setDropdownActive] = useState(false);
-	const [loading, setLoading] = useState(false);
+	useEffect(() => {
+		const fetchVocabularies = async () => {
+			const {data, error} =
+				await VocabularyService.getVocabularies(cmsGroupId);
 
-	const fetchVocabularies = async (search: string = '') => {
-		const queryParams = buildQueryString({
-			search,
-		});
+			if (error) {
+				console.error(error);
 
-		const endpoint = `/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/taxonomy-vocabularies${queryParams}`;
+				return;
+			}
 
-		const {data, error} = await ApiHelper.get<{
-			items: {assetLibraries: {id: number}[]; id: string; name: string}[];
-		}>(endpoint);
+			if (data) {
+				setVocabularies([
+					initialFilters.vocabulary,
+					...data.items
+						.filter(
+							({assetLibraries}) =>
+								space.value === 'all' ||
+								filterBySpaces(assetLibraries, space.value)
+						)
+						.map(({id, name}) => ({
+							label: name,
+							value: String(id),
+						})),
+				]);
+			}
+		};
 
-		if (data) {
-			return data.items
-				.filter(({assetLibraries}) => {
-					if (space.value === 'all') {
-						return true;
-					}
-
-					return filterBySpaces(assetLibraries, space.value);
-				})
-				.map(({id, name}) => ({
-					label: name,
-					value: String(id),
-				}));
-		}
-
-		if (error) {
-			console.error(error);
-		}
-
-		return [];
-	};
+		fetchVocabularies();
+	}, [cmsGroupId, space.value]);
 
 	return (
-		<FilterDropdown
-			active={dropdownActive}
-			className={className}
-			filterByValue="vocabularies"
-			icon="vocabulary"
+		<Picker
+			aria-label={Liferay.Language.get('filter-by-vocabulary')}
+			as={PickerTrigger}
+			borderless
+			filterKey="label"
 			items={vocabularies}
-			loading={loading}
-			onActiveChange={() => setDropdownActive((prevState) => !prevState)}
-			onSearch={async (value) => {
-				setLoading(true);
-
-				const vocabularies = await fetchVocabularies(value);
-
-				setVocabularies(
-					value
-						? vocabularies
-						: [initialFilters.vocabulary, ...vocabularies]
+			messages={{
+				noResultsFound: Liferay.Language.get('no-results-were-found'),
+				searchPlaceholder: Liferay.Language.get('search'),
+			}}
+			onSelectionChange={(key) => {
+				const selectedVocabulary = vocabularies.find(
+					({value}) => value === String(key)
 				);
 
-				setLoading(false);
+				if (selectedVocabulary) {
+					onSelectItem(selectedVocabulary);
+				}
 			}}
-			onSelectItem={(item) => {
-				onSelectItem(item);
-
-				setDropdownActive(false);
-			}}
-			onTrigger={async () => {
-				setLoading(true);
-
-				const vocabularies = await fetchVocabularies();
-
-				setVocabularies([initialFilters.vocabulary, ...vocabularies]);
-
-				setLoading(false);
-			}}
-			selectedItem={item}
-			title={Liferay.Language.get('filter-by-vocabulary')}
-		/>
+			searchable
+			selectedKey={item.value}
+			triggerClassName={className}
+			triggerIcon="vocabulary"
+		>
+			{(vocabulary: Item) => (
+				<Option key={vocabulary.value}>{vocabulary.label}</Option>
+			)}
+		</Picker>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllVocabulariesDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/AllVocabulariesDropdown.tsx
@@ -4,7 +4,7 @@
  */
 
 import {Option, Picker} from '@clayui/core';
-import React, {useContext, useEffect, useState} from 'react';
+import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import VocabularyService from '../../../common/services/VocabularyService';
 import {ViewDashboardContext} from '../ViewDashboardContext';
@@ -16,6 +16,8 @@ import {
 } from './InventoryAnalysisCard';
 import PickerTrigger from './PickerTrigger';
 
+type Vocabulary = {assetLibraries: {id: number}[]; id: string; name: string};
+
 const AllVocabulariesDropdown: React.FC<IAllFiltersDropdown> = ({
 	className,
 	item,
@@ -26,9 +28,7 @@ const AllVocabulariesDropdown: React.FC<IAllFiltersDropdown> = ({
 		filters: {space},
 	} = useContext(ViewDashboardContext);
 
-	const [vocabularies, setVocabularies] = useState<Item[]>([
-		initialFilters.vocabulary,
-	]);
+	const [rawVocabularies, setRawVocabularies] = useState<Vocabulary[]>([]);
 
 	useEffect(() => {
 		const fetchVocabularies = async () => {
@@ -42,24 +42,29 @@ const AllVocabulariesDropdown: React.FC<IAllFiltersDropdown> = ({
 			}
 
 			if (data) {
-				setVocabularies([
-					initialFilters.vocabulary,
-					...data.items
-						.filter(
-							({assetLibraries}) =>
-								space.value === 'all' ||
-								filterBySpaces(assetLibraries, space.value)
-						)
-						.map(({id, name}) => ({
-							label: name,
-							value: String(id),
-						})),
-				]);
+				setRawVocabularies(data.items);
 			}
 		};
 
 		fetchVocabularies();
-	}, [cmsGroupId, space.value]);
+	}, [cmsGroupId]);
+
+	const vocabularies: Item[] = useMemo(
+		() => [
+			initialFilters.vocabulary,
+			...rawVocabularies
+				.filter(
+					({assetLibraries}) =>
+						space.value === 'all' ||
+						filterBySpaces(assetLibraries, space.value)
+				)
+				.map(({id, name}) => ({
+					label: name,
+					value: String(id),
+				})),
+		],
+		[rawVocabularies, space.value]
+	);
 
 	return (
 		<Picker

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/GroupByDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/GroupByDropdown.tsx
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import React, {useState} from 'react';
+import {Option, Picker} from '@clayui/core';
+import React from 'react';
 
-import {FilterDropdown, Item} from './FilterDropdown';
+import {Item} from './FilterDropdown';
 import {IAllFiltersDropdown} from './InventoryAnalysisCard';
+import PickerTrigger from './PickerTrigger';
 
 const defaultStructureTypes: Item[] = [
 	{
@@ -31,25 +33,28 @@ const GroupByDropdown: React.FC<IAllFiltersDropdown> = ({
 	className,
 	item,
 	onSelectItem,
-}) => {
-	const [dropdownActive, setDropdownActive] = useState(false);
+}) => (
+	<Picker
+		aria-label={Liferay.Language.get('group-by')}
+		as={PickerTrigger}
+		borderless
+		items={defaultStructureTypes}
+		onSelectionChange={(key) => {
+			const selectedStructureType = defaultStructureTypes.find(
+				({value}) => value === key
+			);
 
-	return (
-		<FilterDropdown
-			active={dropdownActive}
-			className={className}
-			filterByValue="structureTypes"
-			items={defaultStructureTypes}
-			loading={false}
-			onActiveChange={() => setDropdownActive((prevState) => !prevState)}
-			onSelectItem={(item) => {
-				onSelectItem(item);
-				setDropdownActive(false);
-			}}
-			selectedItem={item}
-			showLabelInSmallViewport
-		/>
-	);
-};
+			if (selectedStructureType) {
+				onSelectItem(selectedStructureType);
+			}
+		}}
+		selectedKey={item.value}
+		triggerClassName={className}
+	>
+		{(structureType: Item) => (
+			<Option key={structureType.value}>{structureType.label}</Option>
+		)}
+	</Picker>
+);
 
 export {GroupByDropdown};

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/InventoryAnalysisCard.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/InventoryAnalysisCard.tsx
@@ -3,13 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
-import {Text} from '@clayui/core';
-import ClayDropdown from '@clayui/drop-down';
+import {Option, Picker, Text} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import {buildQueryString} from '@liferay/analytics-reports-js-components-web';
-import React, {useContext, useEffect, useRef, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 
 import ApiHelper from '../../../common/services/ApiHelper';
 import {ViewDashboardContext} from '../ViewDashboardContext';
@@ -22,6 +20,7 @@ import {BaseCard} from './BaseCard';
 import {Item} from './FilterDropdown';
 import {GroupByDropdown} from './GroupByDropdown';
 import PaginatedTable from './PaginatedTable';
+import PickerTrigger from './PickerTrigger';
 
 export interface IAllFiltersDropdown extends React.HTMLAttributes<HTMLElement> {
 	item: Item;
@@ -165,8 +164,6 @@ export function InventoryAnalysisCard() {
 	const [inventoryAnalysisData, setInventoryAnalysisData] =
 		useState<InventoryAnalysisDataType>();
 
-	const [dropdownActive, setDropdownActive] = useState(false);
-
 	const [selectedItem, setSelectedItem] = useState<DropdownItem>(
 		dropdownItems[0]
 	);
@@ -195,79 +192,34 @@ export function InventoryAnalysisCard() {
 		fetchData();
 	}, [filters, language, pagination, space]);
 
-	const triggerRef = useRef<HTMLButtonElement | null>(null);
-
 	return (
 		<div className="cms-dashboard__inventory-analysis mb-3">
 			<BaseCard
 				Preferences={
-					<ClayDropdown
-						active={dropdownActive}
-						closeOnClickOutside={true}
-						onActiveChange={setDropdownActive}
-						trigger={
-							<ClayButton
-								aria-label={selectedItem.name}
-								borderless={true}
-								displayType="secondary"
-								onClick={() => {
-									setDropdownActive(!dropdownActive);
-								}}
-								ref={(node: HTMLButtonElement) => {
-									triggerRef.current = node;
-								}}
-								size="sm"
-							>
-								{selectedItem.icon && (
-									<ClayIcon
-										className="mr-2"
-										symbol={selectedItem.icon}
-									/>
-								)}
+					<Picker
+						aria-label={selectedItem.name}
+						as={PickerTrigger}
+						items={dropdownItems}
+						onSelectionChange={(key) => {
+							const item = dropdownItems.find(
+								({value}) => value === key
+							);
 
-								<Text weight="semi-bold">
-									{selectedItem.name}
-								</Text>
-
-								<ClayIcon
-									className="mx-2"
-									symbol="caret-bottom"
-								/>
-							</ClayButton>
-						}
+							if (item) {
+								setSelectedItem(item);
+							}
+						}}
+						selectedKey={selectedItem.value}
+						triggerIcon={selectedItem.icon}
 					>
-						{dropdownItems.map((item) => (
-							<ClayDropdown.Item
-								active={item.value === selectedItem.value}
-								key={item.value}
-								onClick={() => {
-									setSelectedItem(item);
-									setDropdownActive(false);
-									triggerRef?.current?.focus();
-								}}
-							>
-								<div className="align-items-center d-flex">
-									{item.value === selectedItem.value ? (
-										<ClayIcon
-											className="mr-2"
-											symbol="check"
-										/>
-									) : (
-										<ClayIcon className="mr-2" symbol="" />
-									)}
+						{(item: DropdownItem) => (
+							<Option key={item.value} textValue={item.name}>
+								<ClayIcon className="mr-2" symbol={item.icon} />
 
-									{item.icon && (
-										<ClayIcon
-											className="mr-2"
-											symbol={item.icon}
-										/>
-									)}
-
-									{item.name}
-								</div>
-							</ClayDropdown.Item>
-						))}
-					</ClayDropdown>
+								{item.name}
+							</Option>
+						)}
+					</Picker>
 				}
 				ariaLevel={3}
 				description={Liferay.Language.get(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/LanguagesDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/LanguagesDropdown.tsx
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {Option, Picker} from '@clayui/core';
 import React, {useContext, useEffect, useState} from 'react';
 
 import SpaceService from '../../../common/services/SpaceService';
 import {ViewDashboardContext, initialLanguage} from '../ViewDashboardContext';
-import {FilterDropdown} from './FilterDropdown';
+import PickerTrigger from './PickerTrigger';
 
 type AvailableLocales = Exclude<
 	Liferay.Language.Locale,
@@ -53,9 +54,6 @@ const LanguagesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 	} = useContext(ViewDashboardContext);
 
 	const [languages, setLanguages] = useState(initialLanguages);
-	const [dropdownActive, setDropdownActive] = useState(false);
-	const [loading, setLoading] = useState(false);
-	const [searchValue, setSearchValue] = useState('');
 
 	useEffect(() => {
 		if (space.value === 'all') {
@@ -65,8 +63,6 @@ const LanguagesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 		}
 
 		const fetchSpaceLanguages = async () => {
-			setLoading(true);
-
 			try {
 				const {settings} = await SpaceService.getSpace(
 					space.externalReferenceCode as string
@@ -100,9 +96,6 @@ const LanguagesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 
 				setLanguages(initialLanguages);
 			}
-			finally {
-				setLoading(false);
-			}
 		};
 
 		fetchSpaceLanguages();
@@ -113,37 +106,34 @@ const LanguagesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 		space.externalReferenceCode,
 	]);
 
-	useEffect(() => {
-		if (!dropdownActive) {
-			setSearchValue('');
-		}
-	}, [dropdownActive]);
-
-	const filteredLanguages = searchValue
-		? languages.filter(({label}) =>
-				label.toLowerCase().includes(searchValue.toLowerCase())
-			)
-		: languages;
-
 	return (
-		<FilterDropdown
-			active={dropdownActive}
-			borderless={false}
-			className={className}
-			filterByValue="languages"
-			icon="automatic-translate"
-			items={filteredLanguages}
-			loading={loading}
-			onActiveChange={() => setDropdownActive((prevState) => !prevState)}
-			onSearch={setSearchValue}
-			onSelectItem={(item) => {
-				changeLanguage(item);
-
-				setDropdownActive(false);
+		<Picker
+			aria-label={Liferay.Language.get('filter-by-languages')}
+			as={PickerTrigger}
+			filterKey="label"
+			items={languages}
+			messages={{
+				noResultsFound: Liferay.Language.get('no-results-were-found'),
+				searchPlaceholder: Liferay.Language.get('search'),
 			}}
-			selectedItem={language}
-			title={Liferay.Language.get('filter-by-languages')}
-		/>
+			onSelectionChange={(key) => {
+				const selectedLanguage = languages.find(
+					({value}) => value === String(key)
+				);
+
+				if (selectedLanguage) {
+					changeLanguage(selectedLanguage);
+				}
+			}}
+			searchable
+			selectedKey={language.value}
+			triggerClassName={className}
+			triggerIcon="automatic-translate"
+		>
+			{(item: {label: string; value: string}) => (
+				<Option key={item.value}>{item.label}</Option>
+			)}
+		</Picker>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/PickerTrigger.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/PickerTrigger.tsx
@@ -8,9 +8,13 @@ import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 const PickerTrigger = React.forwardRef<HTMLButtonElement, any>(
-	({children, triggerClassName, triggerIcon, ...otherProps}, ref) => (
+	(
+		{borderless, children, triggerClassName, triggerIcon, ...otherProps},
+		ref
+	) => (
 		<ClayButton
 			{...otherProps}
+			borderless={borderless}
 			className={triggerClassName}
 			displayType="secondary"
 			ref={ref}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/PickerTrigger.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/PickerTrigger.tsx
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+const PickerTrigger = React.forwardRef<HTMLButtonElement, any>(
+	({children, triggerClassName, triggerIcon, ...otherProps}, ref) => (
+		<ClayButton
+			{...otherProps}
+			className={triggerClassName}
+			displayType="secondary"
+			ref={ref}
+			size="sm"
+		>
+			{triggerIcon && <ClayIcon className="mr-2" symbol={triggerIcon} />}
+
+			{children}
+
+			<ClayIcon className="ml-2" symbol="caret-bottom" />
+		</ClayButton>
+	)
+);
+
+export default PickerTrigger;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/SpacesDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/SpacesDropdown.tsx
@@ -3,48 +3,18 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
-import ClayIcon from '@clayui/icon';
 import React, {useContext, useEffect, useState} from 'react';
 
 import SpaceService from '../../../common/services/SpaceService';
 import {ViewDashboardContext, initialSpace} from '../ViewDashboardContext';
+import PickerTrigger from './PickerTrigger';
 
 type SpaceOption = {
 	externalReferenceCode?: string;
 	label: string;
 	value: string;
 };
-
-const Trigger = React.forwardRef<HTMLButtonElement, any>(
-	(
-		{
-			children,
-			'className': _className,
-			triggerClassName,
-			triggerIcon,
-			...otherProps
-		},
-		ref
-	) => (
-		<ClayButton
-			{...otherProps}
-			className={triggerClassName}
-			displayType="secondary"
-			ref={ref}
-			size="sm"
-		>
-			{triggerIcon && <ClayIcon className="mr-2" symbol={triggerIcon} />}
-
-			{children}
-
-			<ClayIcon className="ml-2" symbol="caret-bottom" />
-		</ClayButton>
-	)
-);
-
-Trigger.displayName = 'Trigger';
 
 const SpacesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 	className,
@@ -76,7 +46,7 @@ const SpacesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 	return (
 		<Picker
 			aria-label={Liferay.Language.get('filter-by-spaces')}
-			as={Trigger}
+			as={PickerTrigger}
 			filterKey="label"
 			items={spaces}
 			messages={{

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/SpacesDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/SpacesDropdown.tsx
@@ -3,19 +3,48 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {buildQueryString} from '@liferay/analytics-reports-js-components-web';
-import React, {useContext, useState} from 'react';
+import ClayButton from '@clayui/button';
+import {Option, Picker} from '@clayui/core';
+import ClayIcon from '@clayui/icon';
+import React, {useContext, useEffect, useState} from 'react';
 
-import ApiHelper from '../../../common/services/ApiHelper';
+import SpaceService from '../../../common/services/SpaceService';
 import {ViewDashboardContext, initialSpace} from '../ViewDashboardContext';
-import {FilterDropdown} from './FilterDropdown';
 
-type Space = {
+type SpaceOption = {
+	externalReferenceCode?: string;
 	label: string;
 	value: string;
 };
 
-const PATH = '/o/headless-asset-library/v1.0/asset-libraries';
+const Trigger = React.forwardRef<HTMLButtonElement, any>(
+	(
+		{
+			children,
+			'className': _className,
+			triggerClassName,
+			triggerIcon,
+			...otherProps
+		},
+		ref
+	) => (
+		<ClayButton
+			{...otherProps}
+			className={triggerClassName}
+			displayType="secondary"
+			ref={ref}
+			size="sm"
+		>
+			{triggerIcon && <ClayIcon className="mr-2" symbol={triggerIcon} />}
+
+			{children}
+
+			<ClayIcon className="ml-2" symbol="caret-bottom" />
+		</ClayButton>
+	)
+);
+
+Trigger.displayName = 'Trigger';
 
 const SpacesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 	className,
@@ -25,73 +54,53 @@ const SpacesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 		filters: {space},
 	} = useContext(ViewDashboardContext);
 
-	const [dropdownActive, setDropdownActive] = useState(false);
+	const [spaces, setSpaces] = useState<SpaceOption[]>([initialSpace]);
 
-	const [spaces, setSpaces] = useState<Space[]>([initialSpace]);
-	const [loading, setLoading] = useState(false);
+	useEffect(() => {
+		const fetchSpaces = async () => {
+			const spaces = await SpaceService.getSpaces();
 
-	const fetchSpaces = async (keywords: string = '') => {
-		const queryParams = buildQueryString({
-			filter: "type eq 'Space'",
-			keywords,
-		});
-		const endpoint = `${PATH}${queryParams}`;
+			setSpaces([
+				initialSpace,
+				...spaces.map(({externalReferenceCode, id, name}) => ({
+					externalReferenceCode,
+					label: name,
+					value: String(id),
+				})),
+			]);
+		};
 
-		const {data, error} = await ApiHelper.get<{
-			items: {externalReferenceCode: string; id: string; name: string}[];
-		}>(endpoint);
-
-		if (data) {
-			return data.items.map(({externalReferenceCode, id, name}) => ({
-				externalReferenceCode,
-				label: name,
-				value: String(id),
-			}));
-		}
-
-		if (error) {
-			console.error(error);
-		}
-
-		return [];
-	};
+		fetchSpaces();
+	}, []);
 
 	return (
-		<FilterDropdown
-			active={dropdownActive}
-			borderless={false}
-			className={className}
-			filterByValue="spaces"
-			icon="box-container"
+		<Picker
+			aria-label={Liferay.Language.get('filter-by-spaces')}
+			as={Trigger}
+			filterKey="label"
 			items={spaces}
-			loading={loading}
-			onActiveChange={() => setDropdownActive((prevState) => !prevState)}
-			onSearch={async (value) => {
-				setLoading(true);
-
-				const spaces = await fetchSpaces(value);
-
-				setSpaces(value ? spaces : [initialSpace, ...spaces]);
-
-				setLoading(false);
+			messages={{
+				noResultsFound: Liferay.Language.get('no-results-were-found'),
+				searchPlaceholder: Liferay.Language.get('search'),
 			}}
-			onSelectItem={(item) => {
-				changeSpace(item);
+			onSelectionChange={(key) => {
+				const selectedSpace = spaces.find(
+					({value}) => value === String(key)
+				);
 
-				setDropdownActive(false);
+				if (selectedSpace) {
+					changeSpace(selectedSpace);
+				}
 			}}
-			onTrigger={async () => {
-				setLoading(true);
-
-				const spaces = await fetchSpaces();
-
-				setSpaces([initialSpace, ...spaces]);
-
-				setLoading(false);
-			}}
-			selectedItem={space}
-			title={Liferay.Language.get('filter-by-spaces')}
-		/>
+			searchable
+			selectedKey={space.value}
+			triggerClassName={className}
+			triggerIcon="box-container"
+		>
+			{(item: SpaceOption) => (
+				<Option key={item.value}>{item.label}</Option>
+			)}
+		</Picker>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AllStructureTypesDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AllStructureTypesDropdown.test.tsx
@@ -5,12 +5,11 @@
 
 import '@testing-library/jest-dom';
 import {
-	act,
 	fireEvent,
 	render,
 	screen,
 	waitFor,
-	waitForElementToBeRemoved,
+	within,
 } from '@testing-library/react';
 import React from 'react';
 
@@ -75,38 +74,32 @@ describe('[CMS Dashboard] Components: AllStructureTypesDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={onSelectItem} />);
 
-		const button = screen.getByRole('button', {
+		const trigger = screen.getByRole('combobox', {
+			name: 'filter-by-content-structure-type',
+		});
+
+		expect(trigger).toHaveTextContent('all-content-structures');
+
+		fireEvent.click(trigger);
+
+		expect(screen.getByPlaceholderText('search')).toBeInTheDocument();
+
+		const listbox = await screen.findByRole('listbox');
+
+		const option = within(listbox).getByRole('option', {
 			name: 'all-content-structures',
 		});
 
-		expect(button).toBeInTheDocument();
+		expect(within(listbox).getAllByRole('option')).toHaveLength(1);
 
-		fireEvent.click(button);
+		fireEvent.click(option);
 
-		expect(
-			screen.queryByText('filter-by-content-structure-type')
-		).toBeInTheDocument();
-
-		expect(screen.queryByPlaceholderText('search')).toBeInTheDocument();
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-		const menuitem = screen.getByRole('menuitem', {
-			name: 'all-content-structures',
-		});
-
-		expect(menuitem).toBeInTheDocument();
-
-		fireEvent.click(menuitem);
-
-		expect(onSelectItem).toHaveBeenCalledTimes(1);
-
-		expect(onSelectItem).toHaveBeenCalledWith({
-			label: 'all-content-structures',
-			value: 'all',
-		});
+		expect(onSelectItem).toHaveBeenCalledWith(
+			expect.objectContaining({
+				label: 'all-content-structures',
+				value: 'all',
+			})
+		);
 	});
 
 	it('renders a structure list', async () => {
@@ -117,169 +110,125 @@ describe('[CMS Dashboard] Components: AllStructureTypesDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		const button = screen.getByRole('button', {
-			name: 'all-content-structures',
-		});
+		fireEvent.click(
+			screen.getByRole('combobox', {
+				name: 'filter-by-content-structure-type',
+			})
+		);
 
-		fireEvent.click(button);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
+		const listbox = await screen.findByRole('listbox');
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'all-content-structures'})
+			await within(listbox).findByRole('option', {name: 'structure 01'})
 		).toBeInTheDocument();
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'structure 01'})
+			within(listbox).getByRole('option', {name: 'structure 02'})
 		).toBeInTheDocument();
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'structure 02'})
+			within(listbox).getByRole('option', {
+				name: 'all-content-structures',
+			})
 		).toBeInTheDocument();
+
+		expect(within(listbox).getAllByRole('option')).toHaveLength(3);
 	});
 
 	it('searches by structure name and returns a filtered result', async () => {
-		jest.useFakeTimers();
-
-		jest.spyOn(ApiHelper, 'get')
-			.mockResolvedValueOnce({
-				data: mockStructureTypesApiResponse,
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: {
-					items: [
-						{
-							id: '02',
-							label: {
-								en_US: 'structure 02',
-							},
-						},
-					],
-				},
-				error: null,
-			});
-
-		render(<WrappedComponent onSelectItem={jest.fn()} />);
-
-		const dropdownButton = screen.getByRole('button', {
-			name: 'all-content-structures',
-		});
-
-		fireEvent.click(dropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {value: 'structure 02'},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-			expect(
-				screen.getByRole('menuitem', {name: 'structure 02'})
-			).toBeInTheDocument();
-		});
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'structure 01'})
-		).not.toBeInTheDocument();
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'all-content-structures'})
-		).not.toBeInTheDocument();
-
-		jest.useRealTimers();
-	});
-
-	it('search by a structure and returns a empty result', async () => {
-		jest.useFakeTimers();
-
-		jest.spyOn(ApiHelper, 'get')
-			.mockResolvedValueOnce({
-				data: mockStructureTypesApiResponse,
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: {
-					items: [],
-				},
-				error: null,
-			});
-
-		render(<WrappedComponent onSelectItem={jest.fn()} />);
-
-		const structuresDropdownButton = screen.getByRole('button', {
-			name: 'all-content-structures',
-		});
-
-		fireEvent.click(structuresDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		global.fetch = jest.fn().mockResolvedValue({
-			json: jest.fn().mockResolvedValue({items: []}),
-			ok: true,
-		});
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {
-					value: 'empty?',
-				},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-			expect(
-				screen.queryByRole('menuitem', {
-					name: 'no-filters-were-found',
-				})
-			).toBeInTheDocument();
-		});
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'all-content-structures'})
-		).not.toBeInTheDocument();
-
-		jest.useRealTimers();
-	});
-
-	it('selects a new strucuture', async () => {
 		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
 			data: mockStructureTypesApiResponse,
 			error: null,
 		});
 
-		render(<WrappedComponent onSelectItem={() => {}} />);
+		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		expect(screen.getByTestId('structures')).toHaveTextContent(
-			'all-content-structures'
+		fireEvent.click(
+			screen.getByRole('combobox', {
+				name: 'filter-by-content-structure-type',
+			})
 		);
 
-		fireEvent.click(screen.getByTestId('structures'));
+		const listbox = await screen.findByRole('listbox');
 
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
+		await within(listbox).findByRole('option', {name: 'structure 02'});
 
-		fireEvent.click(screen.getByRole('menuitem', {name: 'structure 02'}));
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'structure 02'},
+		});
 
-		expect(screen.getByTestId('structures')).toHaveTextContent(
-			'structure 02'
+		await waitFor(() =>
+			expect(within(listbox).getAllByRole('option')).toHaveLength(1)
 		);
+
+		expect(
+			within(listbox).getByRole('option', {name: 'structure 02'})
+		).toBeInTheDocument();
+
+		expect(
+			within(listbox).queryByRole('option', {name: 'structure 01'})
+		).not.toBeInTheDocument();
+
+		expect(
+			within(listbox).queryByRole('option', {
+				name: 'all-content-structures',
+			})
+		).not.toBeInTheDocument();
+	});
+
+	it('shows a message when no structure matches the search', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: mockStructureTypesApiResponse,
+			error: null,
+		});
+
+		render(<WrappedComponent onSelectItem={jest.fn()} />);
+
+		fireEvent.click(
+			screen.getByRole('combobox', {
+				name: 'filter-by-content-structure-type',
+			})
+		);
+
+		const listbox = await screen.findByRole('listbox');
+
+		await within(listbox).findByRole('option', {name: 'structure 02'});
+
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'no-match'},
+		});
+
+		await waitFor(() =>
+			expect(
+				within(listbox).queryByRole('option')
+			).not.toBeInTheDocument()
+		);
+
+		expect(
+			within(listbox).getByText('no-results-were-found')
+		).toBeInTheDocument();
+	});
+
+	it('selects a new structure', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: mockStructureTypesApiResponse,
+			error: null,
+		});
+
+		render(<WrappedComponent onSelectItem={jest.fn()} />);
+
+		const trigger = screen.getByRole('combobox', {
+			name: 'filter-by-content-structure-type',
+		});
+
+		fireEvent.click(trigger);
+
+		const listbox = await screen.findByRole('listbox');
+
+		fireEvent.click(
+			await within(listbox).findByRole('option', {name: 'structure 02'})
+		);
+
+		await waitFor(() => expect(trigger).toHaveTextContent('structure 02'));
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AllTagsDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AllTagsDropdown.test.tsx
@@ -5,12 +5,11 @@
 
 import '@testing-library/jest-dom';
 import {
-	act,
 	fireEvent,
 	render,
 	screen,
 	waitFor,
-	waitForElementToBeRemoved,
+	within,
 } from '@testing-library/react';
 import React from 'react';
 
@@ -71,36 +70,28 @@ describe('[CMS Dashboard] Components: AllTagsDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={onSelectItem} />);
 
-		const tagsDropdownButton = screen.getByRole('button', {
-			name: 'all-tags',
-		});
+		const trigger = screen.getByRole('combobox', {name: 'filter-by-tag'});
 
-		expect(tagsDropdownButton).toBeInTheDocument();
+		expect(trigger).toHaveTextContent('all-tags');
 
-		fireEvent.click(tagsDropdownButton);
+		fireEvent.click(trigger);
 
-		expect(screen.queryByText('filter-by-tag')).toBeInTheDocument();
+		expect(screen.getByPlaceholderText('search')).toBeInTheDocument();
 
-		expect(screen.queryByPlaceholderText('search')).toBeInTheDocument();
+		const listbox = await screen.findByRole('listbox');
 
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
+		const option = within(listbox).getByRole('option', {name: 'all-tags'});
 
-		expect(screen.getAllByRole('menuitem').length).toBe(1);
+		expect(within(listbox).getAllByRole('option')).toHaveLength(1);
 
-		const menuitem = screen.getByRole('menuitem', {
-			name: 'all-tags',
-		});
+		fireEvent.click(option);
 
-		expect(menuitem).toBeInTheDocument();
-
-		fireEvent.click(menuitem);
-
-		expect(onSelectItem).toHaveBeenCalledTimes(1);
-
-		expect(onSelectItem).toHaveBeenCalledWith({
-			label: 'all-tags',
-			value: 'all',
-		});
+		expect(onSelectItem).toHaveBeenCalledWith(
+			expect.objectContaining({
+				label: 'all-tags',
+				value: 'all',
+			})
+		);
 	});
 
 	it('renders a tag list', async () => {
@@ -111,151 +102,107 @@ describe('[CMS Dashboard] Components: AllTagsDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		const tagsDropdownButton = screen.getByRole('button', {
-			name: 'all-tags',
-		});
+		fireEvent.click(screen.getByRole('combobox', {name: 'filter-by-tag'}));
 
-		fireEvent.click(tagsDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
+		const listbox = await screen.findByRole('listbox');
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'all-tags'})
+			await within(listbox).findByRole('option', {name: 'tag 01'})
 		).toBeInTheDocument();
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'tag 01'})
+			within(listbox).getByRole('option', {name: 'tag 02'})
 		).toBeInTheDocument();
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'tag 02'})
+			within(listbox).getByRole('option', {name: 'all-tags'})
 		).toBeInTheDocument();
+
+		expect(within(listbox).getAllByRole('option')).toHaveLength(3);
 	});
 
-	it('search by a tag and returns a filtered result', async () => {
-		jest.useFakeTimers();
-
-		jest.spyOn(ApiHelper, 'get')
-			.mockResolvedValueOnce({
-				data: mockTagsApiResponse,
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: {items: [{id: '02', name: 'tag 02'}]},
-				error: null,
-			});
-
-		render(<WrappedComponent onSelectItem={jest.fn()} />);
-
-		const tagsDropdownButton = screen.getByRole('button', {
-			name: 'all-tags',
-		});
-
-		fireEvent.click(tagsDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {
-					value: 'tag 02',
-				},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-			expect(
-				screen.queryByRole('menuitem', {name: 'tag 02'})
-			).toBeInTheDocument();
-		});
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'all-tags'})
-		).not.toBeInTheDocument();
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'tag 01'})
-		).not.toBeInTheDocument();
-
-		jest.useRealTimers();
-	});
-
-	it('search by a tag and returns a empty result', async () => {
-		jest.useFakeTimers();
-
-		jest.spyOn(ApiHelper, 'get')
-			.mockResolvedValueOnce({
-				data: mockTagsApiResponse,
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: {items: []},
-				error: null,
-			});
-
-		render(<WrappedComponent onSelectItem={jest.fn()} />);
-
-		const tagsDropdownButton = screen.getByRole('button', {
-			name: 'all-tags',
-		});
-
-		fireEvent.click(tagsDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {
-					value: 'empty?',
-				},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-			expect(
-				screen.queryByRole('menuitem', {
-					name: 'no-filters-were-found',
-				})
-			).toBeInTheDocument();
-		});
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'all-tags'})
-		).not.toBeInTheDocument();
-
-		jest.useRealTimers();
-	});
-
-	it('selects a new tag', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValueOnce({
+	it('searches by tag name and returns a filtered result', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
 			data: mockTagsApiResponse,
 			error: null,
 		});
 
-		render(<WrappedComponent onSelectItem={() => {}} />);
+		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		expect(screen.getByTestId('tags')).toHaveTextContent('all-tags');
+		fireEvent.click(screen.getByRole('combobox', {name: 'filter-by-tag'}));
 
-		fireEvent.click(screen.getByTestId('tags'));
+		const listbox = await screen.findByRole('listbox');
 
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
+		await within(listbox).findByRole('option', {name: 'tag 02'});
 
-		fireEvent.click(screen.getByRole('menuitem', {name: 'tag 02'}));
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'tag 02'},
+		});
 
-		expect(screen.getByTestId('tags')).toHaveTextContent('tag 02');
+		await waitFor(() =>
+			expect(within(listbox).getAllByRole('option')).toHaveLength(1)
+		);
+
+		expect(
+			within(listbox).getByRole('option', {name: 'tag 02'})
+		).toBeInTheDocument();
+
+		expect(
+			within(listbox).queryByRole('option', {name: 'tag 01'})
+		).not.toBeInTheDocument();
+
+		expect(
+			within(listbox).queryByRole('option', {name: 'all-tags'})
+		).not.toBeInTheDocument();
+	});
+
+	it('shows a message when no tag matches the search', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: mockTagsApiResponse,
+			error: null,
+		});
+
+		render(<WrappedComponent onSelectItem={jest.fn()} />);
+
+		fireEvent.click(screen.getByRole('combobox', {name: 'filter-by-tag'}));
+
+		const listbox = await screen.findByRole('listbox');
+
+		await within(listbox).findByRole('option', {name: 'tag 02'});
+
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'no-match'},
+		});
+
+		await waitFor(() =>
+			expect(
+				within(listbox).queryByRole('option')
+			).not.toBeInTheDocument()
+		);
+
+		expect(
+			within(listbox).getByText('no-results-were-found')
+		).toBeInTheDocument();
+	});
+
+	it('selects a new tag', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: mockTagsApiResponse,
+			error: null,
+		});
+
+		render(<WrappedComponent onSelectItem={jest.fn()} />);
+
+		const trigger = screen.getByRole('combobox', {name: 'filter-by-tag'});
+
+		fireEvent.click(trigger);
+
+		const listbox = await screen.findByRole('listbox');
+
+		fireEvent.click(
+			await within(listbox).findByRole('option', {name: 'tag 02'})
+		);
+
+		await waitFor(() => expect(trigger).toHaveTextContent('tag 02'));
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AllVocabulariesDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AllVocabulariesDropdown.test.tsx
@@ -5,12 +5,11 @@
 
 import '@testing-library/jest-dom';
 import {
-	act,
 	fireEvent,
 	render,
 	screen,
 	waitFor,
-	waitForElementToBeRemoved,
+	within,
 } from '@testing-library/react';
 import React from 'react';
 
@@ -71,36 +70,32 @@ describe('[CMS Dashboard] Components: AllVocabulariesDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={onSelectItem} />);
 
-		const vocabulariesDropdownButton = screen.getByRole('button', {
+		const trigger = screen.getByRole('combobox', {
+			name: 'filter-by-vocabulary',
+		});
+
+		expect(trigger).toHaveTextContent('all-vocabularies');
+
+		fireEvent.click(trigger);
+
+		expect(screen.getByPlaceholderText('search')).toBeInTheDocument();
+
+		const listbox = await screen.findByRole('listbox');
+
+		const option = within(listbox).getByRole('option', {
 			name: 'all-vocabularies',
 		});
 
-		expect(vocabulariesDropdownButton).toBeInTheDocument();
+		expect(within(listbox).getAllByRole('option')).toHaveLength(1);
 
-		fireEvent.click(vocabulariesDropdownButton);
+		fireEvent.click(option);
 
-		expect(screen.queryByText('filter-by-vocabulary')).toBeInTheDocument();
-
-		expect(screen.queryByPlaceholderText('search')).toBeInTheDocument();
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-		const menuitem = screen.getByRole('menuitem', {
-			name: 'all-vocabularies',
-		});
-
-		expect(menuitem).toBeInTheDocument();
-
-		fireEvent.click(menuitem);
-
-		expect(onSelectItem).toHaveBeenCalledTimes(1);
-
-		expect(onSelectItem).toHaveBeenCalledWith({
-			label: 'all-vocabularies',
-			value: 'all',
-		});
+		expect(onSelectItem).toHaveBeenCalledWith(
+			expect.objectContaining({
+				label: 'all-vocabularies',
+				value: 'all',
+			})
+		);
 	});
 
 	it('renders a vocabulary list', async () => {
@@ -111,32 +106,28 @@ describe('[CMS Dashboard] Components: AllVocabulariesDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		const vocabulariesDropdownButton = screen.getByRole('button', {
-			name: 'all-vocabularies',
-		});
+		fireEvent.click(
+			screen.getByRole('combobox', {name: 'filter-by-vocabulary'})
+		);
 
-		fireEvent.click(vocabulariesDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
+		const listbox = await screen.findByRole('listbox');
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'all-vocabularies'})
+			await within(listbox).findByRole('option', {name: 'vocabulary 01'})
 		).toBeInTheDocument();
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'vocabulary 01'})
+			within(listbox).getByRole('option', {name: 'vocabulary 02'})
 		).toBeInTheDocument();
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'vocabulary 02'})
+			within(listbox).getByRole('option', {name: 'all-vocabularies'})
 		).toBeInTheDocument();
+
+		expect(within(listbox).getAllByRole('option')).toHaveLength(3);
 	});
 
-	it('search by a vocabulary and returns a filtered result', async () => {
-		jest.useFakeTimers();
-
+	it('searches by vocabulary name and returns a filtered result', async () => {
 		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
 			data: mockVocabularyApiResponse,
 			error: null,
@@ -144,60 +135,36 @@ describe('[CMS Dashboard] Components: AllVocabulariesDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		const vocabulariesDropdownButton = screen.getByRole('button', {
-			name: 'all-vocabularies',
+		fireEvent.click(
+			screen.getByRole('combobox', {name: 'filter-by-vocabulary'})
+		);
+
+		const listbox = await screen.findByRole('listbox');
+
+		await within(listbox).findByRole('option', {name: 'vocabulary 02'});
+
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'vocabulary 02'},
 		});
 
-		fireEvent.click(vocabulariesDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: {
-				items: [
-					{
-						id: '02',
-						name: 'vocabulary 02',
-					},
-				],
-			},
-			error: null,
-		});
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {
-					value: 'vocabulary 02',
-				},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-			expect(
-				screen.queryByRole('menuitem', {name: 'vocabulary 02'})
-			).toBeInTheDocument();
-		});
+		await waitFor(() =>
+			expect(within(listbox).getAllByRole('option')).toHaveLength(1)
+		);
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'all-vocabularies'})
+			within(listbox).getByRole('option', {name: 'vocabulary 02'})
+		).toBeInTheDocument();
+
+		expect(
+			within(listbox).queryByRole('option', {name: 'vocabulary 01'})
 		).not.toBeInTheDocument();
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'vocabulary 01'})
+			within(listbox).queryByRole('option', {name: 'all-vocabularies'})
 		).not.toBeInTheDocument();
-
-		jest.useRealTimers();
 	});
 
-	it('search by a vocabulary and returns a empty result', async () => {
-		jest.useFakeTimers();
-
+	it('shows a message when no vocabulary matches the search', async () => {
 		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
 			data: mockVocabularyApiResponse,
 			error: null,
@@ -205,44 +172,27 @@ describe('[CMS Dashboard] Components: AllVocabulariesDropdown', () => {
 
 		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		const vocabulariesDropdownButton = screen.getByRole('button', {
-			name: 'all-vocabularies',
+		fireEvent.click(
+			screen.getByRole('combobox', {name: 'filter-by-vocabulary'})
+		);
+
+		const listbox = await screen.findByRole('listbox');
+
+		await within(listbox).findByRole('option', {name: 'vocabulary 02'});
+
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'no-match'},
 		});
 
-		fireEvent.click(vocabulariesDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: {items: []},
-			error: null,
-		});
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {value: 'empty?'},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
+		await waitFor(() =>
 			expect(
-				screen.queryByRole('menuitem', {name: 'all-vocabularies'})
-			).not.toBeInTheDocument();
+				within(listbox).queryByRole('option')
+			).not.toBeInTheDocument()
+		);
 
-			expect(
-				screen.queryByRole('menuitem', {
-					name: 'no-filters-were-found',
-				})
-			).toBeInTheDocument();
-		});
-
-		jest.useRealTimers();
+		expect(
+			within(listbox).getByText('no-results-were-found')
+		).toBeInTheDocument();
 	});
 
 	it('selects a new vocabulary', async () => {
@@ -251,20 +201,20 @@ describe('[CMS Dashboard] Components: AllVocabulariesDropdown', () => {
 			error: null,
 		});
 
-		render(<WrappedComponent onSelectItem={() => {}} />);
+		render(<WrappedComponent onSelectItem={jest.fn()} />);
 
-		expect(screen.getByTestId('vocabularies')).toHaveTextContent(
-			'all-vocabularies'
+		const trigger = screen.getByRole('combobox', {
+			name: 'filter-by-vocabulary',
+		});
+
+		fireEvent.click(trigger);
+
+		const listbox = await screen.findByRole('listbox');
+
+		fireEvent.click(
+			await within(listbox).findByRole('option', {name: 'vocabulary 02'})
 		);
 
-		fireEvent.click(screen.getByTestId('vocabularies'));
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		fireEvent.click(screen.getByRole('menuitem', {name: 'vocabulary 02'}));
-
-		expect(screen.getByTestId('vocabularies')).toHaveTextContent(
-			'vocabulary 02'
-		);
+		await waitFor(() => expect(trigger).toHaveTextContent('vocabulary 02'));
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GroupByDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GroupByDropdown.test.tsx
@@ -84,21 +84,26 @@ describe('[CMS Dashboard] Components: GroupByDropdown - All Options', () => {
 				/>
 			);
 
-			const button = screen.getByRole('button', {
+			const trigger = screen.getByRole('combobox', {
+				name: 'group-by',
+			});
+			expect(trigger).toHaveTextContent(item.label);
+
+			fireEvent.click(trigger);
+
+			const option = await screen.findByRole('option', {
 				name: item.label,
 			});
-			expect(button).toBeInTheDocument();
+			expect(option).toBeInTheDocument();
 
-			fireEvent.click(button);
+			fireEvent.click(option);
 
-			const menuitem = screen.getByRole('menuitem', {
-				name: item.label,
-			});
-			expect(menuitem).toBeInTheDocument();
-
-			fireEvent.click(menuitem);
-
-			expect(onSelectItem).toHaveBeenCalledWith(item);
+			expect(onSelectItem).toHaveBeenCalledWith(
+				expect.objectContaining({
+					label: item.label,
+					value: item.value,
+				})
+			);
 		}
 	);
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/InventoryAnalysisCard.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/InventoryAnalysisCard.test.tsx
@@ -36,13 +36,22 @@ const mockData = {
 	error: null,
 };
 
+const mockApiHelperGet = (inventoryAnalysisData: any) =>
+	jest
+		.spyOn(ApiHelper, 'get')
+		.mockImplementation((url: string) =>
+			url.includes('inventory-analysis')
+				? Promise.resolve(inventoryAnalysisData)
+				: Promise.resolve({data: {items: []}, error: null})
+		);
+
 describe('[CMS Dashboard] InventoryAnalysisCard', () => {
 	afterEach(() => {
 		jest.restoreAllMocks();
 	});
 
 	it('renders inventory analysis data inside a PaginatedTable', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue(mockData);
+		mockApiHelperGet(mockData);
 
 		render(
 			<ViewDashboardContext.Provider value={mockContextValue}>
@@ -61,7 +70,7 @@ describe('[CMS Dashboard] InventoryAnalysisCard', () => {
 	});
 
 	it('allows user to switch preferences between chart and table', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue(mockData);
+		mockApiHelperGet(mockData);
 
 		render(
 			<ViewDashboardContext.Provider value={mockContextValue}>
@@ -73,20 +82,22 @@ describe('[CMS Dashboard] InventoryAnalysisCard', () => {
 			expect(screen.getByText('Articles')).toBeInTheDocument()
 		);
 
-		const preferencesButton = screen.getByRole('button', {
+		const preferencesButton = screen.getByRole('combobox', {
 			name: 'chart',
 		});
 
 		fireEvent.click(preferencesButton);
 
-		const tableOption = screen.getByText('table');
+		const tableOption = await screen.findByRole('option', {name: 'table'});
 		fireEvent.click(tableOption);
 
-		expect(screen.getByRole('button', {name: 'table'})).toBeInTheDocument();
+		expect(
+			screen.getByRole('combobox', {name: 'table'})
+		).toBeInTheDocument();
 	});
 
 	it('renders filters (group by and filter by) when data is available', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue(mockData);
+		mockApiHelperGet(mockData);
 
 		render(
 			<ViewDashboardContext.Provider value={mockContextValue}>
@@ -103,7 +114,7 @@ describe('[CMS Dashboard] InventoryAnalysisCard', () => {
 	});
 
 	it('renders EmptyStateCard when no inventory analysis data is available', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+		mockApiHelperGet({
 			data: {
 				inventoryAnalysisItems: [],
 				totalCount: 0,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/LanguagesDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/LanguagesDropdown.test.tsx
@@ -4,7 +4,13 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
 import React from 'react';
 
 import SpaceService from '../../../../src/main/resources/META-INF/resources/js/common/services/SpaceService';
@@ -46,35 +52,41 @@ describe('[CMS Dashboard] Components: LanguagesDropdown', () => {
 			</ViewDashboardContext.Provider>
 		);
 
-		const button = screen.getByRole('button', {name: 'all-languages'});
+		const trigger = screen.getByRole('combobox', {
+			name: 'filter-by-languages',
+		});
 
-		expect(button).toBeInTheDocument();
+		expect(trigger).toHaveTextContent('all-languages');
 
-		fireEvent.click(button);
+		fireEvent.click(trigger);
+
+		const listbox = await screen.findByRole('listbox');
 
 		expect(
-			screen.getByRole('menuitem', {name: 'all-languages'})
+			within(listbox).getByRole('option', {name: 'all-languages'})
 		).toBeInTheDocument();
 
-		const availableLanguages = Object.values(localizations);
-
-		availableLanguages.forEach((translation) => {
+		Object.values(localizations).forEach((translation) => {
 			expect(
-				screen.getByRole('menuitem', {name: translation})
+				within(listbox).getByRole('option', {name: translation})
 			).toBeInTheDocument();
 		});
 	});
 
-	it('filters languages when searching and restores them when backspacing or reopening', async () => {
+	it('filters languages when searching and restores them when reopening', async () => {
 		render(
 			<ViewDashboardContext.Provider value={mockedContext}>
 				<LanguagesDropdown />
 			</ViewDashboardContext.Provider>
 		);
 
-		const button = screen.getByRole('button', {name: 'all-languages'});
+		const trigger = screen.getByRole('combobox', {
+			name: 'filter-by-languages',
+		});
 
-		fireEvent.click(button);
+		fireEvent.click(trigger);
+
+		let listbox = await screen.findByRole('listbox');
 
 		const searchInput = screen.getByPlaceholderText('search');
 
@@ -84,11 +96,13 @@ describe('[CMS Dashboard] Components: LanguagesDropdown', () => {
 
 		await waitFor(() => {
 			expect(
-				screen.getByRole('menuitem', {name: localizations.en_US})
+				within(listbox).getByRole('option', {name: localizations.en_US})
 			).toBeInTheDocument();
 
 			expect(
-				screen.queryByRole('menuitem', {name: localizations.es_ES})
+				within(listbox).queryByRole('option', {
+					name: localizations.es_ES,
+				})
 			).not.toBeInTheDocument();
 		});
 
@@ -98,39 +112,29 @@ describe('[CMS Dashboard] Components: LanguagesDropdown', () => {
 
 		await waitFor(() => {
 			expect(
-				screen.queryByRole('menuitem', {name: localizations.en_US})
+				within(listbox).queryByRole('option', {
+					name: localizations.en_US,
+				})
 			).not.toBeInTheDocument();
 		});
 
-		// Backspace (simulated by searching for a prefix)
+		// Close and reopen the dropdown
 
-		fireEvent.change(searchInput, {
-			target: {value: localizations.en_US.substring(0, 3)},
-		});
+		fireEvent.click(trigger);
 
-		await waitFor(() => {
-			expect(
-				screen.getByRole('menuitem', {name: localizations.en_US})
-			).toBeInTheDocument();
-		});
+		fireEvent.click(trigger);
 
-		// Close the dropdown
-
-		fireEvent.click(button);
-
-		// Reopen the dropdown
-
-		fireEvent.click(button);
+		listbox = await screen.findByRole('listbox');
 
 		// Should show all languages again
 
 		await waitFor(() => {
 			expect(
-				screen.getByRole('menuitem', {name: localizations.en_US})
+				within(listbox).getByRole('option', {name: localizations.en_US})
 			).toBeInTheDocument();
 
 			expect(
-				screen.getByRole('menuitem', {name: localizations.es_ES})
+				within(listbox).getByRole('option', {name: localizations.es_ES})
 			).toBeInTheDocument();
 		});
 	});
@@ -168,24 +172,28 @@ describe('[CMS Dashboard] Components: LanguagesDropdown', () => {
 			)
 		);
 
-		fireEvent.click(screen.getByRole('button', {name: 'all-languages'}));
+		fireEvent.click(
+			screen.getByRole('combobox', {name: 'filter-by-languages'})
+		);
+
+		const listbox = await screen.findByRole('listbox');
 
 		expect(
-			screen.getByRole('menuitem', {name: 'all-languages'})
+			within(listbox).getByRole('option', {name: 'all-languages'})
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByRole('menuitem', {name: localizations.en_US})
+			within(listbox).getByRole('option', {name: localizations.en_US})
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByRole('menuitem', {name: localizations.es_ES})
+			within(listbox).getByRole('option', {name: localizations.es_ES})
 		).toBeInTheDocument();
 
 		// Should not show other languages
 
 		expect(
-			screen.queryByRole('menuitem', {name: localizations.pt_BR})
+			within(listbox).queryByRole('option', {name: localizations.pt_BR})
 		).not.toBeInTheDocument();
 	});
 
@@ -256,13 +264,15 @@ describe('[CMS Dashboard] Components: LanguagesDropdown', () => {
 			expect(mockedSpaceService.getSpace).toHaveBeenCalled()
 		);
 
-		fireEvent.click(screen.getByRole('button', {name: 'all-languages'}));
+		fireEvent.click(
+			screen.getByRole('combobox', {name: 'filter-by-languages'})
+		);
 
-		const availableLanguages = Object.values(localizations);
+		const listbox = await screen.findByRole('listbox');
 
-		availableLanguages.forEach((translation) => {
+		Object.values(localizations).forEach((translation) => {
 			expect(
-				screen.getByRole('menuitem', {name: translation})
+				within(listbox).getByRole('option', {name: translation})
 			).toBeInTheDocument();
 		});
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/SpacesDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/SpacesDropdown.test.tsx
@@ -5,243 +5,155 @@
 
 import '@testing-library/jest-dom';
 import {
-	act,
 	fireEvent,
 	render,
 	screen,
 	waitFor,
-	waitForElementToBeRemoved,
+	within,
 } from '@testing-library/react';
 import React from 'react';
 
-import ApiHelper from '../../../../src/main/resources/META-INF/resources/js/common/services/ApiHelper';
+import SpaceService from '../../../../src/main/resources/META-INF/resources/js/common/services/SpaceService';
 import {ViewDashboardContextProvider} from '../../../../src/main/resources/META-INF/resources/js/main_view/dashboard/ViewDashboardContext';
 import {SpacesDropdown} from '../../../../src/main/resources/META-INF/resources/js/main_view/dashboard/components/SpacesDropdown';
 
-const WrappedComponent = ({constants}: any) => (
-	<ViewDashboardContextProvider value={{constants}}>
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/common/services/SpaceService'
+);
+
+const mockedSpaceService = SpaceService as jest.Mocked<typeof SpaceService>;
+
+const WrappedComponent = () => (
+	<ViewDashboardContextProvider value={{}}>
 		<SpacesDropdown />
 	</ViewDashboardContextProvider>
 );
 
 describe('[CMS Dashboard] Components: SpacesDropdown', () => {
-	const mockSpacesApiResponse = {
-		items: [
-			{id: '01', name: 'space 01'},
-			{id: '02', name: 'space 02'},
-		],
-	};
+	const mockSpaces = [
+		{externalReferenceCode: 'ERC_01', id: '01', name: 'space 01'},
+		{externalReferenceCode: 'ERC_02', id: '02', name: 'space 02'},
+	];
 
-	afterEach(() => {
+	beforeEach(() => {
 		jest.clearAllMocks();
-		jest.restoreAllMocks();
+
+		mockedSpaceService.getSpaces.mockResolvedValue(mockSpaces as any);
 	});
 
-	it('fetches spaces filtered by type Space', async () => {
-		const apiHelperGetSpy = jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: {items: []},
-			error: null,
-		});
+	it('fetches the spaces', async () => {
+		render(<WrappedComponent />);
 
+		await waitFor(() =>
+			expect(mockedSpaceService.getSpaces).toHaveBeenCalled()
+		);
+	});
+
+	it('renders the selected space in the trigger', () => {
+		render(<WrappedComponent />);
+
+		expect(
+			screen.getByRole('combobox', {name: 'filter-by-spaces'})
+		).toHaveTextContent('all-spaces');
+	});
+
+	it('renders the space list', async () => {
 		render(<WrappedComponent />);
 
 		fireEvent.click(
-			screen.getByRole('button', {
-				name: 'all-spaces',
-			})
+			screen.getByRole('combobox', {name: 'filter-by-spaces'})
 		);
 
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
+		const listbox = await screen.findByRole('listbox');
 
-		expect(apiHelperGetSpy).toHaveBeenCalledWith(
-			expect.stringContaining(
-				`filter=${encodeURIComponent("type eq 'Space'")}`
-			)
+		expect(
+			await within(listbox).findByRole('option', {name: 'space 01'})
+		).toBeInTheDocument();
+
+		expect(
+			within(listbox).getByRole('option', {name: 'space 02'})
+		).toBeInTheDocument();
+
+		expect(
+			within(listbox).getByRole('option', {name: 'all-spaces'})
+		).toBeInTheDocument();
+
+		expect(within(listbox).getAllByRole('option')).toHaveLength(3);
+	});
+
+	it('filters the list when searching', async () => {
+		render(<WrappedComponent />);
+
+		fireEvent.click(
+			screen.getByRole('combobox', {name: 'filter-by-spaces'})
 		);
+
+		const listbox = await screen.findByRole('listbox');
+
+		await within(listbox).findByRole('option', {name: 'space 02'});
+
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'space 02'},
+		});
+
+		await waitFor(() =>
+			expect(within(listbox).getAllByRole('option')).toHaveLength(1)
+		);
+
+		expect(
+			within(listbox).getByRole('option', {name: 'space 02'})
+		).toBeInTheDocument();
+
+		expect(
+			within(listbox).queryByRole('option', {name: 'space 01'})
+		).not.toBeInTheDocument();
+
+		expect(
+			within(listbox).queryByRole('option', {name: 'all-spaces'})
+		).not.toBeInTheDocument();
 	});
 
-	it('renders correctly', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: {items: []},
-			error: null,
-		});
-
+	it('shows a message when no space matches the search', async () => {
 		render(<WrappedComponent />);
 
-		const spacesDropdownButton = screen.getByRole('button', {
-			name: 'all-spaces',
+		fireEvent.click(
+			screen.getByRole('combobox', {name: 'filter-by-spaces'})
+		);
+
+		const listbox = await screen.findByRole('listbox');
+
+		await within(listbox).findByRole('option', {name: 'space 02'});
+
+		fireEvent.change(screen.getByPlaceholderText('search'), {
+			target: {value: 'no-match'},
 		});
 
-		expect(spacesDropdownButton).toBeInTheDocument();
-
-		fireEvent.click(spacesDropdownButton);
-
-		expect(screen.queryByText('filter-by-spaces')).toBeInTheDocument();
-
-		expect(screen.queryByPlaceholderText('search')).toBeInTheDocument();
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'all-spaces'})
-		).toBeInTheDocument();
-	});
-
-	it('renders a space list', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: mockSpacesApiResponse,
-			error: null,
-		});
-
-		render(<WrappedComponent />);
-
-		const spacesDropdownButton = screen.getByRole('button', {
-			name: 'all-spaces',
-		});
-
-		fireEvent.click(spacesDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'all-spaces'})
-		).toBeInTheDocument();
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'space 01'})
-		).toBeInTheDocument();
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'space 02'})
-		).toBeInTheDocument();
-	});
-
-	it('search by a space and returns a filtered result', async () => {
-		jest.useFakeTimers();
-
-		jest.spyOn(ApiHelper, 'get')
-			.mockResolvedValueOnce({
-				data: mockSpacesApiResponse,
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: {items: [{id: '02', name: 'space 02'}]},
-				error: null,
-			});
-
-		render(<WrappedComponent />);
-
-		const spacesDropdownButton = screen.getByRole('button', {
-			name: 'all-spaces',
-		});
-
-		fireEvent.click(spacesDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {
-					value: 'space 02',
-				},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
+		await waitFor(() =>
 			expect(
-				screen.queryByRole('menuitem', {name: 'space 02'})
-			).toBeInTheDocument();
-		});
+				within(listbox).queryByRole('option')
+			).not.toBeInTheDocument()
+		);
 
 		expect(
-			screen.queryByRole('menuitem', {name: 'all-spaces'})
-		).not.toBeInTheDocument();
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'space 01'})
-		).not.toBeInTheDocument();
-
-		jest.useRealTimers();
-	});
-
-	it('search by a space and returns a empty result', async () => {
-		jest.useFakeTimers();
-
-		jest.spyOn(ApiHelper, 'get')
-			.mockResolvedValueOnce({
-				data: mockSpacesApiResponse,
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: {items: []},
-				error: null,
-			});
-
-		render(<WrappedComponent />);
-
-		const spacesDropdownButton = screen.getByRole('button', {
-			name: 'all-spaces',
-		});
-
-		fireEvent.click(spacesDropdownButton);
-
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
-
-		expect(screen.getAllByRole('menuitem').length).toBe(3);
-
-		await act(async () => {
-			fireEvent.change(screen.getByPlaceholderText('search'), {
-				target: {
-					value: 'empty?',
-				},
-			});
-
-			jest.advanceTimersByTime(300);
-		});
-
-		await waitFor(() => {
-			expect(screen.getAllByRole('menuitem').length).toBe(1);
-
-			expect(
-				screen.queryByRole('menuitem', {
-					name: 'no-filters-were-found',
-				})
-			).toBeInTheDocument();
-		});
-
-		expect(
-			screen.queryByRole('menuitem', {name: 'all-spaces'})
-		).not.toBeInTheDocument();
-
-		jest.useRealTimers();
+			within(listbox).getByText('no-results-were-found')
+		).toBeInTheDocument();
 	});
 
 	it('selects a new space', async () => {
-		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
-			data: mockSpacesApiResponse,
-			error: null,
-		});
-
 		render(<WrappedComponent />);
 
-		expect(screen.getByTestId('spaces')).toHaveTextContent('all-spaces');
+		const trigger = screen.getByRole('combobox', {
+			name: 'filter-by-spaces',
+		});
 
-		fireEvent.click(screen.getByTestId('spaces'));
+		fireEvent.click(trigger);
 
-		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
+		const listbox = await screen.findByRole('listbox');
 
-		fireEvent.click(screen.getByRole('menuitem', {name: 'space 02'}));
+		fireEvent.click(
+			await within(listbox).findByRole('option', {name: 'space 02'})
+		);
 
-		expect(screen.getByTestId('spaces')).toHaveTextContent('space 02');
+		await waitFor(() => expect(trigger).toHaveTextContent('space 02'));
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-66606

## What Is Being Fixed

The CMS dashboard filter controls (All Spaces, All Languages, the Inventory
Analysis view selector, Group by, All Content Structures, All Vocabularies and
All Tags) were built on the custom `FilterDropdown`/`ClayDropdown`, each
re-implementing its own trigger, open state, loading and search handling
instead of using the standard Clay Picker.

## How It Is Being Fixed

Each flat dropdown now uses the Clay `Picker` from `@clayui/core`. The ones
that need filtering (spaces, languages, content structures, vocabularies and
tags) rely on the Picker's built-in client-side search, loading their options
once and dropping the per-keystroke server-side search; the selection-only
ones (Group by and the Inventory Analysis chart/table selector) use a plain
Picker without search. A shared `PickerTrigger` renders the bordered or
borderless secondary trigger button so the markup is not duplicated. Option
fetching that used inline `ApiHelper.get` calls is now routed through the
existing services, adding `VocabularyService.getVocabularies` and
`TagService.getTags`. The hierarchical All Categories dropdown keeps using
`FilterDropdown`, since its drill-down + back-button navigation does not map
onto a flat Picker.

The Jest suites for every migrated component were updated to the Picker's
combobox/listbox/option roles and client-side search, and a new `PickerTrigger`
is covered through those components.

## PR Check

**pr-check: PASS** — tested on `c1babbdaa7899a6481d5f70b3bbd0e5a8efa5532`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c1babbdaa7899a6481d5f70b3bbd0e5a8efa5532"} -->
