### PR TITLE
LPD-95852 Export empty XLIFF target for untranslated fields

### DIFF
--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporter;
 import com.liferay.translation.info.field.TranslationInfoFieldChecker;
+import com.liferay.translation.internal.util.XLIFFExporterUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -168,8 +169,9 @@ public class XLIFF12InfoFormTranslationExporter
 
 					mrkElement.addAttribute("mid", String.valueOf(mid));
 					mrkElement.addAttribute("mtype", "seg");
-					mrkElement.addCDATA(
-						(String)infoFieldValue.getValue(targetLocale));
+
+					XLIFFExporterUtil.addTargetValue(
+						mrkElement, infoFieldValue, targetLocale);
 
 					mid++;
 				}
@@ -177,8 +179,8 @@ public class XLIFF12InfoFormTranslationExporter
 			else {
 				InfoFieldValue<Object> infoFieldValue = infoFieldValues.get(0);
 
-				targetElement.addCDATA(
-					_getStringValue(infoFieldValue.getValue(targetLocale)));
+				XLIFFExporterUtil.addTargetValue(
+					targetElement, infoFieldValue, targetLocale);
 			}
 		}
 

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF20InfoFormTranslationExporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF20InfoFormTranslationExporter.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporter;
 import com.liferay.translation.info.field.TranslationInfoFieldChecker;
+import com.liferay.translation.internal.util.XLIFFExporterUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -139,8 +140,8 @@ public class XLIFF20InfoFormTranslationExporter
 
 		Element targetElement = segmentElement.addElement("target");
 
