### PR TITLE
LPD-96232 Redirect signed in users to the CMS

### DIFF
--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/events/CMSServicePreAction.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/events/CMSServicePreAction.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.events;
+
+import com.liferay.portal.kernel.events.Action;
+import com.liferay.portal.kernel.events.ActionException;
+import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez Álvarez
+ */
+@Component(
+	property = "key=servlet.service.events.pre", service = LifecycleAction.class
+)
+public class CMSServicePreAction extends Action {
+
+	@Override
+	public void run(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws ActionException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if ((themeDisplay == null) || !themeDisplay.isSignedIn() ||
+			!StringUtil.endsWith(
+				httpServletRequest.getRequestURI(),
+				Portal.PATH_PORTAL_LAYOUT)) {
+
+			return;
+		}
+
+		Group scopeGroup = themeDisplay.getScopeGroup();
+
+		if (!scopeGroup.isGuest() ||
+			!FeatureFlagManagerUtil.isEnabled(
+				themeDisplay.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		try {
+			httpServletResponse.sendRedirect(
+				_portal.getPathContext() + "/web/cms");
+		}
+		catch (IOException ioException) {
+			throw new ActionException(ioException);
+		}
+	}
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/test/java/com/liferay/site/cms/standalone/site/initializer/internal/events/CMSServicePreActionTest.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/test/java/com/liferay/site/cms/standalone/site/initializer/internal/events/CMSServicePreActionTest.java
@@ -1,0 +1,232 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.events;
+
+import com.liferay.portal.kernel.events.ActionException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Adolfo Pérez Álvarez
+ */
+public class CMSServicePreActionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+			FeatureFlagManagerUtil.class);
+	}
+
+	@After
+	public void tearDown() {
+		_featureFlagManagerUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testRun() throws Exception {
+		_testRunRedirectsToCMS();
+		_testRunWhenFeatureFlagIsDisabled();
+		_testRunWhenRequestURIIsNotLayout();
+		_testRunWhenScopeGroupIsNotGuest();
+		_testRunWhenSendRedirectFails();
+		_testRunWhenThemeDisplayIsNull();
+		_testRunWhenUserIsNotSignedIn();
+	}
+
+	private void _assertRunDoesNotRedirect() throws Exception {
+		_cmsServicePreAction.run(_httpServletRequest, _httpServletResponse);
+
+		Mockito.verify(
+			_httpServletResponse, Mockito.never()
+		).sendRedirect(
+			Mockito.anyString()
+		);
+	}
+
+	private void _setUpMocks() {
+		_featureFlagManagerUtilMockedStatic.when(
+			() -> FeatureFlagManagerUtil.isEnabled(
+				Mockito.anyLong(), Mockito.eq("LPD-17564"))
+		).thenReturn(
+			true
+		);
+
+		_group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			_group.isGuest()
+		).thenReturn(
+			true
+		);
+
+		_themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			_themeDisplay.isSignedIn()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_themeDisplay.getScopeGroup()
+		).thenReturn(
+			_group
+		);
+
+		_httpServletRequest = Mockito.mock(HttpServletRequest.class);
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_themeDisplay
+		);
+
+		Mockito.when(
+			_httpServletRequest.getRequestURI()
+		).thenReturn(
+			"/c" + Portal.PATH_PORTAL_LAYOUT
+		);
+
+		_httpServletResponse = Mockito.mock(HttpServletResponse.class);
+
+		Portal portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			portal.getPathContext()
+		).thenReturn(
+			""
+		);
+
+		_cmsServicePreAction = new CMSServicePreAction();
+
+		ReflectionTestUtil.setFieldValue(
+			_cmsServicePreAction, "_portal", portal);
+	}
+
+	private void _testRunRedirectsToCMS() throws Exception {
+		_setUpMocks();
+
+		_cmsServicePreAction.run(_httpServletRequest, _httpServletResponse);
+
+		Mockito.verify(
+			_httpServletResponse
+		).sendRedirect(
+			"/web/cms"
+		);
+	}
+
+	private void _testRunWhenFeatureFlagIsDisabled() throws Exception {
+		_setUpMocks();
+
+		_featureFlagManagerUtilMockedStatic.when(
+			() -> FeatureFlagManagerUtil.isEnabled(
+				Mockito.anyLong(), Mockito.eq("LPD-17564"))
+		).thenReturn(
+			false
+		);
+
+		_assertRunDoesNotRedirect();
+	}
+
+	private void _testRunWhenRequestURIIsNotLayout() throws Exception {
+		_setUpMocks();
+
+		Mockito.when(
+			_httpServletRequest.getRequestURI()
+		).thenReturn(
+			"/c/portal/logout"
+		);
+
+		_assertRunDoesNotRedirect();
+	}
+
+	private void _testRunWhenScopeGroupIsNotGuest() throws Exception {
+		_setUpMocks();
+
+		Mockito.when(
+			_group.isGuest()
+		).thenReturn(
+			false
+		);
+
+		_assertRunDoesNotRedirect();
+	}
+
+	private void _testRunWhenSendRedirectFails() throws Exception {
+		_setUpMocks();
+
+		Mockito.doThrow(
+			new IOException()
+		).when(
+			_httpServletResponse
+		).sendRedirect(
+			Mockito.anyString()
+		);
+
+		Assert.assertThrows(
+			ActionException.class,
+			() -> _cmsServicePreAction.run(
+				_httpServletRequest, _httpServletResponse));
+	}
+
+	private void _testRunWhenThemeDisplayIsNull() throws Exception {
+		_setUpMocks();
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			null
+		);
+
+		_assertRunDoesNotRedirect();
+	}
+
+	private void _testRunWhenUserIsNotSignedIn() throws Exception {
+		_setUpMocks();
+
+		Mockito.when(
+			_themeDisplay.isSignedIn()
+		).thenReturn(
+			false
+		);
+
+		_assertRunDoesNotRedirect();
+	}
+
+	private CMSServicePreAction _cmsServicePreAction;
+	private MockedStatic<FeatureFlagManagerUtil>
+		_featureFlagManagerUtilMockedStatic;
+	private Group _group;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
+	private ThemeDisplay _themeDisplay;
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
@@ -66,9 +66,9 @@ definition {
 				-d privateLayout=false
 		''';
 
-		var liveLayoutId = JSONCurlUtil.post(${liveLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+		var liveLayoutNames = JSONCurlUtil.post(${liveLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 
-		if (${liveLayoutId} != "") {
+		if (${liveLayoutNames} != "") {
 			var stagingLayoutsCurl = '''
 				${portalURL}/api/jsonws/layout/get-layouts \
 					-u ${userLoginInfo} \
@@ -76,10 +76,10 @@ definition {
 					-d privateLayout=false
 			''';
 
-			var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+			var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 
-			while ((${stagingLayoutId} == "")) {
-				var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+			while (${stagingLayoutNames} != ${liveLayoutNames}) {
+				var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96232

## What Is Being Fixed

In the CMS standalone bundle, a signed-in user who opened the login page — directly via /web/guest or via the default URL — was shown the login page in a signed-in state instead of being taken into the CMS.

## How It Is Being Fixed

Adds a servlet.service.events.pre lifecycle action (CMSServicePreAction) to the CMS standalone site initializer module. When a signed-in user renders a Guest site page and the LPD-17564 feature flag is enabled, it redirects to /web/cms. The guards are ordered cheapest-first and limited to real page renders (request URI ending in /portal/layout), so control requests such as /c/portal/logout are not intercepted and logout keeps working.

## PR Check

**pr-check: PASS** — tested on `69884947a8398cf3ac576dc083dfdadb4e020442`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "69884947a8398cf3ac576dc083dfdadb4e020442"} -->
