### PR TITLE
LPD-83022 Add a folder option to the CMS type filter

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/odata/entity/v1_0/BulkActionEntityModel.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/odata/entity/v1_0/BulkActionEntityModel.java
@@ -77,9 +77,11 @@ public class BulkActionEntityModel implements EntityModel {
 				"objectDefinitionId", locale -> "objectDefinitionId"),
 			new IntegerEntityField("scopeGroupId", locale -> "scopeGroupId"),
 			new IntegerEntityField("status", locale -> Field.STATUS),
-			new StringEntityField("cmsKind", locale -> "cms_kind"),
 			new StringEntityField("cmsSection", locale -> "cms_section"),
 			new StringEntityField("name", locale -> "name"),
+			new StringEntityField(
+				"objectDefinitionExternalReferenceCode",
+				locale -> "objectDefinitionExternalReferenceCode"),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -59,8 +59,8 @@ function urlBuilder({
 	const scopePredicates = folderId
 		? [`(folderId eq ${folderId})`]
 		: [
-				"(cmsSection eq 'files')",
 				'(cmsRoot eq true)',
+				"(cmsSection eq 'files')",
 				'(rootDescendantNode eq false)',
 			];
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -223,7 +223,7 @@ function normalizeExtensions(allowedExtensions: string) {
 
 	const extensions = cleanExtensions.map((item) => `'${item}'`).join(',');
 
-	return `(extension in (${extensions}) or cmsKind eq 'folder')`;
+	return `(extension in (${extensions}) or objectDefinitionExternalReferenceCode eq 'L_OBJECT_ENTRY_FOLDER')`;
 }
 
 export default function openCMSFileSelectorModal({

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
@@ -135,12 +135,14 @@ describe('openCMSFileSelectorModal', () => {
 
 		expect(firstURL).toContain('(rootDescendantNode eq false)');
 
-		expect(firstURL).not.toContain("cmsKind eq 'object'");
+		expect(firstURL).not.toContain(
+			"objectDefinitionExternalReferenceCode ne 'L_OBJECT_ENTRY_FOLDER'"
+		);
 
 		expect(firstURL).not.toContain('folderId eq ');
 	});
 
-	it("widens the extension filter so folders pass through with cmsKind eq 'folder'", async () => {
+	it("widens the extension filter so folders pass through with objectDefinitionExternalReferenceCode eq 'L_OBJECT_ENTRY_FOLDER'", async () => {
 		openModal({
 			allowedExtensions: 'jpg,png',
 			groupId: 123,
@@ -157,7 +159,9 @@ describe('openCMSFileSelectorModal', () => {
 
 		expect(firstURL).toContain("extension in ('jpg','png')");
 
-		expect(firstURL).toContain("cmsKind eq 'folder'");
+		expect(firstURL).toContain(
+			"objectDefinitionExternalReferenceCode eq 'L_OBJECT_ENTRY_FOLDER'"
+		);
 	});
 
 	it('reopens at the folder browsed when the previous selection was confirmed', async () => {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntryFolderConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntryFolderConstants.java
@@ -14,6 +14,9 @@ public class ObjectEntryFolderConstants {
 
 	public static final String EXTERNAL_REFERENCE_CODE_FILES = "L_FILES";
 
+	public static final String EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER =
+		"L_OBJECT_ENTRY_FOLDER";
+
 	public static final String
 		EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_ENTRY_FOLDER = "L_";
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -50,6 +50,10 @@ public class ObjectEntryFolderModelDocumentContributor
 			document.addKeyword("cms_kind", "folder");
 			document.addKeyword("cms_root", parts.length == 3);
 			document.addKeyword("cms_section", cmsSection);
+			document.addKeyword(
+				"objectDefinitionExternalReferenceCode",
+				ObjectEntryFolderConstants.
+					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER);
 		}
 
 		document.addLocalizedKeyword(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -47,7 +47,6 @@ public class ObjectEntryFolderModelDocumentContributor
 		String cmsSection = _getCMSSection(parts);
 
 		if (cmsSection != null) {
-			document.addKeyword("cms_kind", "folder");
 			document.addKeyword("cms_root", parts.length == 3);
 			document.addKeyword("cms_section", cmsSection);
 			document.addKeyword(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -600,7 +600,6 @@ public class ObjectEntryModelDocumentContributor
 			return;
 		}
 
-		document.addKeyword("cms_kind", "object");
 		document.addKeyword(
 			"cms_root",
 			rootObjectEntryFolder.getObjectEntryFolderId() ==

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
@@ -55,8 +55,6 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 	public void testContribute() throws Exception {
 		_testContribute(
 			HashMapBuilder.put(
-				"cms_kind", "folder"
-			).put(
 				"cms_root", "true"
 			).put(
 				"cms_section", "contents"
@@ -68,8 +66,6 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS);
 		_testContribute(
 			HashMapBuilder.put(
-				"cms_kind", "folder"
-			).put(
 				"cms_root", "true"
 			).put(
 				"cms_section", "files"
@@ -81,8 +77,6 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES);
 		_testContribute(
 			HashMapBuilder.put(
-				"cms_kind", StringPool.BLANK
-			).put(
 				"cms_root", StringPool.BLANK
 			).put(
 				"cms_section", StringPool.BLANK

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
@@ -60,6 +60,10 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 				"cms_root", "true"
 			).put(
 				"cms_section", "contents"
+			).put(
+				"objectDefinitionExternalReferenceCode",
+				ObjectEntryFolderConstants.
+					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER
 			).build(),
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS);
 		_testContribute(
@@ -69,6 +73,10 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 				"cms_root", "true"
 			).put(
 				"cms_section", "files"
+			).put(
+				"objectDefinitionExternalReferenceCode",
+				ObjectEntryFolderConstants.
+					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER
 			).build(),
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES);
 		_testContribute(
@@ -78,6 +86,8 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 				"cms_root", StringPool.BLANK
 			).put(
 				"cms_section", StringPool.BLANK
+			).put(
+				"objectDefinitionExternalReferenceCode", StringPool.BLANK
 			).build(),
 			null);
 	}

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -86,7 +86,6 @@ public class SearchResultEntityModel implements EntityModel {
 			new IntegerEntityField("status", locale -> Field.STATUS),
 			new StringEntityField("cmpAssignTo", locale -> "cmpAssignTo"),
 			new StringEntityField("cmpState", locale -> "cmpState"),
-			new StringEntityField("cmsKind", locale -> "cms_kind"),
 			new StringEntityField("cmsSection", locale -> "cms_section"),
 			new StringEntityField("extension", locale -> "extension"),
 			new StringEntityField(

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -1551,10 +1551,9 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 	}
 
 	private static final String[] _IGNORED_ENTITY_FIELD_NAMES = {
-		"cmpAssignTo", "cmpDueDate", "cmpState", "cmsKind", "cmsRoot",
-		"cmsSection", "extension", "dateDisplay", "dateExpiration",
-		"datePublish", "dateReview", "folderId",
-		"objectDefinitionExternalReferenceCode",
+		"cmpAssignTo", "cmpDueDate", "cmpState", "cmsRoot", "cmsSection",
+		"extension", "dateDisplay", "dateExpiration", "datePublish",
+		"dateReview", "folderId", "objectDefinitionExternalReferenceCode",
 		"objectFolderExternalReferenceCode", "rootDescendantNode"
 	};
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -195,11 +195,11 @@ public class ViewAllSectionDisplayContextTest
 	@Override
 	protected String getFilterString() {
 		return StringBundler.concat(
+			"(cmsSection eq 'contents' or cmsSection eq 'files') and ",
 			"objectDefinitionExternalReferenceCode ne '",
 			ObjectEntryFolderConstants.
 				EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
-			"' and (cmsSection eq 'contents' or cmsSection eq 'files') and ",
-			"rootDescendantNode eq false");
+			"' and rootDescendantNode eq false");
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -11,6 +11,7 @@ import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.data.set.test.util.FrontendDataSetTestUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -193,8 +194,12 @@ public class ViewAllSectionDisplayContextTest
 
 	@Override
 	protected String getFilterString() {
-		return "cmsKind eq 'object' and (cmsSection eq 'contents' or " +
-			"cmsSection eq 'files') and rootDescendantNode eq false";
+		return StringBundler.concat(
+			"objectDefinitionExternalReferenceCode ne '",
+			ObjectEntryFolderConstants.
+				EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
+			"' and (cmsSection eq 'contents' or cmsSection eq 'files') and ",
+			"rootDescendantNode eq false");
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
@@ -217,10 +217,11 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 	@Override
 	protected String getFilterString() {
 		return StringBundler.concat(
+			"(cmsSection eq 'contents' or cmsSection eq 'files') and ",
 			"objectDefinitionExternalReferenceCode ne '",
 			ObjectEntryFolderConstants.
 				EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
-			"' and (cmsSection eq 'contents' or cmsSection eq 'files')");
+			"'");
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
@@ -10,8 +10,10 @@ import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.data.set.test.util.FrontendDataSetTestUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
@@ -214,8 +216,11 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 
 	@Override
 	protected String getFilterString() {
-		return "cmsKind eq 'object' and (cmsSection eq 'contents' or " +
-			"cmsSection eq 'files')";
+		return StringBundler.concat(
+			"objectDefinitionExternalReferenceCode ne '",
+			ObjectEntryFolderConstants.
+				EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
+			"' and (cmsSection eq 'contents' or cmsSection eq 'files')");
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -8,7 +8,9 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -120,8 +122,12 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 	protected String getCMSSectionFilterString() {
 		return appendStatus(
 			appendGroupIds(
-				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
-					"cmsSection eq 'files') and rootDescendantNode eq false"));
+				StringBundler.concat(
+					"objectDefinitionExternalReferenceCode ne '",
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
+					"' and (cmsSection eq 'contents' or cmsSection eq ",
+					"'files') and rootDescendantNode eq false")));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -123,11 +123,11 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 		return appendStatus(
 			appendGroupIds(
 				StringBundler.concat(
+					"(cmsSection eq 'contents' or cmsSection eq 'files') and ",
 					"objectDefinitionExternalReferenceCode ne '",
 					ObjectEntryFolderConstants.
 						EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
-					"' and (cmsSection eq 'contents' or cmsSection eq ",
-					"'files') and rootDescendantNode eq false")));
+					"' and rootDescendantNode eq false")));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set;
 
 import com.liferay.frontend.data.set.SystemFDSEntry;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
@@ -30,8 +31,12 @@ public class ViewAllSectionSystemFDSEntry implements SystemFDSEntry {
 
 		String filterString = SectionDisplayContextUtil.appendStatus(
 			SectionDisplayContextUtil.appendGroupIds(
-				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
-					"cmsSection eq 'files') and rootDescendantNode eq false",
+				StringBundler.concat(
+					"objectDefinitionExternalReferenceCode ne '",
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
+					"' and (cmsSection eq 'contents' or cmsSection eq ",
+					"'files') and rootDescendantNode eq false"),
 				httpServletRequest));
 
 		String additionalAPIURLParameters =

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
@@ -32,11 +32,11 @@ public class ViewAllSectionSystemFDSEntry implements SystemFDSEntry {
 		String filterString = SectionDisplayContextUtil.appendStatus(
 			SectionDisplayContextUtil.appendGroupIds(
 				StringBundler.concat(
+					"(cmsSection eq 'contents' or cmsSection eq 'files') and ",
 					"objectDefinitionExternalReferenceCode ne '",
 					ObjectEntryFolderConstants.
 						EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
-					"' and (cmsSection eq 'contents' or cmsSection eq ",
-					"'files') and rootDescendantNode eq false"),
+					"' and rootDescendantNode eq false"),
 				httpServletRequest));
 
 		String additionalAPIURLParameters =

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseObjectDefinitionSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseObjectDefinitionSelectionFDSFilter.java
@@ -13,6 +13,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,22 +54,38 @@ public abstract class BaseObjectDefinitionSelectionFDSFilter
 				CompanyThreadLocal.getCompanyId(),
 				getObjectFolderExternalReferenceCodes());
 
+		String[] excludedObjectDefinitionExternalReferenceCodes =
+			getExcludedObjectDefinitionExternalReferenceCodes();
+
 		for (ObjectDefinition objectDefinition : objectDefinitions) {
-			objectDefinition.getLabel(locale);
+			if (!ArrayUtil.contains(
+					excludedObjectDefinitionExternalReferenceCodes,
+					objectDefinition.getExternalReferenceCode())) {
+
+				selectionFDSFilterItems.add(
+					new SelectionFDSFilterItem(
+						objectDefinition.getLabel(locale),
+						objectDefinition.getExternalReferenceCode()));
+			}
+		}
+
+		if (!ArrayUtil.contains(
+				excludedObjectDefinitionExternalReferenceCodes,
+				ObjectEntryFolderConstants.
+					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER)) {
 
 			selectionFDSFilterItems.add(
 				new SelectionFDSFilterItem(
-					objectDefinition.getLabel(locale),
-					objectDefinition.getExternalReferenceCode()));
+					language.get(locale, "folder"),
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER));
 		}
 
-		selectionFDSFilterItems.add(
-			new SelectionFDSFilterItem(
-				language.get(locale, "folder"),
-				ObjectEntryFolderConstants.
-					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER));
-
 		return selectionFDSFilterItems;
+	}
+
+	protected String[] getExcludedObjectDefinitionExternalReferenceCodes() {
+		return new String[0];
 	}
 
 	protected abstract String[] getObjectFolderExternalReferenceCodes();

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseObjectDefinitionSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseObjectDefinitionSelectionFDSFilter.java
@@ -8,8 +8,10 @@ package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import java.util.ArrayList;
@@ -51,10 +53,6 @@ public abstract class BaseObjectDefinitionSelectionFDSFilter
 				CompanyThreadLocal.getCompanyId(),
 				getObjectFolderExternalReferenceCodes());
 
-		if (objectDefinitions.isEmpty()) {
-			return selectionFDSFilterItems;
-		}
-
 		for (ObjectDefinition objectDefinition : objectDefinitions) {
 			objectDefinition.getLabel(locale);
 
@@ -64,10 +62,19 @@ public abstract class BaseObjectDefinitionSelectionFDSFilter
 					objectDefinition.getExternalReferenceCode()));
 		}
 
+		selectionFDSFilterItems.add(
+			new SelectionFDSFilterItem(
+				language.get(locale, "folder"),
+				ObjectEntryFolderConstants.
+					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER));
+
 		return selectionFDSFilterItems;
 	}
 
 	protected abstract String[] getObjectFolderExternalReferenceCodes();
+
+	@Reference
+	protected Language language;
 
 	@Reference
 	protected ObjectDefinitionService objectDefinitionService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ObjectDefinitionSelectionAllFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ObjectDefinitionSelectionAllFDSFilter.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
 import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 
@@ -25,6 +26,14 @@ import org.osgi.service.component.annotations.Component;
 )
 public class ObjectDefinitionSelectionAllFDSFilter
 	extends BaseObjectDefinitionSelectionFDSFilter {
+
+	@Override
+	protected String[] getExcludedObjectDefinitionExternalReferenceCodes() {
+		return new String[] {
+			ObjectEntryFolderConstants.
+				EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER
+		};
+	}
 
 	@Override
 	protected String[] getObjectFolderExternalReferenceCodes() {

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ObjectDefinitionSelectionAllFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ObjectDefinitionSelectionAllFDSFilterTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class ObjectDefinitionSelectionAllFDSFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		_objectDefinitionSelectionAllFDSFilter =
+			new ObjectDefinitionSelectionAllFDSFilter();
+
+		ReflectionTestUtil.setFieldValue(
+			_objectDefinitionSelectionAllFDSFilter, "language", _language);
+		ReflectionTestUtil.setFieldValue(
+			_objectDefinitionSelectionAllFDSFilter, "objectDefinitionService",
+			_objectDefinitionService);
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItems() {
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		String objectDefinitionExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		Mockito.when(
+			objectDefinition.getExternalReferenceCode()
+		).thenReturn(
+			objectDefinitionExternalReferenceCode
+		);
+
+		Mockito.when(
+			_objectDefinitionService.getCMSObjectDefinitions(
+				Mockito.anyLong(), Mockito.any(String[].class))
+		).thenReturn(
+			List.of(objectDefinition)
+		);
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			_objectDefinitionSelectionAllFDSFilter.getSelectionFDSFilterItems(
+				_locale);
+
+		Assert.assertEquals(
+			selectionFDSFilterItems.toString(), 1,
+			selectionFDSFilterItems.size());
+
+		SelectionFDSFilterItem objectDefinitionSelectionFDSFilterItem =
+			selectionFDSFilterItems.get(0);
+
+		Assert.assertEquals(
+			objectDefinitionExternalReferenceCode,
+			objectDefinitionSelectionFDSFilterItem.getValue());
+	}
+
+	@Mock
+	private Language _language;
+
+	private final Locale _locale = LocaleUtil.US;
+	private ObjectDefinitionSelectionAllFDSFilter
+		_objectDefinitionSelectionAllFDSFilter;
+
+	@Mock
+	private ObjectDefinitionService _objectDefinitionService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ObjectDefinitionSelectionFilesFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ObjectDefinitionSelectionFilesFDSFilterTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class ObjectDefinitionSelectionFilesFDSFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		_objectDefinitionSelectionFilesFDSFilter =
+			new ObjectDefinitionSelectionFilesFDSFilter();
+
+		ReflectionTestUtil.setFieldValue(
+			_objectDefinitionSelectionFilesFDSFilter, "language", _language);
+		ReflectionTestUtil.setFieldValue(
+			_objectDefinitionSelectionFilesFDSFilter, "objectDefinitionService",
+			_objectDefinitionService);
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItems() {
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		String objectDefinitionExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		Mockito.when(
+			objectDefinition.getExternalReferenceCode()
+		).thenReturn(
+			objectDefinitionExternalReferenceCode
+		);
+
+		Mockito.when(
+			_objectDefinitionService.getCMSObjectDefinitions(
+				Mockito.anyLong(), Mockito.any(String[].class))
+		).thenReturn(
+			List.of(objectDefinition)
+		);
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			_objectDefinitionSelectionFilesFDSFilter.getSelectionFDSFilterItems(
+				_locale);
+
+		Assert.assertEquals(
+			selectionFDSFilterItems.toString(), 2,
+			selectionFDSFilterItems.size());
+
+		SelectionFDSFilterItem objectDefinitionSelectionFDSFilterItem =
+			selectionFDSFilterItems.get(0);
+
+		Assert.assertEquals(
+			objectDefinitionExternalReferenceCode,
+			objectDefinitionSelectionFDSFilterItem.getValue());
+
+		SelectionFDSFilterItem folderSelectionFDSFilterItem =
+			selectionFDSFilterItems.get(1);
+
+		Assert.assertEquals(
+			ObjectEntryFolderConstants.
+				EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
+			folderSelectionFDSFilterItem.getValue());
+	}
+
+	@Mock
+	private Language _language;
+
+	private final Locale _locale = LocaleUtil.US;
+	private ObjectDefinitionSelectionFilesFDSFilter
+		_objectDefinitionSelectionFilesFDSFilter;
+
+	@Mock
+	private ObjectDefinitionService _objectDefinitionService;
+
+}

--- a/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
@@ -22,6 +22,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
@@ -23,6 +23,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
@@ -24,6 +24,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
@@ -47,7 +47,7 @@ test('Generate a new token after expired', async ({
 			const rowToken = page.getByTestId(`row-token-${tokenId}`);
 
 			expect(await rowToken.textContent()).toBe(
-				`Token ending in${tokenId}Expired`
+				`Token Ending In${tokenId}Expired`
 			);
 		});
 

--- a/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
@@ -24,6 +24,7 @@ import {closeSessions} from './utils/sessions';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
+++ b/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
@@ -143,7 +143,7 @@ export class SegmentsPage {
 
 	async clickDuplicateButton() {
 		const duplicateButton = this.page.getByRole('button', {
-			name: 'Duplicate Segment Property',
+			name: 'Duplicate Property',
 		});
 		await duplicateButton.click();
 	}
@@ -253,7 +253,9 @@ export class SegmentsPage {
 			exact: true,
 			name: tabName,
 		});
-		const propertyLocator = this.page.getByText(propertyName);
+		const propertyLocator = this.page.getByText(propertyName, {
+			exact: true,
+		});
 		const isPropertyVisible = await propertyLocator.isVisible();
 
 		if (!isPropertyVisible) {

--- a/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
+++ b/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
@@ -32,6 +32,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-78863': {enabled: true, system: true},
+		'LPS-178052': {enabled: true},
 	}),
 	instanceSettingsPagesTest,
 	pageEditorPagesTest,
@@ -295,9 +296,11 @@ test(
 
 		// Create an organization, a user, and assign the user to the organization
 
+		const organizationName = getRandomString();
+
 		const organization =
 			await apiHelpers.headlessAdminUser.postOrganization({
-				name: getRandomString(),
+				name: organizationName,
 			});
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount({
@@ -318,7 +321,9 @@ test(
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: page.getByRole('menuitem', {name: 'Edit'}),
-			trigger: page.getByRole('button', {name: 'Show Actions'}),
+			trigger: page
+				.locator('tr', {hasText: organizationName})
+				.getByRole('button', {name: 'Show Actions'}),
 		});
 
 		await clickAndExpectToBeVisible({
@@ -1802,7 +1807,7 @@ test(
 			await editUserPage.lastNameInput.fill('userln');
 			await editUserPage.screenNameInput.fill('usersn');
 
-			const tagInputFied = page.getByLabel('Tags', {exact: true});
+			const tagInputFied = page.getByRole('combobox', {name: 'Tags'});
 			await tagInputFied.fill('tagName');
 			await tagInputFied.press('Enter');
 			await page.locator('body').click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83022

## What Is Being Fixed

The CMS asset views let users filter by object type but offered no way to filter for folders, so folders could not be isolated in the Contents, Files, and folder-browse data sets.

## How It Is Being Fixed

Folders are now indexed with the existing, already-filterable objectDefinitionExternalReferenceCode search field, using a virtual external reference code (L_OBJECT_ENTRY_FOLDER, added as a constant on ObjectEntryFolderConstants and reused everywhere). The CMS "Type" filter adds a "Folder" item bound to that value and excludes it from the "All" section, where folders are not listed.

With the object-vs-folder distinction now carried entirely by objectDefinitionExternalReferenceCode, the redundant cmsKind search field is removed: the document contributors stop emitting cms_kind, the search and bulk OData entity models drop the cmsKind field (the bulk model gains objectDefinitionExternalReferenceCode so the CMS bulk "select all" flow keeps working), and the section OData filters switch from cmsKind to objectDefinitionExternalReferenceCode. OData subexpressions are kept in alphabetical order.

## PR Check

**pr-check: PASS** — tested on `83d76b83892656f87727bc3b38cd87cd26ae2732`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "83d76b83892656f87727bc3b38cd87cd26ae2732"} -->
