### PR TITLE
LPD-96201 Enable LPD-17564 so the upgrade test provisions CMS folders

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSObjectRelationshipEdgeUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSObjectRelationshipEdgeUpgradeProcessTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -69,7 +70,9 @@ import org.junit.runner.RunWith;
 /**
  * @author Víctor Galán
  */
-@FeatureFlag("LPD-34594")
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-34594")}
+)
 @RunWith(Arquillian.class)
 public class CMSObjectRelationshipEdgeUpgradeProcessTest {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96201

## What Is Being Fixed

CMSObjectRelationshipEdgeUpgradeProcessTest has failed on every CI build since it was introduced (2026-06-21); all seven test methods fail in setUp. The class only enables the LPD-34594 feature flag, but its setUp calls CMSTestUtil.getOrAddGroup, which manually runs the CMS site initializer to create the L_CMS_CONTENT_STRUCTURES and L_CMS_FILE_TYPES object folders. Those batch records are gated behind LPD-17564, so without that flag the folders are never created and the getObjectFolderByExternalReferenceCode lookups in setUp throw, failing the whole class. LPD-95797 added the getOrAddGroup call but did not enable LPD-17564, so it did not resolve the failure.

## How It Is Being Fixed

Replace the single @FeatureFlag("LPD-34594") with @FeatureFlags enabling both LPD-17564 and LPD-34594, matching every other CMS test that relies on getOrAddGroup. With LPD-17564 enabled the object folders are provisioned, setUp succeeds, and all seven methods pass (verified locally with testIntegration).

## Why Are There No Tests?

The change is itself a test-only fix: it corrects the feature-flag setup of an existing integration test so its seven methods run. No new test is warranted because the change restores existing coverage rather than adding behavior.

## PR Check

**pr-check: PASS** — tested on `b141fb7f13ad428ffc8ba1d7823b174e88217253`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b141fb7f13ad428ffc8ba1d7823b174e88217253"} -->
