### PR TITLE
LPD-95527 Add CMS user group sharing E2E Playwright tests

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -70,6 +70,8 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -830,9 +832,12 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		new AssetLibraryEntityModel();
 
 	@Reference(
-		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.AssetLibraryDTOConverter)"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(dto.class.name=com.liferay.depot.model.DepotEntry)"
 	)
-	private DTOConverter<DepotEntry, AssetLibrary> _assetLibraryDTOConverter;
+	private volatile DTOConverter<DepotEntry, AssetLibrary>
+		_assetLibraryDTOConverter;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/search/spi/index/configuration/contributor/dependencies/additional-type-mappings.json
+++ b/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/search/spi/index/configuration/contributor/dependencies/additional-type-mappings.json
@@ -9,6 +9,9 @@
 		"objectActionId": {
 			"type": "keyword"
 		},
+		"objectDefinitionExternalReferenceCode": {
+			"type": "keyword"
+		},
 		"objectDefinitionId": {
 			"type": "keyword"
 		},

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerIndexedFieldsTest.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"able", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				TestPropsValues.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				_objectDefinition.getClassName()
+			).addComplexQueryPart(
+				_complexQueryPartBuilderFactory.builder(
+				).query(
+					QueriesUtil.term(
+						"objectDefinitionExternalReferenceCode",
+						_objectDefinition.getExternalReferenceCode())
+				).build()
+			).build());
+
+		Assert.assertEquals(1, searchResponse.getTotalHits());
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	@Inject
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -9,6 +9,8 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryPin;
 import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -41,6 +43,7 @@ import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -50,13 +53,13 @@ import java.util.Map;
 public class BreadcrumbDisplayContext {
 
 	public BreadcrumbDisplayContext(
-		ModelResourcePermission<DepotEntry> depotEntryModelResourcePermission,
+		AssetLibraryResource.Factory assetLibraryResourceFactory,
 		DepotEntryPinLocalService depotEntryPinLocalService, long groupId,
 		GroupLocalService groupLocalService,
 		ModelResourcePermission<Group> groupModelResourcePermission,
 		HttpServletRequest httpServletRequest, String size) {
 
-		_depotEntryModelResourcePermission = depotEntryModelResourcePermission;
+		_assetLibraryResourceFactory = assetLibraryResourceFactory;
 		_depotEntryPinLocalService = depotEntryPinLocalService;
 		_groupId = groupId;
 		_groupLocalService = groupLocalService;
@@ -223,31 +226,38 @@ public class BreadcrumbDisplayContext {
 							).put(
 								"target", "manageMembersModal"
 							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "view-connected-sites")
-							).put(
-								"manageConnectedSitesData",
-								HashMapBuilder.<String, Object>put(
-									"externalReferenceCode",
-									group.getExternalReferenceCode()
+
+						Map<String, Map<String, String>> actions =
+							_getAssetLibraryActions(group);
+
+						if (actions.containsKey("connect-sites") ||
+							actions.containsKey("view-connected-sites")) {
+
+							unsafeConsumer.accept(
+								JSONUtil.put(
+									"href", StringPool.BLANK
 								).put(
-									"hasConnectSitesPermission",
-									_depotEntryModelResourcePermission.contains(
-										permissionChecker, group.getClassPK(),
-										ActionKeys.UPDATE)
-								).build()
-							).put(
-								"redirect", _themeDisplay.getURLCurrent()
-							).put(
-								"symbolLeft", "globe"
-							).put(
-								"target", "manageConnectedSitesModal"
-							));
+									"label",
+									LanguageUtil.get(
+										_httpServletRequest,
+										"view-connected-sites")
+								).put(
+									"manageConnectedSitesData",
+									HashMapBuilder.<String, Object>put(
+										"externalReferenceCode",
+										group.getExternalReferenceCode()
+									).put(
+										"hasConnectSitesPermission",
+										actions.containsKey("connect-sites")
+									).build()
+								).put(
+									"redirect", _themeDisplay.getURLCurrent()
+								).put(
+									"symbolLeft", "globe"
+								).put(
+									"target", "manageConnectedSitesModal"
+								));
+						}
 					}
 
 					if (permissionChecker.hasPermission(
@@ -393,6 +403,32 @@ public class BreadcrumbDisplayContext {
 		).build();
 	}
 
+	private Map<String, Map<String, String>> _getAssetLibraryActions(
+			Group group)
+		throws Exception {
+
+		AssetLibraryResource assetLibraryResource =
+			_assetLibraryResourceFactory.create(
+			).httpServletRequest(
+				_httpServletRequest
+			).preferredLocale(
+				_themeDisplay.getLocale()
+			).user(
+				_themeDisplay.getUser()
+			).build();
+
+		AssetLibrary assetLibrary = assetLibraryResource.getAssetLibrary(
+			group.getExternalReferenceCode());
+
+		Map<String, Map<String, String>> actions = assetLibrary.getActions();
+
+		if (actions == null) {
+			return Collections.emptyMap();
+		}
+
+		return actions;
+	}
+
 	private String _getControlPanelPortletURL(String portletId)
 		throws Exception {
 
@@ -426,8 +462,7 @@ public class BreadcrumbDisplayContext {
 		return jsonArray;
 	}
 
-	private final ModelResourcePermission<DepotEntry>
-		_depotEntryModelResourcePermission;
+	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
 	private final DepotEntryPinLocalService _depotEntryPinLocalService;
 	private final long _groupId;
 	private final GroupLocalService _groupLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -83,301 +84,273 @@ public class BreadcrumbDisplayContext {
 		return HashMapBuilder.<String, Object>put(
 			"actionItems",
 			_putAll(
-				unsafeConsumer -> {
-					PermissionChecker permissionChecker =
-						_themeDisplay.getPermissionChecker();
+				unsafeBiConsumer -> {
+					DepotEntryPin depotEntryPin =
+						_depotEntryPinLocalService.fetchGroupDepotEntryPin(
+							_groupId, _themeDisplay.getUserId());
 
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.UPDATE)) {
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission() && (depotEntryPin == null),
+						JSONUtil.put(
+							"href",
+							StringBundler.concat(
+								"/o/headless-asset-library/v1.0",
+								"/asset-libraries/",
+								group.getExternalReferenceCode(), "/pins")
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "pin-to-product-menu")
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"successMessage",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"the-space-has-been-successfully-pinned-to-" +
+									"the-product-menu")
+						).put(
+							"symbolLeft", "pin"
+						).put(
+							"target", "asyncPut"
+						));
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission() && (depotEntryPin != null),
+						JSONUtil.put(
+							"href",
+							StringBundler.concat(
+								"/o/headless-asset-library/v1.0",
+								"/asset-libraries/",
+								group.getExternalReferenceCode(), "/pins")
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "unpin-from-product-menu")
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"successMessage",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"the-space-has-been-successfully-unpinned-" +
+									"from-the-product-menu")
+						).put(
+							"symbolLeft", "unpin"
+						).put(
+							"target", "asyncDelete"
+						));
 
