### PR TITLE
LPD-95528 Add CMS content translation E2E Playwright tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -75,6 +75,7 @@ import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-ma
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
+import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
 import {config as expandoWebConfig} from './tests/expando-web/main/config';
 import {config as exportImportServiceConfig} from './tests/export-import-service/main/config';
@@ -317,6 +318,7 @@ export default defineConfig({
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
 		e2eCmsDxpSharingConfig,
+		e2eCmsDxpTranslationsConfig,
 		e2eCmsDxpWorkflowConfig,
 		expandoWebConfig,
 		exportImportServiceConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/translations/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/translations/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'translations.main',
+	testDir: 'tests/e2e-cms-dxp/translations/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/translations/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/translations/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationBasicWebContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationBasicWebContent.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'A translated Basic Web Content renders in the requested language on a mapped page',
+	{tag: ['@LPD-95528', '@LPD-95528/TC-5.a']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const titleEn = `TitleEN ${getRandomString()}`;
+		const titleEs = `TitleES ${getRandomString()}`;
+		const contentEn = `BodyEN ${getRandomString()}`;
+		const contentEs = `BodyES ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content_i18n: {
+					en_US: `<p>${contentEn}</p>`,
+					es_ES: `<p>${contentEs}</p>`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title_i18n: {en_US: titleEn, es_ES: titleEs},
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.getObjectDefinitionByName(
+				'CMSBasicWebContent'
+			);
+
+		const companyId = String(
+			await page.evaluate(() => Liferay.ThemeDisplay.getCompanyId())
+		);
+
+		const guestRole = await apiHelpers.jsonWebServicesRole.getRole(
+			companyId,
+			'Guest'
+		);
+
+		await apiHelpers.jsonWebServicesResourcePermissionApiHelper.setIndividualResourcePermissions(
+			['VIEW'],
+			companyId,
+			String(space.siteId),
+			objectDefinition.className,
+			String(entry.id),
+			String(guestRole.roleId)
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><div><lfr-editable id="content" type="rich-text">Content</lfr-editable></div></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the translated Title and Content into the page fragment and publish', async () => {
+			await pageEditorPage.selectEditable(fragmentId, 'title');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: ENTITY, entry: titleEn, field: 'Title'},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'content');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: ENTITY, entry: titleEn, field: 'Content'},
+			});
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('GUEST sees the Spanish translation at /es/', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(`/es${viewUrl}`);
+
+					await expect(
+						guestPage.getByText(titleEs, {exact: true})
+					).toBeVisible({timeout: 5000});
+
+					await expect(
+						guestPage.getByText(contentEs, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 30000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+
+		await test.step('GUEST sees the English translation at /en/', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(`/en${viewUrl}`);
+
+					await expect(
+						guestPage.getByText(titleEn, {exact: true})
+					).toBeVisible({timeout: 5000});
+
+					await expect(
+						guestPage.getByText(contentEn, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 30000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationFallback.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationFallback.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'A Basic Web Content with an untranslated field falls back to the default language for that field',
+	{tag: ['@LPD-95528', '@LPD-95528/TC-5.d']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.fail(
+			true,
+			'Fails due to LPD-96215: an untranslated field does not fall back to the default language, it renders empty'
+		);
+
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const titleEn = `TitleEN ${getRandomString()}`;
+		const titleEs = `TitleES ${getRandomString()}`;
+		const contentEn = `BodyEN ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content_i18n: {en_US: `<p>${contentEn}</p>`},
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title_i18n: {en_US: titleEn, es_ES: titleEs},
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.getObjectDefinitionByName(
+				'CMSBasicWebContent'
+			);
+
+		const companyId = String(
+			await page.evaluate(() => Liferay.ThemeDisplay.getCompanyId())
+		);
+
+		const guestRole = await apiHelpers.jsonWebServicesRole.getRole(
+			companyId,
+			'Guest'
+		);
+
+		await apiHelpers.jsonWebServicesResourcePermissionApiHelper.setIndividualResourcePermissions(
+			['VIEW'],
+			companyId,
+			String(space.siteId),
+			objectDefinition.className,
+			String(entry.id),
+			String(guestRole.roleId)
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><div><lfr-editable id="content" type="rich-text">Content</lfr-editable></div></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the Title and Content into the page fragment and publish', async () => {
+			await pageEditorPage.selectEditable(fragmentId, 'title');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: ENTITY, entry: titleEn, field: 'Title'},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'content');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: ENTITY, entry: titleEn, field: 'Content'},
+			});
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('At /es/ the translated Title shows and the untranslated Content falls back to the default language', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(`/es${viewUrl}`);
+
+					await expect(
+						guestPage.getByText(titleEs, {exact: true})
+					).toBeVisible({timeout: 5000});
+
+					await expect(
+						guestPage.getByText(contentEn, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 30000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationFile.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const ENTITY = 'Basic Documents (CMS)';
+
+const fileBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A translated CMS file renders its title in the requested language on a mapped page',
+	{tag: ['@LPD-95528', '@LPD-95528/TC-5.c']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const titleEn = `TitleEN ${getRandomString()}`;
+		const titleEs = `TitleES ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {fileBase64, name: `${getRandomString()}.jpg`},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title_i18n: {en_US: titleEn, es_ES: titleEs},
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.getObjectDefinitionByName(
+				'CMSBasicDocument'
+			);
+
+		const companyId = String(
+			await page.evaluate(() => Liferay.ThemeDisplay.getCompanyId())
+		);
+
+		const guestRole = await apiHelpers.jsonWebServicesRole.getRole(
+			companyId,
+			'Guest'
+		);
+
+		await apiHelpers.jsonWebServicesResourcePermissionApiHelper.setIndividualResourcePermissions(
+			['DOWNLOAD_FILE', 'VIEW'],
+			companyId,
+			String(space.siteId),
+			objectDefinition.className,
+			String(entry.id),
+			String(guestRole.roleId)
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><lfr-editable id="image" type="image"><img alt="" src=""/></lfr-editable></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the translated Title and Preview URL into the page fragment and publish', async () => {
+			await pageEditorPage.selectEditable(fragmentId, 'title');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: ENTITY, entry: titleEn, field: 'Title'},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'image');
+
+			await page.getByLabel('Source Selection').selectOption('Mapping');
+
+			await pageEditorPage.setMappedItem({
+				entity: ENTITY,
+				entry: titleEn,
+				field: 'Preview URL',
+			});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('GUEST sees the Spanish file title at /es/', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(`/es${viewUrl}`);
+
+					await expect(
+						guestPage.getByText(titleEs, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 30000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+
+		await test.step('GUEST sees the English file title at /en/', async () => {
+			const guestContext = await browser.newContext();
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(`/en${viewUrl}`);
+
+					await expect(
+						guestPage.getByText(titleEn, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 30000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationStructuredContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationStructuredContent.spec.ts
@@ -107,7 +107,7 @@ test(
 
 		if (!bodyField || !numericField) {
 			throw new Error(
-				'Body or Numeric field not found in object definition'
+				'The "Body" or "Numeric" field was not found in the object definition'
 			);
 		}
 

--- a/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationStructuredContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/translations/main/translationStructuredContent.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi, userData} from '../../../../utils/performLogin';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	structureBuilderPagesTest
+);
+
+test(
+	'A translated Event structured content shows localized fields per language to a USER changing the URL locale',
+	{tag: ['@LPD-95528', '@LPD-95528/TC-5.b']},
+	async ({
+		apiHelpers,
+		browser,
+		page,
+		pageEditorPage,
+		site,
+		structureBuilderPage,
+	}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const titleEn = `TitleEN ${getRandomString()}`;
+		const titleEs = `TitleES ${getRandomString()}`;
+		const bodyEn = `BodyEN ${getRandomString()}`;
+		const bodyEs = `BodyES ${getRandomString()}`;
+		const numericValue = 100000 + (getRandomInt() % 800000);
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a custom Event structure (localizable Body text + Numeric)', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({
+					label: 'Body',
+					localizable: true,
+				});
+
+				await structureBuilderPage.addField('Numeric');
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const entityLabel = `${objectDefinition.pluralLabel.en_US} (CMS)`;
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) =>
+				objectField.label && objectField.label.en_US === 'Body'
+		);
+
+		const numericField = objectDefinition.objectFields.find(
+			(objectField) =>
+				objectField.label && objectField.label.en_US === 'Numeric'
+		);
+
+		if (!bodyField || !numericField) {
+			throw new Error(
+				'Body or Numeric field not found in object definition'
+			);
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[`${bodyField.name}_i18n`]: {en_US: bodyEn, es_ES: bodyEs},
+				[numericField.name]: numericValue,
+				[`${objectDefinition.titleObjectFieldName}_i18n`]: {
+					en_US: titleEn,
+					es_ES: titleEs,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		const companyId = String(
+			await page.evaluate(() => Liferay.ThemeDisplay.getCompanyId())
+		);
+
+		const guestRole = await apiHelpers.jsonWebServicesRole.getRole(
+			companyId,
+			'Guest'
+		);
+
+		await apiHelpers.jsonWebServicesResourcePermissionApiHelper.setIndividualResourcePermissions(
+			['VIEW'],
+			companyId,
+			String(space.siteId),
+			objectDefinition.className,
+			String(entry.id),
+			String(guestRole.roleId)
+		);
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await apiHelpers.jsonWebServicesUser.addGroupUsers(String(site.id), [
+			user.id,
+		]);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><p><lfr-editable id="body" type="text">Body</lfr-editable></p><h2><lfr-editable id="numeric" type="text">Numeric</lfr-editable></h2></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the Title, Body and Numeric fields into the page fragment and publish', async () => {
+			await pageEditorPage.selectEditable(fragmentId, 'title');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: entityLabel, entry: titleEn, field: 'Title'},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'body');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {entity: entityLabel, entry: titleEn, field: 'Body'},
+			});
+
+			await pageEditorPage.selectEditable(fragmentId, 'numeric');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {
+					entity: entityLabel,
+					entry: titleEn,
+					field: 'Numeric',
+				},
+			});
+
+			await pageEditorPage.publishPage();
+		});
+
+		const userContext = await browser.newContext();
+
+		const userPage = await userContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: userPage,
+				screenName: user.alternateName,
+			});
+
+			await test.step('The USER sees the Spanish translation at /es/', async () => {
+				await expect(async () => {
+					await userPage.goto(`/es${viewUrl}`);
+
+					await expect(
+						userPage.getByText(titleEs, {exact: true})
+					).toBeVisible({timeout: 5000});
+
+					await expect(
+						userPage.getByText(bodyEs, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 30000});
+			});
+
+			await test.step('The USER sees the English translation at /en/', async () => {
+				await expect(async () => {
+					await userPage.goto(`/en${viewUrl}`);
+
+					await expect(
+						userPage.getByText(titleEn, {exact: true})
+					).toBeVisible({timeout: 5000});
+
+					await expect(
+						userPage.getByText(bodyEn, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 30000});
+			});
+		}
+		finally {
+			await userContext.close();
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95528

## What Is Being Fixed

The CMS "Content Translations" scenarios (LPD-95528, under the CMS E2E epic LPD-85582) had no automated end-to-end coverage.

## How It Is Being Fixed

Adds four Playwright specs under tests/e2e-cms-dxp/translations: a translated Basic Web Content rendered per language on a mapped DXP page for a guest; a custom Event structure with localizable Title and Body whose fields update per language for an authenticated user changing the URL locale; a translated CMS file whose title renders per language; and an untranslated-field fallback scenario. Translations are set via the headless object i18n suffix and the localized page is read through the site page locale prefix (for example /es/).

Three scenarios pass. The fallback scenario is kept as a recorded failure: when a content field is left untranslated, the localized page does not fall back to the default-language value (the field renders empty). That defect is filed as LPD-96215.

## PR Check

**pr-check: PASS** — tested on `8a4a48145b2ff29df7f510b8f7371ada685bf9dd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is entirely under modules/test/playwright, so only Source Format applies; the committed files have no formatting drift.

<!-- pr-check {"result": "success", "sha": "8a4a48145b2ff29df7f510b8f7371ada685bf9dd"} -->