-		targetElement.addCDATA(
-			_getStringValue(infoFieldValue.getValue(targetLocale)));
+		XLIFFExporterUtil.addTargetValue(
+			targetElement, infoFieldValue, targetLocale);
 	}
 
 	private String _getStringValue(Object value) {

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
@@ -7,6 +7,7 @@ package com.liferay.translation.internal.manager;
 
 import com.liferay.document.library.kernel.exception.FileMimeTypeException;
 import com.liferay.info.exception.InfoItemPermissionException;
+import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.InfoItemReference;
@@ -49,6 +50,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -300,6 +302,13 @@ public class TranslationManagerImpl implements TranslationManager {
 
 		InfoItemFieldValues infoItemFieldValues =
 			translationSnapshot.getInfoItemFieldValues();
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues();
+
+		if (infoFieldValues.isEmpty()) {
+			return;
+		}
 
 		try {
 			_translationEntryService.addOrUpdateTranslationEntry(

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
@@ -344,6 +344,22 @@ public class XLIFFTranslationSnapshotProvider
 		return LocaleUtil.fromLanguageId(targetLanguageProperty.getValue());
 	}
 
+	private boolean _isBlankTargetUnit(Unit unit) {
+		for (int i = 0; i < unit.getPartCount(); i++) {
+			Part part = unit.getPart(i);
+
+			Fragment targetFragment = part.getTarget();
+
+			if ((targetFragment == null) ||
+				!Validator.isBlank(targetFragment.getPlainText())) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private boolean _isVersion20(List<Event> events) {
 		for (Event event : events) {
 			if (event.isStartDocument()) {
@@ -386,6 +402,10 @@ public class XLIFFTranslationSnapshotProvider
 			for (LocaleId targetLocaleId : iTextUnit.getTargetLocales()) {
 				TextContainer targetTextContainer = iTextUnit.getTarget(
 					targetLocaleId);
+
+				if (targetTextContainer.isEmpty()) {
+					continue;
+				}
 
 				for (TextPart targetTextPart : targetTextContainer.getParts()) {
 					if (!targetTextPart.isSegment()) {
@@ -431,6 +451,10 @@ public class XLIFFTranslationSnapshotProvider
 		throws XLIFFFileException {
 
 		for (Unit unit : xliffDocument.getUnits()) {
+			if (_isBlankTargetUnit(unit)) {
+				continue;
+			}
+
 			for (int i = 0; i < unit.getPartCount(); i++) {
 				Part part = unit.getPart(i);
 
@@ -441,12 +465,14 @@ public class XLIFFTranslationSnapshotProvider
 						"There is no translation target");
 				}
 
+				String targetPlainText = targetFragment.getPlainText();
+
 				unsafeConsumer.accept(
 					new InfoFieldValue<>(
 						_createInfoField(targetLocale, unit.getId()),
 						InfoLocalizedValue.builder(
 						).value(
-							targetLocale, targetFragment.getPlainText()
+							targetLocale, targetPlainText
 						).value(
 							biConsumer -> {
 								if (includeSource) {
@@ -506,14 +532,6 @@ public class XLIFFTranslationSnapshotProvider
 
 				throw new XLIFFFileException.MustBeWellFormed(
 					"Only one translation language per file is permitted");
-			}
-
-			TextContainer targetTextContainer = iTextUnit.getTarget(
-				targetLocaleId);
-
-			if (!textContainer.isEmpty() && targetTextContainer.isEmpty()) {
-				throw new XLIFFFileException.MustBeWellFormed(
-					"There is no translation target");
 			}
 		}
 	}

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/util/XLIFFExporterUtil.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/util/XLIFFExporterUtil.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.translation.internal.util;
+
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.xml.Element;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * @author Akhash Ramprakash
+ */
+public class XLIFFExporterUtil {
+
+	public static void addTargetValue(
+		Element element, InfoFieldValue<Object> infoFieldValue,
+		Locale targetLocale) {
+
+		String targetStringValue = _getTargetStringValue(
+			infoFieldValue, targetLocale);
+
+		if (targetStringValue == null) {
+			element.addText(StringPool.BLANK);
+		}
+		else {
+			element.addCDATA(targetStringValue);
+		}
+	}
+
+	private static String _getTargetStringValue(
+		InfoFieldValue<Object> infoFieldValue, Locale targetLocale) {
+
+		Object value = infoFieldValue.getValue();
+
+		if (value instanceof InfoLocalizedValue) {
+			InfoLocalizedValue<?> infoLocalizedValue =
+				(InfoLocalizedValue<?>)value;
+
+			Set<Locale> availableLocales =
+				infoLocalizedValue.getAvailableLocales();
+
+			if (!availableLocales.contains(targetLocale)) {
+				return null;
+			}
+		}
+
+		Object targetValue = infoFieldValue.getValue(targetLocale);
+
+		if (targetValue == null) {
+			return null;
+		}
+
+		return targetValue.toString();
+	}
+
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF12TranslationInfoItemFieldValuesExporterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF12TranslationInfoItemFieldValuesExporterTest.java
@@ -45,6 +45,36 @@ public class XLIFF12TranslationInfoItemFieldValuesExporterTest {
 	}
 
 	@Test
+	public void testExportReturnsEmptyTargetForUntranslatedField()
+		throws Exception {
+
+		InfoItemFieldValuesProvider<JournalArticle>
+			infoItemFieldValuesProvider =
+				(InfoItemFieldValuesProvider<JournalArticle>)
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						InfoItemFieldValuesProvider.class,
+						JournalArticle.class.getName());
+
+		String xliff = StreamUtil.toString(
+			_xliffTranslationInfoItemFieldValuesExporter.
+				exportInfoItemFieldValues(
+					infoItemFieldValuesProvider.getInfoItemFieldValues(
+						TranslationTestUtil.getJournalArticle(
+							_group, _ddmFormDeserializer)),
+					LocaleUtil.getDefault(),
+					LocaleUtil.fromLanguageId("es_ES")));
+
+		Assert.assertTrue(
+			xliff, xliff.contains("<![CDATA[Test Article]]></source>"));
+		Assert.assertFalse(
+			xliff, xliff.contains("<![CDATA[Test Article]]></target>"));
+		Assert.assertTrue(
+			xliff, xliff.contains("<target xml:lang=\"es-ES\"></target>"));
+		Assert.assertTrue(
+			xliff, xliff.contains("<![CDATA[Un poco de texto]]></target>"));
+	}
+
+	@Test
 	public void testExportReturnsTheXLIFFRepresentationOfAJournalArticle()
 		throws Exception {
 

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF20TranslationInfoItemFieldValuesExporterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF20TranslationInfoItemFieldValuesExporterTest.java
@@ -45,6 +45,35 @@ public class XLIFF20TranslationInfoItemFieldValuesExporterTest {
 	}
 
 	@Test
+	public void testExportReturnsEmptyTargetForUntranslatedField()
+		throws Exception {
+
+		InfoItemFieldValuesProvider<JournalArticle>
+			infoItemFieldValuesProvider =
+				(InfoItemFieldValuesProvider<JournalArticle>)
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						InfoItemFieldValuesProvider.class,
+						JournalArticle.class.getName());
+
+		String xliff = StreamUtil.toString(
+			_xliffTranslationInfoItemFieldValuesExporter.
+				exportInfoItemFieldValues(
+					infoItemFieldValuesProvider.getInfoItemFieldValues(
+						TranslationTestUtil.getJournalArticle(
+							_group, _ddmFormDeserializer)),
+					LocaleUtil.getDefault(),
+					LocaleUtil.fromLanguageId("es_ES")));
+
+		Assert.assertTrue(
+			xliff, xliff.contains("<![CDATA[Test Article]]></source>"));
+		Assert.assertFalse(
+			xliff, xliff.contains("<![CDATA[Test Article]]></target>"));
+		Assert.assertTrue(xliff, xliff.contains("<target></target>"));
+		Assert.assertTrue(
+			xliff, xliff.contains("<![CDATA[Un poco de texto]]></target>"));
+	}
+
+	@Test
 	public void testExportReturnsTheXLIFFRepresentationOfAJournalArticle()
 		throws Exception {
 

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/importer/test/XLIFFTranslationInfoItemFieldValuesImporterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/importer/test/XLIFFTranslationInfoItemFieldValuesImporterTest.java
@@ -78,6 +78,32 @@ public class XLIFFTranslationInfoItemFieldValuesImporterTest {
 				"example-1_2-bad-formed.xlf"));
 	}
 
+	@Test(expected = XLIFFFileException.MustBeWellFormed.class)
+	public void testImportXLIFF12FailsFileNoTarget() throws Exception {
+		_xliffTranslationInfoItemFieldValuesImporter.importInfoItemFieldValues(
+			_group.getGroupId(),
+			new InfoItemReference(JournalArticle.class.getName(), 122),
+			TranslationTestUtil.readFileToInputStream(
+				"example-1_2-no-target.xlf"));
+	}
+
+	@Test
+	public void testImportXLIFF12IgnoresEmptyTarget() throws Exception {
+		InfoItemFieldValues infoItemFieldValues =
+			_xliffTranslationInfoItemFieldValuesImporter.
+				importInfoItemFieldValues(
+					_group.getGroupId(),
+					new InfoItemReference(JournalArticle.class.getName(), 122),
+					TranslationTestUtil.readFileToInputStream(
+						"example-1_2-empty-target.xlf"));
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues();
+
+		Assert.assertEquals(
+			infoFieldValues.toString(), 1, infoFieldValues.size());
+	}
+
 	@Test
 	public void testImportXLIFF12VersionDocument() throws Exception {
 		InfoItemFieldValues infoItemFieldValues =
@@ -156,6 +182,23 @@ public class XLIFFTranslationInfoItemFieldValuesImporterTest {
 			new InfoItemReference(JournalArticle.class.getName(), 122),
 			TranslationTestUtil.readFileToInputStream(
 				"test-journal-article-no-target.xlf"));
+	}
+
+	@Test
+	public void testImportXLIFF20IgnoresEmptyTarget() throws Exception {
+		InfoItemFieldValues infoItemFieldValues =
+			_xliffTranslationInfoItemFieldValuesImporter.
+				importInfoItemFieldValues(
+					_group.getGroupId(),
+					new InfoItemReference(JournalArticle.class.getName(), 122),
+					TranslationTestUtil.readFileToInputStream(
+						"test-journal-article-122-empty-target.xlf"));
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues();
+
+		Assert.assertEquals(
+			infoFieldValues.toString(), 1, infoFieldValues.size());
 	}
 
 	@Test

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-empty-target.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-empty-target.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2">
+	<file original="com.liferay.journal.model.JournalArticle:122" source-language="en-US" target-language="de-DE" tool="okapi" datatype="html">
+		<header/>
+		<body>
+			<trans-unit id="1">
+				<source xml:lang="en-US">Segment one.</source>
+				<target xml:lang="de-DE"></target>
+			</trans-unit>
+			<trans-unit id="2">
+				<source xml:lang="en-US">Segment two.</source>
+				<target xml:lang="de-DE">Segment zwei.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-no-target.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-no-target.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2">
+	<file original="com.liferay.journal.model.JournalArticle:122" source-language="en-US" target-language="de-DE" tool="okapi" datatype="html">
+		<header/>
+		<body>
+			<trans-unit id="1">
+				<source xml:lang="en-US">Segment one.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-122-empty-target.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-122-empty-target.xlf
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-US" trgLang="es-ES" version="2.0">
+	<file id="com.liferay.journal.model.JournalArticle:122">
+		<unit id="JournalArticle_title">
+			<segment>
+				<source><![CDATA[This is the Title]]></source>
+				<target></target>
+			</segment>
+		</unit>
+		<unit id="JournalArticle_description">
+			<segment>
+				<source><![CDATA[This is the summary]]></source>
+				<target><![CDATA[Este es el resumen]]></target>
+			</segment>
+		</unit>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-v12.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-v12.xlf
@@ -5,11 +5,11 @@
 		<body>
 			<trans-unit id="JournalArticle_title">
 				<source xml:lang="en-US"><![CDATA[Test Article]]></source>
-				<target xml:lang="es-ES"><![CDATA[Test Article]]></target>
+				<target xml:lang="es-ES"></target>
 			</trans-unit>
 			<trans-unit id="JournalArticle_description">
 				<source xml:lang="en-US"><![CDATA[]]></source>
-				<target xml:lang="es-ES"><![CDATA[]]></target>
+				<target xml:lang="es-ES"></target>
 			</trans-unit>
 			<trans-unit id="DDMStructure_HTML4acl">
 				<source xml:lang="en-US"><![CDATA[<p>Some HTML</p>]]></source>
@@ -25,7 +25,7 @@
 			</trans-unit>
 			<trans-unit id="DDMStructure_Integer2cc6">
 				<source xml:lang="en-US"><![CDATA[1]]></source>
-				<target xml:lang="es-ES"><![CDATA[1]]></target>
+				<target xml:lang="es-ES"></target>
 			</trans-unit>
 		</body>
 	</file>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article.xlf
@@ -5,13 +5,13 @@
 		<unit id="JournalArticle_title">
 			<segment>
 				<source><![CDATA[Test Article]]></source>
-				<target><![CDATA[Test Article]]></target>
+				<target></target>
 			</segment>
 		</unit>
 		<unit id="JournalArticle_description">
 			<segment>
 				<source><![CDATA[]]></source>
-				<target><![CDATA[]]></target>
+				<target></target>
 			</segment>
 		</unit>
 		<unit id="DDMStructure_HTML4acl">
@@ -35,7 +35,7 @@
 		<unit id="DDMStructure_Integer2cc6">
 			<segment>
 				<source><![CDATA[1]]></source>
-				<target><![CDATA[1]]></target>
+				<target></target>
 			</segment>
 		</unit>
 	</file>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95852

## What is this trying to solve?

Liferay's XLIFF 1.2 and 2.0 translation export populated every `<target>` element with the source text, even for fields that had no translation. AWS Translate Batch Translation treats a populated `<target>` as an already-translated segment, so it skips every unit and fails with "No translatable text found in the input file" (charactersTranslated: 0). Customer SMILES (GOL Airlines) hit this on DXP 2025.Q4.1 and it reproduces on a clean bundle. A related defect surfaced once empty targets were involved: re-importing a fully untranslated export failed with "The file is an invalid XLIFF file."

## How am I fixing it?

The XLIFF 1.2 and 2.0 exporters now emit an empty `<target>` for an untranslated field instead of copying the source value, so downstream tools see those segments as still needing translation. A shared `XLIFFExporterUtil.addTargetValue` writes an empty target when there is no translated value and a CDATA target otherwise. The importer accepts and skips empty targets — the snapshot provider no longer rejects an empty target as malformed, while a unit that has a source but no `<target>` element at all is still rejected. Finally, importing a file with no translated fields is now a no-op: with zero field values the manager returns early instead of re-exporting an empty XLIFF 2.0 `<file>`, which is invalid against the 2.0 schema and previously broke the re-import performed on approval.

## How can you verify that it works?

1. Create a content page with a fragment containing translatable text.
2. Open Translations and export the page to XLIFF 1.2 for a target language without translating anything.
3. Confirm every `<target>` in the export is empty (the source is not copied).
4. Submit the file to AWS Translate Batch Translation and confirm it no longer reports "No translatable text found."
5. Re-import the untranslated file and confirm the import succeeds with no "invalid XLIFF file" error.

Integration coverage: `XLIFF12/XLIFF20TranslationInfoItemFieldValuesExporterTest` assert an untranslated field exports an empty target, and `XLIFFTranslationInfoItemFieldValuesImporterTest` asserts an empty target is accepted and skipped on import for both XLIFF 1.2 and 2.0.

## PR Check

**pr-check: PASS** — tested on `33e9b5776234a2838b3632f2e77f3f4209099e4d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "33e9b5776234a2838b3632f2e77f3f4209099e4d"} -->