-						DepotEntryPin depotEntryPin =
-							_depotEntryPinLocalService.fetchGroupDepotEntryPin(
-								_groupId, _themeDisplay.getUserId());
-
-						if (depotEntryPin == null) {
-							unsafeConsumer.accept(
-								JSONUtil.put(
-									"href",
-									StringBundler.concat(
-										"/o/headless-asset-library/v1.0",
-										"/asset-libraries/",
-										group.getExternalReferenceCode(),
-										"/pins")
-								).put(
-									"label",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"pin-to-product-menu")
-								).put(
-									"redirect", _themeDisplay.getURLCurrent()
-								).put(
-									"successMessage",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"the-space-has-been-successfully-" +
-											"pinned-to-the-product-menu")
-								).put(
-									"symbolLeft", "pin"
-								).put(
-									"target", "asyncPut"
-								));
-						}
-						else {
-							unsafeConsumer.accept(
-								JSONUtil.put(
-									"href",
-									StringBundler.concat(
-										"/o/headless-asset-library/v1.0",
-										"/asset-libraries/",
-										group.getExternalReferenceCode(),
-										"/pins")
-								).put(
-									"label",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"unpin-from-product-menu")
-								).put(
-									"redirect", _themeDisplay.getURLCurrent()
-								).put(
-									"successMessage",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"the-space-has-been-successfully-" +
-											"unpinned-from-the-product-menu")
-								).put(
-									"symbolLeft", "unpin"
-								).put(
-									"target", "asyncDelete"
-								));
-						}
-
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								ActionUtil.getSpaceSettingsURL(
-									group.getClassPK(),
-									_themeDisplay.getURLCurrent(),
-									_themeDisplay)
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission(),
+						JSONUtil.put(
+							"href",
+							ActionUtil.getSpaceSettingsURL(
+								group.getClassPK(),
+								_themeDisplay.getURLCurrent(), _themeDisplay)
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "space-settings")
+						).put(
+							"symbolLeft", "cog"
+						));
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission(),
+						JSONUtil.put(
+							"href",
+							_getControlPanelPortletURL(
+								ExportImportPortletKeys.EXPORT)
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "export")
+						).put(
+							"symbolLeft", "export"
+						));
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission(),
+						JSONUtil.put(
+							"href",
+							_getControlPanelPortletURL(
+								ExportImportPortletKeys.IMPORT)
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "import")
+						).put(
+							"symbolLeft", "import"
+						));
+					unsafeBiConsumer.accept(
+						_hasViewPermission(),
+						JSONUtil.put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "view-members")
+						).put(
+							"manageMembersData",
+							HashMapBuilder.<String, Object>put(
+								"assetLibraryCreatorUserId",
+								_themeDisplay.getUserId()
 							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "space-settings")
+								"externalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"symbolLeft", "cog"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								_getControlPanelPortletURL(
-									ExportImportPortletKeys.EXPORT)
-							).put(
-								"label",
-								LanguageUtil.get(_httpServletRequest, "export")
-							).put(
-								"symbolLeft", "export"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								_getControlPanelPortletURL(
-									ExportImportPortletKeys.IMPORT)
-							).put(
-								"label",
-								LanguageUtil.get(_httpServletRequest, "import")
-							).put(
-								"symbolLeft", "import"
-							));
-					}
-
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.VIEW)) {
-
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "view-members")
-							).put(
-								"manageMembersData",
-								HashMapBuilder.<String, Object>put(
-									"assetLibraryCreatorUserId",
-									_themeDisplay.getUserId()
-								).put(
-									"externalReferenceCode",
-									group.getExternalReferenceCode()
-								).put(
-									"hasAssignMembersPermission",
-									_groupModelResourcePermission.contains(
-										permissionChecker, group.getGroupId(),
-										ActionKeys.ASSIGN_MEMBERS)
-								).put(
-									"title",
-									LanguageUtil.get(
-										_httpServletRequest, "all-members")
-								).build()
-							).put(
-								"redirect", _themeDisplay.getURLCurrent()
-							).put(
-								"symbolLeft", "users"
-							).put(
-								"target", "manageMembersModal"
-							));
-
-						Map<String, Map<String, String>> actions =
-							_getAssetLibraryActions(group);
-
-						if (actions.containsKey("connect-sites") ||
-							actions.containsKey("view-connected-sites")) {
-
-							unsafeConsumer.accept(
-								JSONUtil.put(
-									"href", StringPool.BLANK
-								).put(
-									"label",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"view-connected-sites")
-								).put(
-									"manageConnectedSitesData",
-									HashMapBuilder.<String, Object>put(
-										"externalReferenceCode",
-										group.getExternalReferenceCode()
-									).put(
-										"hasConnectSitesPermission",
-										actions.containsKey("connect-sites")
-									).build()
-								).put(
-									"redirect", _themeDisplay.getURLCurrent()
-								).put(
-									"symbolLeft", "globe"
-								).put(
-									"target", "manageConnectedSitesModal"
-								));
-						}
-					}
-
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.PERMISSIONS)) {
-
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								PermissionsURLTag.doTag(
-									StringPool.BLANK,
-									DepotEntry.class.getName(), group.getName(),
+								"hasAssignMembersPermission",
+								_groupModelResourcePermission.contains(
+									_themeDisplay.getPermissionChecker(),
 									group.getGroupId(),
-									String.valueOf(group.getClassPK()),
-									LiferayWindowState.POP_UP.toString(), null,
-									_httpServletRequest)
+									ActionKeys.ASSIGN_MEMBERS)
 							).put(
-								"label",
+								"title",
 								LanguageUtil.get(
-									_httpServletRequest, "permissions")
-							).put(
-								"symbolLeft", "password-policies"
-							).put(
-								"target", "modal"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"defaultPermissionAdditionalProps",
-								HashMapBuilder.putAll(
-									PermissionUtil.
-										getDefaultPermissionAdditionalProps(
-											_httpServletRequest, _themeDisplay)
-								).put(
-									"classExternalReferenceCode",
-									group.getExternalReferenceCode()
-								).put(
-									"className", DepotEntry.class.getName()
-								).build()
-							).put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "default-permissions")
-							).put(
-								"symbolLeft", "password-policies"
-							).put(
-								"target", "defaultPermissionsModal"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"defaultPermissionAdditionalProps",
-								HashMapBuilder.putAll(
-									PermissionUtil.
-										getDefaultPermissionAdditionalProps(
-											true, _httpServletRequest,
-											_themeDisplay)
-								).put(
-									"classExternalReferenceCode",
-									group.getExternalReferenceCode()
-								).put(
-									"className", DepotEntry.class.getName()
-								).build()
-							).put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest,
-									"edit-and-propagate-default-permissions")
-							).put(
-								"symbolLeft", "password-policies"
-							).put(
-								"target", "defaultPermissionsModal"
-							));
-					}
+									_httpServletRequest, "all-members")
+							).build()
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"symbolLeft", "users"
+						).put(
+							"target", "manageMembersModal"
+						));
 
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.DELETE)) {
+					Map<String, Map<String, String>> actions =
+						_getAssetLibraryActions(group);
 
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"confirmationMessage",
-								LanguageUtil.get(
-									_httpServletRequest,
-									"delete-space-confirmation-body")
+					unsafeBiConsumer.accept(
+						_hasViewPermission() &&
+						(actions.containsKey("connect-sites") ||
+						 actions.containsKey("view-connected-sites")),
+						JSONUtil.put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "view-connected-sites")
+						).put(
+							"manageConnectedSitesData",
+							HashMapBuilder.<String, Object>put(
+								"externalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"confirmationTitle",
-								LanguageUtil.format(
-									_httpServletRequest,
-									"delete-space-confirmation-title",
-									group.getDescriptiveName())
+								"hasConnectSitesPermission",
+								actions.containsKey("connect-sites")
+							).build()
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"symbolLeft", "globe"
+						).put(
+							"target", "manageConnectedSitesModal"
+						));
+
+					unsafeBiConsumer.accept(
+						_hasPermissionsPermission(),
+						JSONUtil.put(
+							"href",
+							PermissionsURLTag.doTag(
+								StringPool.BLANK, DepotEntry.class.getName(),
+								group.getName(), group.getGroupId(),
+								String.valueOf(group.getClassPK()),
+								LiferayWindowState.POP_UP.toString(), null,
+								_httpServletRequest)
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "permissions")
+						).put(
+							"symbolLeft", "password-policies"
+						).put(
+							"target", "modal"
+						));
+					unsafeBiConsumer.accept(
+						_hasPermissionsPermission(),
+						JSONUtil.put(
+							"defaultPermissionAdditionalProps",
+							HashMapBuilder.putAll(
+								PermissionUtil.
+									getDefaultPermissionAdditionalProps(
+										_httpServletRequest, _themeDisplay)
 							).put(
-								"href",
-								StringBundler.concat(
-									"/o/headless-asset-library/v1.0",
-									"/asset-libraries/",
-									group.getExternalReferenceCode())
+								"classExternalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"label",
-								LanguageUtil.get(_httpServletRequest, "delete")
+								"className", DepotEntry.class.getName()
+							).build()
+						).put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "default-permissions")
+						).put(
+							"symbolLeft", "password-policies"
+						).put(
+							"target", "defaultPermissionsModal"
+						));
+					unsafeBiConsumer.accept(
+						_hasPermissionsPermission(),
+						JSONUtil.put(
+							"defaultPermissionAdditionalProps",
+							HashMapBuilder.putAll(
+								PermissionUtil.
+									getDefaultPermissionAdditionalProps(
+										true, _httpServletRequest,
+										_themeDisplay)
 							).put(
-								"redirect",
-								StringBundler.concat(
-									_themeDisplay.getPathFriendlyURLPublic(),
-									GroupConstants.CMS_FRIENDLY_URL,
-									"/all-spaces")
+								"classExternalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"successMessage",
-								LanguageUtil.format(
-									_httpServletRequest,
-									"x-was-successfully-deleted",
-									group.getDescriptiveName())
-							).put(
-								"symbolLeft", "trash"
-							).put(
-								"target", "asyncDelete"
-							));
-					}
+								"className", DepotEntry.class.getName()
+							).build()
+						).put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"edit-and-propagate-default-permissions")
+						).put(
+							"symbolLeft", "password-policies"
+						).put(
+							"target", "defaultPermissionsModal"
+						));
+					unsafeBiConsumer.accept(
+						_hasPermission(ActionKeys.DELETE),
+						JSONUtil.put(
+							"confirmationMessage",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"delete-space-confirmation-body")
+						).put(
+							"confirmationTitle",
+							LanguageUtil.format(
+								_httpServletRequest,
+								"delete-space-confirmation-title",
+								group.getDescriptiveName())
+						).put(
+							"href",
+							StringBundler.concat(
+								"/o/headless-asset-library/v1.0",
+								"/asset-libraries/",
+								group.getExternalReferenceCode())
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "delete")
+						).put(
+							"redirect",
+							StringBundler.concat(
+								_themeDisplay.getPathFriendlyURLPublic(),
+								GroupConstants.CMS_FRIENDLY_URL, "/all-spaces")
+						).put(
+							"successMessage",
+							LanguageUtil.format(
+								_httpServletRequest,
+								"x-was-successfully-deleted",
+								group.getDescriptiveName())
+						).put(
+							"symbolLeft", "trash"
+						).put(
+							"target", "asyncDelete"
+						));
 				})
 		).put(
 			"breadcrumbItems",
@@ -406,6 +379,10 @@ public class BreadcrumbDisplayContext {
 	private Map<String, Map<String, String>> _getAssetLibraryActions(
 			Group group)
 		throws Exception {
+
+		if (!_hasViewPermission()) {
+			return Collections.emptyMap();
+		}
 
 		AssetLibraryResource assetLibraryResource =
 			_assetLibraryResourceFactory.create(
@@ -443,17 +420,61 @@ public class BreadcrumbDisplayContext {
 	}
 
 	private Group _getGroup() throws Exception {
-		return _groupLocalService.getGroup(_groupId);
+		if (_group == null) {
+			_group = _groupLocalService.getGroup(_groupId);
+		}
+
+		return _group;
+	}
+
+	private boolean _hasPermission(String actionId) throws Exception {
+		PermissionChecker permissionChecker =
+			_themeDisplay.getPermissionChecker();
+
+		Group group = _getGroup();
+
+		return permissionChecker.hasPermission(
+			group, DepotEntry.class.getName(), group.getClassPK(), actionId);
+	}
+
+	private boolean _hasPermissionsPermission() throws Exception {
+		if (_hasPermissionsPermission == null) {
+			_hasPermissionsPermission = _hasPermission(ActionKeys.PERMISSIONS);
+		}
+
+		return _hasPermissionsPermission;
+	}
+
+	private boolean _hasUpdatePermission() throws Exception {
+		if (_hasUpdatePermission == null) {
+			_hasUpdatePermission = _hasPermission(ActionKeys.UPDATE);
+		}
+
+		return _hasUpdatePermission;
+	}
+
+	private boolean _hasViewPermission() throws Exception {
+		if (_hasViewPermission == null) {
+			_hasViewPermission = _hasPermission(ActionKeys.VIEW);
+		}
+
+		return _hasViewPermission;
 	}
 
 	private JSONArray _putAll(
-			UnsafeConsumer<UnsafeConsumer<JSONObject, Exception>, Exception>
-				unsafeConsumer)
+			UnsafeConsumer
+				<UnsafeBiConsumer<Boolean, JSONObject, Exception>, Exception>
+					unsafeConsumer)
 		throws Exception {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		unsafeConsumer.accept(jsonArray::put);
+		unsafeConsumer.accept(
+			(boolean1, jsonObject) -> {
+				if (boolean1) {
+					jsonArray.put(jsonObject);
+				}
+			});
 
 		if (jsonArray.length() == 0) {
 			return null;
@@ -464,9 +485,13 @@ public class BreadcrumbDisplayContext {
 
 	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
 	private final DepotEntryPinLocalService _depotEntryPinLocalService;
+	private Group _group;
 	private final long _groupId;
 	private final GroupLocalService _groupLocalService;
 	private final ModelResourcePermission<Group> _groupModelResourcePermission;
+	private Boolean _hasPermissionsPermission;
+	private Boolean _hasUpdatePermission;
+	private Boolean _hasViewPermission;
 	private final HttpServletRequest _httpServletRequest;
 	private final String _size;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
@@ -5,10 +5,10 @@
 
 package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -53,7 +53,7 @@ public class BreadcrumbComponentSectionFragmentRenderer
 
 		BreadcrumbDisplayContext breadcrumbDisplayContext =
 			new BreadcrumbDisplayContext(
-				_depotEntryModelResourcePermission, _depotEntryPinLocalService,
+				_assetLibraryResourceFactory, _depotEntryPinLocalService,
 				InfoItemUtil.getGroupId(httpServletRequest), _groupLocalService,
 				_groupModelResourcePermission, httpServletRequest,
 				CMSSpaceConstants.SPACE_STICKER_MD);
@@ -61,9 +61,8 @@ public class BreadcrumbComponentSectionFragmentRenderer
 		return breadcrumbDisplayContext.getProps();
 	}
 
-	@Reference(target = "(model.class.name=com.liferay.depot.model.DepotEntry)")
-	private ModelResourcePermission<DepotEntry>
-		_depotEntryModelResourcePermission;
+	@Reference
+	private AssetLibraryResource.Factory _assetLibraryResourceFactory;
 
 	@Reference
 	private DepotEntryPinLocalService _depotEntryPinLocalService;

--- a/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
@@ -25,6 +26,8 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:headless:headless-asset-library:headless-asset-library-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:knowledge-base:knowledge-base-api")
 	compileOnly project(":apps:layout:layout-admin-api")
@@ -35,6 +38,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:notification:notification-api")
 	compileOnly project(":apps:on-demand-admin:on-demand-admin-api")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:push-notifications:push-notifications-api")

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/dto/v1_0/converter/CMSAssetLibraryDTOConverter.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/dto/v1_0/converter/CMSAssetLibraryDTOConverter.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.dto.v1_0.converter;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"dto.class.name=com.liferay.depot.model.DepotEntry",
+		"service.ranking:Integer=100"
+	},
+	service = DTOConverter.class
+)
+public class CMSAssetLibraryDTOConverter
+	implements DTOConverter<DepotEntry, AssetLibrary> {
+
+	@Override
+	public String getContentType() {
+		return _dtoConverter.getContentType();
+	}
+
+	@Override
+	public String getJaxRsLink(long classPK, UriInfo uriInfo) {
+		return _dtoConverter.getJaxRsLink(classPK, uriInfo);
+	}
+
+	@Override
+	public AssetLibrary toDTO(DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		_removeConnectedSitesActions(dtoConverterContext);
+
+		return _dtoConverter.toDTO(dtoConverterContext);
+	}
+
+	@Override
+	public AssetLibrary toDTO(
+			DTOConverterContext dtoConverterContext, DepotEntry depotEntry)
+		throws Exception {
+
+		_removeConnectedSitesActions(dtoConverterContext);
+
+		return _dtoConverter.toDTO(dtoConverterContext, depotEntry);
+	}
+
+	private void _removeConnectedSitesActions(
+		DTOConverterContext dtoConverterContext) {
+
+		Map<String, Map<String, String>> actions =
+			dtoConverterContext.getActions();
+
+		if (actions == null) {
+			return;
+		}
+
+		actions.remove("connect-sites");
+		actions.remove("view-connected-sites");
+	}
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.AssetLibraryDTOConverter)"
+	)
+	private DTOConverter<DepotEntry, AssetLibrary> _dtoConverter;
+
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -74,6 +74,7 @@ import {config as documentLibraryWebConfig} from './tests/document-library-web/m
 import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-mapping-form-web/main/config';
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
+import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
 import {config as expandoWebConfig} from './tests/expando-web/main/config';
 import {config as exportImportServiceConfig} from './tests/export-import-service/main/config';
@@ -315,6 +316,7 @@ export default defineConfig({
 		dynamicDataMappingFormWebConfig,
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
+		e2eCmsDxpSharingConfig,
 		e2eCmsDxpWorkflowConfig,
 		expandoWebConfig,
 		exportImportServiceConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'sharing.main',
+	testDir: 'tests/e2e-cms-dxp/sharing/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/directSharingBasicWebContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/directSharingBasicWebContent.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	createRecipient,
+	expectShareNotification,
+} from '../../../../utils/sharingRecipient';
+
+const test = mergeTests(dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'A Basic Web Content shared directly with a user notifies that user and not others',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.g']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const recipient = await createRecipient(apiHelpers);
+		const other = await createRecipient(apiHelpers);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: recipient.id,
+					share: false,
+					type: 'User',
+				},
+			],
+			APPLICATION_NAME,
+			entry.id
+		);
+
+		await test.step('The recipient is notified of the shared content', async () => {
+			await expectShareNotification(
+				browser,
+				recipient.alternateName,
+				contentTitle,
+				{present: true}
+			);
+		});
+
+		await test.step('A user the content was not shared with is not notified', async () => {
+			await expectShareNotification(
+				browser,
+				other.alternateName,
+				contentTitle,
+				{present: false}
+			);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/directSharingFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/directSharingFile.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	createRecipient,
+	expectShareNotification,
+} from '../../../../utils/sharingRecipient';
+
+const test = mergeTests(dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const fileBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A CMS file shared directly with a user notifies that user and not others',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.h']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const recipient = await createRecipient(apiHelpers);
+		const other = await createRecipient(apiHelpers);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {fileBase64, name: `${getRandomString()}.jpg`},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: recipient.id,
+					share: false,
+					type: 'User',
+				},
+			],
+			APPLICATION_NAME,
+			entry.id
+		);
+
+		await test.step('The recipient is notified of the shared file', async () => {
+			await expectShareNotification(
+				browser,
+				recipient.alternateName,
+				fileTitle,
+				{present: true}
+			);
+		});
+
+		await test.step('A user the file was not shared with is not notified', async () => {
+			await expectShareNotification(
+				browser,
+				other.alternateName,
+				fileTitle,
+				{present: false}
+			);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingBasicWebContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingBasicWebContent.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	createRecipient,
+	expectShareNotification,
+} from '../../../../utils/sharingRecipient';
+
+const test = mergeTests(dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'A Basic Web Content shared with a user group notifies group members and not non-members',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.a']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		const member = await createRecipient(apiHelpers);
+		const nonMember = await createRecipient(apiHelpers);
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[String(member.id)]
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: userGroup.id,
+					share: false,
+					type: 'UserGroup',
+				},
+			],
+			APPLICATION_NAME,
+			entry.id
+		);
+
+		await test.step('A group member is notified of the shared content', async () => {
+			await expectShareNotification(
+				browser,
+				member.alternateName,
+				contentTitle,
+				{present: true}
+			);
+		});
+
+		await test.step('A user who is not a group member is not notified', async () => {
+			await expectShareNotification(
+				browser,
+				nonMember.alternateName,
+				contentTitle,
+				{present: false}
+			);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingBasicWebContentPage.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingBasicWebContentPage.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {createRecipient} from '../../../../utils/sharingRecipient';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'A group-shared Basic Web Content mapped to a page is visible to group members but not to guests',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.d']},
+	async ({apiHelpers, browser, pageEditorPage, site}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		const member = await createRecipient(apiHelpers);
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[String(member.id)]
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: userGroup.id,
+					share: false,
+					type: 'UserGroup',
+				},
+			],
+			APPLICATION_NAME,
+			entry.id
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><div><lfr-editable id="content" type="rich-text">Content</lfr-editable></div></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the shared content into the page fragment and publish', async () => {
+			await pageEditorPage.selectEditable(fragmentId, 'title');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: ENTITY, entry: contentTitle, field: 'Title'},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'content');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {
+					entity: ENTITY,
+					entry: contentTitle,
+					field: 'Content',
+				},
+			});
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('A group member sees the shared content on the page', async () => {
+			const memberContext = await browser.newContext();
+
+			const memberPage = await memberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: memberPage,
+					screenName: member.alternateName,
+				});
+
+				await expect(async () => {
+					await memberPage.goto(viewUrl);
+
+					await expect(
+						memberPage.getByText(contentTitle, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 120000});
+			}
+			finally {
+				await memberContext.close();
+			}
+		});
+
+		await test.step('A guest does not see the shared content on the page', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				const response = await guestPage.goto(viewUrl);
+
+				// Positive control: a guest can load the public page itself, so
+				// the missing content below reflects the permission gate and not
+				// a page the guest never reached.
+
+				expect(response?.ok()).toBe(true);
+				expect(guestPage.url()).toContain(viewUrl);
+
+				await expect(
+					guestPage.getByText(contentTitle, {exact: true})
+				).toHaveCount(0);
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingFile.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	createRecipient,
+	expectShareNotification,
+} from '../../../../utils/sharingRecipient';
+
+const test = mergeTests(dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const fileBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A CMS file shared with a user group notifies group members and not non-members',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.c']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		const member = await createRecipient(apiHelpers);
+		const nonMember = await createRecipient(apiHelpers);
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[String(member.id)]
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {fileBase64, name: `${getRandomString()}.jpg`},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: userGroup.id,
+					share: false,
+					type: 'UserGroup',
+				},
+			],
+			APPLICATION_NAME,
+			entry.id
+		);
+
+		await test.step('A group member is notified of the shared file', async () => {
+			await expectShareNotification(
+				browser,
+				member.alternateName,
+				fileTitle,
+				{present: true}
+			);
+		});
+
+		await test.step('A user who is not a group member is not notified', async () => {
+			await expectShareNotification(
+				browser,
+				nonMember.alternateName,
+				fileTitle,
+				{present: false}
+			);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingFilePage.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingFilePage.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {createRecipient} from '../../../../utils/sharingRecipient';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const ENTITY = 'Basic Documents (CMS)';
+
+const fileBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A group-shared CMS file mapped to a page is visible to group members but not to guests',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.f']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		const member = await createRecipient(apiHelpers);
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[String(member.id)]
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {fileBase64, name: `${getRandomString()}.jpg`},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: userGroup.id,
+					share: false,
+					type: 'UserGroup',
+				},
+			],
+			APPLICATION_NAME,
+			entry.id
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><lfr-editable id="image" type="image"><img alt="" src=""/></lfr-editable></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the shared file Title and Preview URL into the page fragment and publish', async () => {
+			await pageEditorPage.selectEditable(fragmentId, 'title');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: ENTITY, entry: fileTitle, field: 'Title'},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'image');
+
+			await page.getByLabel('Source Selection').selectOption('Mapping');
+
+			await pageEditorPage.setMappedItem({
+				entity: ENTITY,
+				entry: fileTitle,
+				field: 'Preview URL',
+			});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('A group member sees the shared file on the page', async () => {
+			const memberContext = await browser.newContext();
+
+			const memberPage = await memberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: memberPage,
+					screenName: member.alternateName,
+				});
+
+				await expect(async () => {
+					await memberPage.goto(viewUrl);
+
+					await expect(
+						memberPage.getByText(fileTitle, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 120000});
+			}
+			finally {
+				await memberContext.close();
+			}
+		});
+
+		await test.step('A guest does not see the shared file on the page', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				const response = await guestPage.goto(viewUrl);
+
+				// Positive control: a guest can load the public page itself, so
+				// the missing content below reflects the permission gate and not
+				// a page the guest never reached.
+
+				expect(response?.ok()).toBe(true);
+				expect(guestPage.url()).toContain(viewUrl);
+
+				await expect(
+					guestPage.getByText(fileTitle, {exact: true})
+				).toHaveCount(0);
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingStructuredContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingStructuredContent.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	createRecipient,
+	expectShareNotification,
+} from '../../../../utils/sharingRecipient';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+test(
+	'A custom Event structured content shared with a user group notifies group members and not non-members',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.b']},
+	async ({apiHelpers, browser, structureBuilderPage}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const titleValue = `Title ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		const member = await createRecipient(apiHelpers);
+		const nonMember = await createRecipient(apiHelpers);
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[String(member.id)]
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a custom Event structure (localizable Body text)', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({
+					label: 'Body',
+					localizable: true,
+				});
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) =>
+				objectField.label && objectField.label.en_US === 'Body'
+		);
+
+		if (!bodyField) {
+			throw new Error('Body field not found in object definition');
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[bodyField.name]: `Body ${getRandomString()}`,
+				[objectDefinition.titleObjectFieldName]: titleValue,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: userGroup.id,
+					share: false,
+					type: 'UserGroup',
+				},
+			],
+			applicationName,
+			entry.id
+		);
+
+		await test.step('A group member is notified of the shared content', async () => {
+			await expectShareNotification(
+				browser,
+				member.alternateName,
+				titleValue,
+				{present: true}
+			);
+		});
+
+		await test.step('A user who is not a group member is not notified', async () => {
+			await expectShareNotification(
+				browser,
+				nonMember.alternateName,
+				titleValue,
+				{present: false}
+			);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingStructuredContentPage.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/groupSharingStructuredContentPage.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {createRecipient} from '../../../../utils/sharingRecipient';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	structureBuilderPagesTest
+);
+
+test(
+	'A group-shared Event structured content mapped to a page is visible to group members but not to guests',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.e']},
+	async ({
+		apiHelpers,
+		browser,
+		pageEditorPage,
+		site,
+		structureBuilderPage,
+	}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const titleValue = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		const member = await createRecipient(apiHelpers);
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[String(member.id)]
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a custom Event structure (localizable Body text)', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({
+					label: 'Body',
+					localizable: true,
+				});
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const entityLabel = `${objectDefinition.pluralLabel.en_US} (CMS)`;
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) =>
+				objectField.label && objectField.label.en_US === 'Body'
+		);
+
+		if (!bodyField) {
+			throw new Error('Body field not found in object definition');
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[bodyField.name]: bodyValue,
+				[objectDefinition.titleObjectFieldName]: titleValue,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntryCollaborators(
+			[
+				{
+					actionIds: ['VIEW'],
+					id: userGroup.id,
+					share: false,
+					type: 'UserGroup',
+				},
+			],
+			applicationName,
+			entry.id
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><p><lfr-editable id="body" type="text">Body</lfr-editable></p></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the shared Title and Body into the page fragment and publish', async () => {
+			await pageEditorPage.selectEditable(fragmentId, 'title');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {
+					entity: entityLabel,
+					entry: titleValue,
+					field: 'Title',
+				},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'body');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {
+					entity: entityLabel,
+					entry: titleValue,
+					field: 'Body',
+				},
+			});
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('A group member sees the shared content on the page', async () => {
+			const memberContext = await browser.newContext();
+
+			const memberPage = await memberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: memberPage,
+					screenName: member.alternateName,
+				});
+
+				await expect(async () => {
+					await memberPage.goto(viewUrl);
+
+					await expect(
+						memberPage.getByText(titleValue, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 120000});
+			}
+			finally {
+				await memberContext.close();
+			}
+		});
+
+		await test.step('A guest does not see the shared content on the page', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				const response = await guestPage.goto(viewUrl);
+
+				// Positive control: a guest can load the public page itself, so
+				// the missing content below reflects the permission gate and not
+				// a page the guest never reached.
+
+				expect(response?.ok()).toBe(true);
+				expect(guestPage.url()).toContain(viewUrl);
+
+				await expect(
+					guestPage.getByText(titleValue, {exact: true})
+				).toHaveCount(0);
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/sharingPermissions.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {addSpaceUser} from '../../../../utils/addSpaceUser';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+
+const test = mergeTests(dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'A Space Member cannot use the Share action on a content entry',
+	{tag: ['@LPD-95527', '@LPD-95527/TC-4.i']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(180000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceMember = await addSpaceUser(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Member'
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await test.step('The Space Member has no Share action on the entry', async () => {
+			const memberContext = await browser.newContext();
+
+			const memberPage = await memberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: memberPage,
+					screenName: spaceMember.alternateName,
+				});
+
+				await memberPage.goto('/web/cms/contents');
+
+				const row = memberPage
+					.locator('tr', {hasText: contentTitle})
+					.or(
+						memberPage.locator('.card-row', {
+							hasText: contentTitle,
+						})
+					)
+					.first();
+
+				await expect(row).toBeVisible({timeout: 5000});
+
+				await row.hover();
+
+				const actionsButton = row.locator('button').last();
+
+				await actionsButton.click();
+
+				// Positive control: the actions menu actually opened, so the
+				// absence of Share below is a real result and not a menu that
+				// never rendered.
+
+				await expect(
+					memberPage.getByRole('menuitem').first()
+				).toBeVisible({timeout: 5000});
+
+				await expect(
+					memberPage.getByRole('menuitem', {
+						exact: true,
+						name: 'Share',
+					})
+				).toHaveCount(0);
+			}
+			finally {
+				await memberContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/sharing/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/utils/sharingRecipient.ts
+++ b/modules/test/playwright/utils/sharingRecipient.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser, expect} from '@playwright/test';
+
+import {DataApiHelpers} from '../helpers/ApiHelpers';
+import {PersonalMenuPage} from '../pages/users-admin-web/PersonalMenuPage';
+import {performLoginViaApi, userData} from './performLogin';
+
+export async function createRecipient(apiHelpers: DataApiHelpers) {
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+	userData[user.alternateName] = {
+		name: user.givenName,
+		password: 'test',
+		surname: user.familyName,
+	};
+
+	return user;
+}
+
+export async function expectShareNotification(
+	browser: Browser,
+	screenName: string,
+	title: string,
+	{present}: {present: boolean}
+) {
+	const context = await browser.newContext();
+
+	const page = await context.newPage();
+
+	try {
+		await performLoginViaApi({page, screenName});
+
+		const personalMenuPage = new PersonalMenuPage(page);
+
+		await page.goto('/');
+
+		await personalMenuPage.userPersonalMenuButton.click();
+
+		await personalMenuPage.menuItem('Notifications').click();
+
+		const notification = page.getByText(`has shared ${title} with you`, {
+			exact: false,
+		});
+
+		if (present) {
+			await expect(notification).toBeVisible({timeout: 5000});
+		}
+		else {
+			await expect(notification).toHaveCount(0);
+		}
+	}
+	finally {
+		await context.close();
+	}
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95527

## What Is Being Fixed

The CMS "User Group Sharing & Permissions" scenarios (LPD-95527, under the CMS E2E epic LPD-85582) had no automated end-to-end coverage.

## How It Is Being Fixed

Adds nine Playwright specs under tests/e2e-cms-dxp/sharing that exercise CMS content and file sharing: sharing a Basic Web Content, a custom Event structured content, and a CMS file with a user group, verifying group members are notified while non-members are not; the same three content kinds mapped onto a DXP page so a logged-in group member sees the shared content while a guest does not; sharing a Basic Web Content and a CMS file directly with a single user; and a space member having no Share action on an entry. Sharing uses the collaborators API with a UserGroup or User collaborator, and recipient access is verified through the share notification, because a recipient without CMS access cannot open the CMS Shared With Me section and group shares do not list in User Menu Shared Content.

## PR Check

**pr-check: PASS** — tested on `231547974098b8d37c8dcea8b9f452d6fc2f17a3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is entirely under modules/test/playwright, so only Source Format applies (no Java, JSP, Service Builder, REST, or bnd changes); the committed files have no formatting drift.

<!-- pr-check {"result": "success", "sha": "231547974098b8d37c8dcea8b9f452d6fc2f17a3"} -->
