### PR TITLE
LPD-96203 Fix taxonomy category upsert to create with the path ERC

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -587,7 +587,9 @@ public class TaxonomyCategoryResourceImpl
 			Long assetLibraryId, TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
-		return _postTaxonomyCategory(assetLibraryId, taxonomyCategory);
+		return _postTaxonomyCategory(
+			assetLibraryId, taxonomyCategory.getExternalReferenceCode(),
+			taxonomyCategory);
 	}
 
 	@Override
@@ -595,7 +597,9 @@ public class TaxonomyCategoryResourceImpl
 			Long siteId, TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
-		return _postTaxonomyCategory(siteId, taxonomyCategory);
+		return _postTaxonomyCategory(
+			siteId, taxonomyCategory.getExternalReferenceCode(),
+			taxonomyCategory);
 	}
 
 	@Override
@@ -1034,7 +1038,8 @@ public class TaxonomyCategoryResourceImpl
 	}
 
 	private TaxonomyCategory _postTaxonomyCategory(
-			long groupId, TaxonomyCategory taxonomyCategory)
+			long groupId, String externalReferenceCode,
+			TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
 		Long taxonomyVocabularyId = _getTaxonomyVocabularyId(
@@ -1047,7 +1052,7 @@ public class TaxonomyCategoryResourceImpl
 		}
 
 		return _addTaxonomyCategory(
-			taxonomyCategory.getExternalReferenceCode(), groupId,
+			externalReferenceCode, groupId,
 			contextAcceptLanguage.getPreferredLanguageId(),
 			_getParentTaxonomyCategoryId(groupId, taxonomyCategory),
 			taxonomyCategory, taxonomyVocabularyId);
@@ -1063,7 +1068,8 @@ public class TaxonomyCategoryResourceImpl
 				externalReferenceCode, groupId);
 
 		if (persistedAssetCategory == null) {
-			return _postTaxonomyCategory(groupId, taxonomyCategory);
+			return _postTaxonomyCategory(
+				groupId, externalReferenceCode, taxonomyCategory);
 		}
 
 		long assetVocabularyId = _getAssetVocabularyId(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96203

## What Is Being Fixed

The integration tests testPutSiteTaxonomyCategoryByExternalReferenceCode and testPutAssetLibraryTaxonomyCategoryByExternalReferenceCode failed deterministically with "There is another taxonomy category named X as a child of taxonomy category 0". When a PUT by external reference code did not match an existing category, the site and asset library endpoints created the new category with the external reference code from the request body instead of the one in the path, so the category was not addressable at the URL it was PUT to. A repeated identical PUT missed again and tried to create a duplicate, colliding on the unique category name at the vocabulary root.

## How It Is Being Fixed

The shared _postTaxonomyCategory helper now takes an explicit external reference code. The POST handlers keep passing the body's value, while the PUT-by-ERC create-on-miss branch passes the path external reference code. This matches the taxonomy vocabulary endpoint, which never had the bug because it already created with the path value, and makes the upsert idempotent.

## Why Are There No Tests?

The defect is covered by the autogenerated integration tests in BaseTaxonomyCategoryResourceTestCase, which REST Builder regenerates and which must not be hand-edited. Those two tests failed before this change and pass after it; the full TaxonomyCategoryResourceTest class is green.

## PR Check

**pr-check: PASS** — tested on `9ee1b0161c417a6eec0ddca0ad10181083a25d74`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "9ee1b0161c417a6eec0ddca0ad10181083a25d74"} -->
