### PR TITLE
LPD-95530 Add E2E tests for CMS content in collections on DXP pages

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionDisplay.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionDisplay.spec.ts
@@ -17,7 +17,7 @@ import {
 	CMS_FILE_APPLICATION,
 	CMS_WEB_CONTENT_APPLICATION,
 	addMappedCollectionDisplay,
-	createCmsCategory,
+	createCMSCategory,
 	createDynamicCollection,
 	createDynamicCollectionWithFilterViaUI,
 	createEventStructure,
@@ -383,7 +383,7 @@ test(
 	}) => {
 		const space = await createSpace(apiHelpers);
 
-		const category = await createCmsCategory(apiHelpers);
+		const category = await createCMSCategory(apiHelpers);
 
 		const categorizedTitle = `Categorized ${getRandomString()}`;
 		const uncategorizedTitle = `Uncategorized ${getRandomString()}`;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionDisplay.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionDisplay.spec.ts
@@ -1,0 +1,829 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser, Page, expect, mergeTests} from '@playwright/test';
+
+import {collectionsPagesTest} from '../../../../fixtures/collectionsPagesTest';
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	CMS_FILE_APPLICATION,
+	CMS_WEB_CONTENT_APPLICATION,
+	addMappedCollectionDisplay,
+	createCmsCategory,
+	createDynamicCollection,
+	createDynamicCollectionWithFilterViaUI,
+	createEventStructure,
+	createManualCollection,
+	getAssetEntryId,
+	getBasicDocumentClassName,
+	getBasicWebContentClassName,
+	getClassNameId,
+} from './helpers/collectionDisplay';
+
+const test = mergeTests(
+	collectionsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const TINY_FILE = 'R0lGODlhAQABAAAAACw=';
+
+async function createSpace(apiHelpers: DataApiHelpers) {
+	return apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name: `Space ${getRandomString()}`,
+		settings: {},
+		type: 'Space',
+	});
+}
+
+async function connectSpace(
+	apiHelpers: DataApiHelpers,
+	space: {externalReferenceCode: string},
+	site: {externalReferenceCode: string}
+) {
+	await apiHelpers.headlessAssetLibrary.connectSite(
+		space.externalReferenceCode,
+		site.externalReferenceCode,
+		{searchable: true}
+	);
+}
+
+async function createWebContent(
+	apiHelpers: DataApiHelpers,
+	spaceName: string,
+	title: string
+) {
+	return apiHelpers.objectEntry.postObjectEntry(
+		{
+			content: `<p>${title} body</p>`,
+			objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			title,
+		},
+		CMS_WEB_CONTENT_APPLICATION,
+		spaceName
+	);
+}
+
+async function createDocument(
+	apiHelpers: DataApiHelpers,
+	spaceName: string,
+	title: string
+) {
+	return apiHelpers.objectEntry.postObjectEntry(
+		{
+			file: {fileBase64: TINY_FILE, name: `${title}.png`},
+			objectEntryFolderExternalReferenceCode: 'L_FILES',
+			title,
+		},
+		CMS_FILE_APPLICATION,
+		spaceName
+	);
+}
+
+async function createEventEntry(
+	apiHelpers: DataApiHelpers,
+	applicationName: string,
+	spaceName: string,
+	title: string
+) {
+	return apiHelpers.objectEntry.postObjectEntry(
+		{
+			body: `${title} body`,
+			objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			title,
+		},
+		applicationName,
+		spaceName
+	);
+}
+
+async function withGuestPage(
+	browser: Browser,
+	viewURL: string,
+	assertions: (guestPage: Page) => Promise<void>
+) {
+	const context = await browser.newContext();
+
+	try {
+		const guestPage = await context.newPage();
+
+		await guestPage.goto(viewURL);
+
+		await assertions(guestPage);
+	}
+	finally {
+		await context.close();
+	}
+}
+
+test(
+	'TC-7.a Manual collection of Basic Web Content renders the items in order for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const className = await getBasicWebContentClassName(apiHelpers);
+
+		const titles = [
+			`A ${getRandomString()}`,
+			`B ${getRandomString()}`,
+			`C ${getRandomString()}`,
+		];
+
+		const assetEntryIds = [];
+
+		for (const title of titles) {
+			const entry = await createWebContent(apiHelpers, space.name, title);
+
+			await apiHelpers.objectEntry.putObjectEntryPermissions(
+				CMS_WEB_CONTENT_APPLICATION,
+				entry.id,
+				[{actionIds: ['VIEW'], roleName: 'Guest'}]
+			);
+
+			assetEntryIds.push(
+				await getAssetEntryId(apiHelpers, className, entry.id)
+			);
+		}
+
+		await connectSpace(apiHelpers, space, site);
+
+		const orderedTitles = [titles[2], titles[0], titles[1]];
+
+		const collection = await createManualCollection(
+			apiHelpers,
+			String(site.id),
+			[assetEntryIds[2], assetEntryIds[0], assetEntryIds[1]]
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees the items in the configured order', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				for (const title of orderedTitles) {
+					await expect(guestPage.getByText(title)).toBeVisible();
+				}
+
+				const content = await guestPage
+					.locator('#main-content')
+					.innerText();
+
+				const positions = orderedTitles.map((title) =>
+					content.indexOf(title)
+				);
+
+				for (const position of positions) {
+					expect(position).toBeGreaterThanOrEqual(0);
+				}
+
+				expect(positions[0]).toBeLessThan(positions[1]);
+				expect(positions[1]).toBeLessThan(positions[2]);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.b Manual collection of custom structure content renders in order for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const {applicationName, definition} = await createEventStructure(
+			apiHelpers,
+			space.externalReferenceCode
+		);
+
+		const titles = [
+			`A ${getRandomString()}`,
+			`B ${getRandomString()}`,
+			`C ${getRandomString()}`,
+		];
+
+		const assetEntryIds = [];
+
+		for (const title of titles) {
+			const entry = await createEventEntry(
+				apiHelpers,
+				applicationName,
+				space.name,
+				title
+			);
+
+			await apiHelpers.objectEntry.putObjectEntryPermissions(
+				applicationName,
+				entry.id,
+				[{actionIds: ['VIEW'], roleName: 'Guest'}]
+			);
+
+			assetEntryIds.push(
+				await getAssetEntryId(
+					apiHelpers,
+					definition.className as string,
+					entry.id
+				)
+			);
+		}
+
+		await connectSpace(apiHelpers, space, site);
+
+		const orderedTitles = [titles[2], titles[0], titles[1]];
+
+		const collection = await createManualCollection(
+			apiHelpers,
+			String(site.id),
+			[assetEntryIds[2], assetEntryIds[0], assetEntryIds[1]]
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees the custom structure items in the configured order', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				for (const title of orderedTitles) {
+					await expect(guestPage.getByText(title)).toBeVisible();
+				}
+
+				const content = await guestPage
+					.locator('#main-content')
+					.innerText();
+
+				const positions = orderedTitles.map((title) =>
+					content.indexOf(title)
+				);
+
+				for (const position of positions) {
+					expect(position).toBeGreaterThanOrEqual(0);
+				}
+
+				expect(positions[0]).toBeLessThan(positions[1]);
+				expect(positions[1]).toBeLessThan(positions[2]);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.d Dynamic collection filtered by tag shows only tagged content for GUEST',
+	{tag: ['@LPD-95530', '@LPD-96296']},
+	async ({
+		apiHelpers,
+		browser,
+		collectionsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		test.fail(
+			true,
+			'Fails due to LPD-96296: a tag-filtered collection returns no CMS content on the published page'
+		);
+
+		const space = await createSpace(apiHelpers);
+
+		const tag = `tag${getRandomString()}`.toLowerCase();
+		const taggedTitle = `Tagged ${getRandomString()}`;
+		const untaggedTitle = `Untagged ${getRandomString()}`;
+
+		const tagged = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				keywords: [tag],
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: taggedTitle,
+			},
+			CMS_WEB_CONTENT_APPLICATION,
+			space.name
+		);
+		const untagged = await createWebContent(
+			apiHelpers,
+			space.name,
+			untaggedTitle
+		);
+
+		for (const entry of [tagged, untagged]) {
+			await apiHelpers.objectEntry.putObjectEntryPermissions(
+				CMS_WEB_CONTENT_APPLICATION,
+				entry.id,
+				[{actionIds: ['VIEW'], roleName: 'Guest'}]
+			);
+		}
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createDynamicCollectionWithFilterViaUI(
+			collectionsPage,
+			page,
+			site,
+			{
+				filterProperty: 'assetTags',
+				filterValueName: tag,
+				itemTypeLabel: 'Basic Web Content (CMS)',
+				spaceName: space.name,
+			}
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees only the tagged content', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(taggedTitle)).toBeVisible();
+				await expect(guestPage.getByText(untaggedTitle)).toHaveCount(0);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.c Dynamic collection filtered by category shows only categorized content for GUEST',
+	{tag: '@LPD-95530'},
+	async ({
+		apiHelpers,
+		browser,
+		collectionsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const space = await createSpace(apiHelpers);
+
+		const category = await createCmsCategory(apiHelpers);
+
+		const categorizedTitle = `Categorized ${getRandomString()}`;
+		const uncategorizedTitle = `Uncategorized ${getRandomString()}`;
+
+		const categorized = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				taxonomyCategoryIds: [category.id],
+				title: categorizedTitle,
+			},
+			CMS_WEB_CONTENT_APPLICATION,
+			space.name
+		);
+		const uncategorized = await createWebContent(
+			apiHelpers,
+			space.name,
+			uncategorizedTitle
+		);
+
+		for (const entry of [categorized, uncategorized]) {
+			await apiHelpers.objectEntry.putObjectEntryPermissions(
+				CMS_WEB_CONTENT_APPLICATION,
+				entry.id,
+				[{actionIds: ['VIEW'], roleName: 'Guest'}]
+			);
+		}
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createDynamicCollectionWithFilterViaUI(
+			collectionsPage,
+			page,
+			site,
+			{
+				filterProperty: 'assetCategories',
+				filterValueName: category.name,
+				itemTypeLabel: 'Basic Web Content (CMS)',
+				spaceName: space.name,
+			}
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees only the categorized content', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(
+					guestPage.getByText(categorizedTitle)
+				).toBeVisible();
+				await expect(
+					guestPage.getByText(uncategorizedTitle)
+				).toHaveCount(0);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.e Dynamic collection filtered by Basic Web Content (CMS) shows only web content for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const className = await getBasicWebContentClassName(apiHelpers);
+		const classNameId = await getClassNameId(apiHelpers, className);
+
+		const webContentTitle = `Content ${getRandomString()}`;
+		const documentTitle = `Document ${getRandomString()}`;
+
+		const webContent = await createWebContent(
+			apiHelpers,
+			space.name,
+			webContentTitle
+		);
+		await createDocument(apiHelpers, space.name, documentTitle);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			CMS_WEB_CONTENT_APPLICATION,
+			webContent.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createDynamicCollection(
+			apiHelpers,
+			String(site.id),
+			`anyAssetType=${classNameId}\nclassNameIds=${classNameId}\ngroupIds=${space.siteId}\n`
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees only the Basic Web Content', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(
+					guestPage.getByText(webContentTitle)
+				).toBeVisible();
+				await expect(guestPage.getByText(documentTitle)).toHaveCount(0);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.f Dynamic collection filtered by the custom structure type shows only those entries for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const {applicationName, classNameId} = await createEventStructure(
+			apiHelpers,
+			space.externalReferenceCode
+		);
+
+		const eventTitle = `Event ${getRandomString()}`;
+		const webContentTitle = `Content ${getRandomString()}`;
+
+		const event = await createEventEntry(
+			apiHelpers,
+			applicationName,
+			space.name,
+			eventTitle
+		);
+		await createWebContent(apiHelpers, space.name, webContentTitle);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			event.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createDynamicCollection(
+			apiHelpers,
+			String(site.id),
+			`anyAssetType=${classNameId}\nclassNameIds=${classNameId}\ngroupIds=${space.siteId}\n`
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees only the custom structure entries', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(eventTitle)).toBeVisible();
+				await expect(guestPage.getByText(webContentTitle)).toHaveCount(
+					0
+				);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.g Dynamic collection filtered by Basic Document (CMS) shows only files for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const className = await getBasicDocumentClassName(apiHelpers);
+		const classNameId = await getClassNameId(apiHelpers, className);
+
+		const documentTitle = `Document ${getRandomString()}`;
+		const webContentTitle = `Content ${getRandomString()}`;
+
+		const document = await createDocument(
+			apiHelpers,
+			space.name,
+			documentTitle
+		);
+		await createWebContent(apiHelpers, space.name, webContentTitle);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			CMS_FILE_APPLICATION,
+			document.id,
+			[{actionIds: ['DOWNLOAD_FILE', 'VIEW'], roleName: 'Guest'}]
+		);
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createDynamicCollection(
+			apiHelpers,
+			String(site.id),
+			`anyAssetType=${classNameId}\nclassNameIds=${classNameId}\ngroupIds=${space.siteId}\n`
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees only the files', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(documentTitle)).toBeVisible();
+				await expect(guestPage.getByText(webContentTitle)).toHaveCount(
+					0
+				);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.i Editing a Basic Web Content title updates the published page live for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const className = await getBasicWebContentClassName(apiHelpers);
+
+		const originalTitle = `Content ${getRandomString()}`;
+		const updatedTitle = `Updated ${getRandomString()}`;
+
+		const entry = await createWebContent(
+			apiHelpers,
+			space.name,
+			originalTitle
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			CMS_WEB_CONTENT_APPLICATION,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createManualCollection(
+			apiHelpers,
+			String(site.id),
+			[await getAssetEntryId(apiHelpers, className, entry.id)]
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees the original title', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(originalTitle)).toBeVisible();
+			});
+		});
+
+		await test.step('Edit the title in the CMS', async () => {
+			await apiHelpers.objectEntry.putObjectEntry(
+				{title: updatedTitle},
+				CMS_WEB_CONTENT_APPLICATION,
+				entry.id
+			);
+		});
+
+		await test.step('GUEST sees the updated title without the page being republished', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(updatedTitle)).toBeVisible();
+				await expect(guestPage.getByText(originalTitle)).toHaveCount(0);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.j Editing a custom structure entry title updates the published page live for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const {applicationName, definition} = await createEventStructure(
+			apiHelpers,
+			space.externalReferenceCode
+		);
+
+		const originalTitle = `Event ${getRandomString()}`;
+		const updatedTitle = `Updated ${getRandomString()}`;
+
+		const entry = await createEventEntry(
+			apiHelpers,
+			applicationName,
+			space.name,
+			originalTitle
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createManualCollection(
+			apiHelpers,
+			String(site.id),
+			[
+				await getAssetEntryId(
+					apiHelpers,
+					definition.className as string,
+					entry.id
+				),
+			]
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees the original title', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(originalTitle)).toBeVisible();
+			});
+		});
+
+		await test.step('Edit the title in the CMS', async () => {
+			await apiHelpers.objectEntry.putObjectEntry(
+				{title: updatedTitle},
+				applicationName,
+				entry.id
+			);
+		});
+
+		await test.step('GUEST sees the updated title without the page being republished', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(updatedTitle)).toBeVisible();
+				await expect(guestPage.getByText(originalTitle)).toHaveCount(0);
+			});
+		});
+	}
+);
+
+test(
+	'TC-7.k Deleting a Basic Document removes it from the published page for GUEST',
+	{tag: '@LPD-95530'},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		const space = await createSpace(apiHelpers);
+
+		const className = await getBasicDocumentClassName(apiHelpers);
+
+		const keptTitle = `Kept ${getRandomString()}`;
+		const deletedTitle = `Deleted ${getRandomString()}`;
+
+		const keptEntry = await createDocument(
+			apiHelpers,
+			space.name,
+			keptTitle
+		);
+		const deletedEntry = await createDocument(
+			apiHelpers,
+			space.name,
+			deletedTitle
+		);
+
+		const assetEntryIds = [];
+
+		for (const entry of [keptEntry, deletedEntry]) {
+			await apiHelpers.objectEntry.putObjectEntryPermissions(
+				CMS_FILE_APPLICATION,
+				entry.id,
+				[{actionIds: ['DOWNLOAD_FILE', 'VIEW'], roleName: 'Guest'}]
+			);
+
+			assetEntryIds.push(
+				await getAssetEntryId(apiHelpers, className, entry.id)
+			);
+		}
+
+		await connectSpace(apiHelpers, space, site);
+
+		const collection = await createManualCollection(
+			apiHelpers,
+			String(site.id),
+			assetEntryIds
+		);
+
+		const {viewURL} =
+			await test.step('Render the collection in a Collection Display mapped to Title', () =>
+				addMappedCollectionDisplay(
+					apiHelpers,
+					page,
+					pageEditorPage,
+					site,
+					collection.title
+				));
+
+		await test.step('GUEST sees both files', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(keptTitle)).toBeVisible();
+				await expect(guestPage.getByText(deletedTitle)).toBeVisible();
+			});
+		});
+
+		await test.step('Delete one document in the CMS', async () => {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				CMS_FILE_APPLICATION,
+				String(deletedEntry.id)
+			);
+		});
+
+		await test.step('GUEST no longer sees the deleted file', async () => {
+			await withGuestPage(browser, viewURL, async (guestPage) => {
+				await expect(guestPage.getByText(keptTitle)).toBeVisible();
+				await expect(guestPage.getByText(deletedTitle)).toHaveCount(0);
+			});
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/collectionDisplay.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/collectionDisplay.ts
@@ -246,7 +246,7 @@ export async function createDynamicCollectionWithFilterViaUI(
  * Creates a CMS vocabulary (available to all asset libraries / Spaces) with a
  * single category, and returns the category's id and name.
  */
-export async function createCmsCategory(apiHelpers: DataApiHelpers) {
+export async function createCMSCategory(apiHelpers: DataApiHelpers) {
 	const cmsSiteId = await apiHelpers.headlessAdminUser
 		.getSiteByFriendlyUrlPath('cms')
 		.then((response) => response.id);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/collectionDisplay.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/collectionDisplay.ts
@@ -1,0 +1,381 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {DataApiHelpers} from '../../../../../helpers/ApiHelpers';
+import {liferayConfig} from '../../../../../liferay.config';
+import {CollectionsPage} from '../../../../../pages/asset-list-web/CollectionsPage';
+import {PageEditorPage} from '../../../../../pages/layout-content-page-editor-web/PageEditorPage';
+import {getRandomInt} from '../../../../../utils/getRandomInt';
+import getRandomString from '../../../../../utils/getRandomString';
+import {waitForAlert} from '../../../../../utils/waitForAlert';
+import getPageDefinition from '../../../../layout-content-page-editor-web/main/utils/getPageDefinition';
+
+const BASIC_DOCUMENT_ERC = 'L_CMS_BASIC_DOCUMENT';
+const BASIC_WEB_CONTENT_ERC = 'L_CMS_BASIC_WEB_CONTENT';
+
+export const CMS_FILE_APPLICATION = 'cms/basic-documents';
+export const CMS_WEB_CONTENT_APPLICATION = 'cms/basic-web-contents';
+
+const jsonWebServices = async (
+	apiHelpers: DataApiHelpers,
+	path: string,
+	params: Record<string, string>
+) => {
+	const urlSearchParams = new URLSearchParams();
+
+	for (const [key, value] of Object.entries(params)) {
+		urlSearchParams.append(key, value);
+	}
+
+	return apiHelpers.post(
+		`${liferayConfig.environment.baseUrl}/api/jsonws/${path}`,
+		{
+			data: urlSearchParams.toString(),
+			headers: await apiHelpers.getJSONWebServicesHeaders(),
+		}
+	);
+};
+
+export async function getObjectClassName(
+	apiHelpers: DataApiHelpers,
+	externalReferenceCode: string
+): Promise<string> {
+	const objectDefinition = await apiHelpers.get(
+		`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/by-external-reference-code/${externalReferenceCode}`
+	);
+
+	return objectDefinition.className;
+}
+
+export async function getBasicWebContentClassName(apiHelpers: DataApiHelpers) {
+	return getObjectClassName(apiHelpers, BASIC_WEB_CONTENT_ERC);
+}
+
+export async function getBasicDocumentClassName(apiHelpers: DataApiHelpers) {
+	return getObjectClassName(apiHelpers, BASIC_DOCUMENT_ERC);
+}
+
+export async function getClassNameId(
+	apiHelpers: DataApiHelpers,
+	className: string
+): Promise<string> {
+	const {classNameId} =
+		await apiHelpers.jsonWebServicesClassName.fetchClassName(className);
+
+	return classNameId;
+}
+
+export async function getAssetEntryId(
+	apiHelpers: DataApiHelpers,
+	className: string,
+	classPK: number | string
+): Promise<string> {
+	const assetEntry = await jsonWebServices(
+		apiHelpers,
+		'assetentry/get-entry',
+		{
+			className,
+			classPK: String(classPK),
+		}
+	);
+
+	return assetEntry.entryId;
+}
+
+/**
+ * Creates a published custom CMS content structure (e.g. "Event") with a
+ * localizable Title and Body, available in the given Space, and returns its
+ * REST application name and class name id.
+ */
+export async function createEventStructure(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string
+) {
+	const definition = await apiHelpers.objectAdmin.postRandomObjectDefinition({
+		objectDefinitionExternalReferenceCode: `Event${getRandomInt()}`,
+		objectDefinitionSettings: [
+			{
+				name: 'acceptedGroupExternalReferenceCodes',
+				value: spaceExternalReferenceCode as unknown as object,
+			},
+		],
+		objectFields: [
+			{
+				DBType: 'String',
+				businessType: 'Text',
+				externalReferenceCode: getRandomString(),
+				indexed: true,
+				indexedAsKeyword: false,
+				indexedLanguageId: 'en_US',
+				label: {en_US: 'Title'},
+				localized: true,
+				name: 'title',
+				required: true,
+			},
+			{
+				DBType: 'Clob',
+				businessType: 'LongText',
+				externalReferenceCode: getRandomString(),
+				indexed: true,
+				indexedAsKeyword: false,
+				indexedLanguageId: 'en_US',
+				label: {en_US: 'Body'},
+				localized: true,
+				name: 'body',
+				required: false,
+			},
+		],
+		objectFolderExternalReferenceCode: 'L_CMS_CONTENT_STRUCTURES',
+		scope: 'depot',
+		status: {code: 0},
+		titleObjectFieldName: 'title',
+	});
+
+	apiHelpers.data.push({
+		id: definition.id as number,
+		type: 'objectDefinition',
+	});
+
+	return {
+		applicationName: (definition.restContextPath as string).replace(
+			/^\/o\//,
+			''
+		),
+		classNameId: await getClassNameId(
+			apiHelpers,
+			definition.className as string
+		),
+		definition,
+	};
+}
+
+/**
+ * Creates a dynamic collection through the Collections editor UI: sets the item
+ * type, scopes it to the given Space, and adds a tag or category filter. Returns
+ * the collection title (used to select it in the Collection Display picker).
+ */
+export async function createDynamicCollectionWithFilterViaUI(
+	collectionsPage: CollectionsPage,
+	page: Page,
+	site: {friendlyUrlPath: string},
+	{
+		filterProperty,
+		filterValueName,
+		itemTypeLabel,
+		spaceName,
+	}: {
+		filterProperty: 'assetCategories' | 'assetTags';
+		filterValueName: string;
+		itemTypeLabel: string;
+		spaceName: string;
+	}
+) {
+	const title = getRandomString();
+
+	await collectionsPage.goto(site.friendlyUrlPath);
+	await collectionsPage.addNewDynamicCollection(title);
+
+	await page.getByLabel('Item Type').selectOption({label: itemTypeLabel});
+
+	// Scope to the Space
+
+	await page.getByRole('button', {name: 'Scope'}).click();
+	await page.getByRole('button', {name: 'Select Site'}).click();
+	await page
+		.getByRole('menuitem', {name: 'Other Site, Asset Library, or'})
+		.click();
+
+	const scopeFrame = page.locator('iframe[title="Scope"]').contentFrame();
+
+	await scopeFrame.getByRole('link', {name: 'Spaces'}).click();
+	await scopeFrame.getByRole('link', {exact: true, name: spaceName}).click();
+
+	// Add the tag / category filter. The condition row defaults to "Tags"; the
+	// "of the following" select chooses the property. The filter value picker is
+	// opened by the last "Select" button (the first one belongs to Scope).
+
+	await page.getByRole('button', {name: 'Filter'}).click();
+
+	await page.getByLabel('of the following').selectOption(filterProperty);
+
+	const isTag = filterProperty === 'assetTags';
+
+	await page
+		.getByRole('button', {
+			exact: !isTag,
+			name: isTag ? 'Select Tags' : 'Select',
+		})
+		.last()
+		.click();
+
+	// Pick the value, then confirm with "Done". The Tags picker is a table inside
+	// an iframe; the Categories picker is a checkbox tree directly on the page.
+
+	if (isTag) {
+		await page
+			.frameLocator('iframe[title="Tags"]')
+			.getByRole('row', {name: filterValueName})
+			.getByRole('checkbox')
+			.check();
+	}
+	else {
+
+		// The Categories tree row is a Clay custom checkbox with no accessible
+		// name; toggle it by clicking its label within the matching row.
+
+		await page
+			.locator('.autofit-row')
+			.filter({hasText: filterValueName})
+			.locator('input[type="checkbox"]')
+			.check({force: true});
+	}
+
+	await page.getByRole('button', {name: 'Done'}).click();
+
+	await page.getByRole('button', {name: 'Save'}).click();
+	await waitForAlert(page);
+
+	return {title};
+}
+
+/**
+ * Creates a CMS vocabulary (available to all asset libraries / Spaces) with a
+ * single category, and returns the category's id and name.
+ */
+export async function createCmsCategory(apiHelpers: DataApiHelpers) {
+	const cmsSiteId = await apiHelpers.headlessAdminUser
+		.getSiteByFriendlyUrlPath('cms')
+		.then((response) => response.id);
+
+	const vocabulary =
+		await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
+			assetLibraries: [{id: -1}],
+			assetTypes: [
+				{
+					required: false,
+					subtype: 'AllAssetSubtypes',
+					type: 'AllAssetTypes',
+				},
+			],
+			name: getRandomString(),
+			siteId: cmsSiteId,
+			visibilityType: 'PUBLIC',
+		});
+
+	const name = getRandomString();
+
+	const category =
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{name, vocabularyId: vocabulary.id}
+		);
+
+	return {id: category.id, name};
+}
+
+export async function createManualCollection(
+	apiHelpers: DataApiHelpers,
+	groupId: string,
+	assetEntryIds: string[]
+) {
+	const title = getRandomString();
+
+	const collection =
+		await apiHelpers.jsonWebServicesAssetListEntry.addManualAssetListEntry({
+			groupId,
+			title,
+		});
+
+	for (const assetEntryId of assetEntryIds) {
+		await jsonWebServices(
+			apiHelpers,
+			'assetlist.assetlistentry/add-asset-entry-selection',
+			{
+				assetEntryId,
+				assetListEntryId: String(collection.assetListEntryId),
+				segmentsEntryId: '0',
+				serviceContext: JSON.stringify({scopeGroupId: groupId}),
+			}
+		);
+	}
+
+	return {title};
+}
+
+export async function createDynamicCollection(
+	apiHelpers: DataApiHelpers,
+	groupId: string,
+	typeSettings: string
+) {
+	const title = getRandomString();
+
+	await apiHelpers.jsonWebServicesAssetListEntry.addDynamicAssetListEntry({
+		groupId,
+		title,
+		typeSettings,
+	});
+
+	return {title};
+}
+
+/**
+ * Creates a content page with a Collection Display bound to the named
+ * collection, drops a Heading into the collection item mapped to the given
+ * field (default "Title"), publishes the page, and returns its view URL.
+ */
+export async function addMappedCollectionDisplay(
+	apiHelpers: DataApiHelpers,
+	page: Page,
+	pageEditorPage: PageEditorPage,
+	site: {friendlyUrlPath: string; id: string},
+	collectionTitle: string,
+	fieldLabel = 'Title'
+) {
+	const layout = await apiHelpers.headlessDelivery.createSitePage({
+		pageDefinition: getPageDefinition(),
+		siteId: site.id,
+		title: getRandomString(),
+	});
+
+	await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+	await pageEditorPage.addFragment('Content Display', 'Collection Display');
+
+	await pageEditorPage.selectFragment(
+		await pageEditorPage.getFragmentId('Collection Display')
+	);
+
+	await pageEditorPage.chooseCollectionDisplayCollection(
+		'Collections',
+		collectionTitle,
+		{search: true}
+	);
+
+	await pageEditorPage.waitForChangesSaved();
+
+	// Drop a Heading into the collection item and map it to the entry field
+
+	await pageEditorPage.addFragment(
+		'Basic Components',
+		'Heading',
+		page.locator('.page-editor__collection-item.empty').first()
+	);
+
+	await pageEditorPage.goToSidebarTab('Browser');
+
+	await page.getByLabel('Select element-text').click();
+
+	await page.getByLabel('Field').selectOption({label: fieldLabel});
+
+	await pageEditorPage.waitForChangesSaved();
+
+	await pageEditorPage.publishPage();
+
+	return {
+		layout,
+		viewURL: `${liferayConfig.environment.baseUrl}/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`,
+	};
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95530

## What Is Being Fixed

The CMS-on-DXP epic had no automated coverage for displaying CMS content (Basic Web Content, custom structures, and files held in a Space) on a DXP site page through a Collection Display fragment. This adds that coverage and, in doing so, surfaced a product defect in collection tag filtering.

## How It Is Being Fixed

Adds a Playwright suite (collectionDisplay.spec.ts) plus shared helpers for the Collections scenarios (TC-6.a-k). Each scenario is verified faithfully on the published page as an anonymous Guest: content and Spaces are created via apiHelpers, categories are assigned with the writable taxonomyCategoryIds field, manual collections are built through the asset-list JSON web services and tag/category-filtered collections through the Collections editor UI, and a Heading mapped to the entry Title renders the items. Nine scenarios pass (manual ordering, dynamic filtering by content type and by category, live update on edit, and removal on delete).

The tag-filter scenario (TC-6.d) is kept as a faithful failing test: a collection filtered by a tag returns no CMS content on the published page even though a category filter on the same setup works. That defect is filed as LPD-96296, and the combined category+tag+type scenario (TC-6.h) is left out as it depends on the same behavior.

## PR Check

**pr-check: PASS** — tested on `2dd83dd6f45d44a82a9156eb46232d162ff17496`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is limited to the Playwright test harness (modules/test/playwright). Per-Module Compile and JavaScript Unit Tests matched by path but were not run: they target deployable OSGi modules / Jest suites, whereas these are Playwright tests (out of pr-check scope).

<!-- pr-check {"result": "success", "sha": "2dd83dd6f45d44a82a9156eb46232d162ff17496"} -->
