### PR TITLE
LPD-94445 Adapt the CMS gallery view to the design mockups

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
@@ -1,9 +1,14 @@
 @import 'atlas-variables';
 
 .fds-gallery-view {
-	$gallery-preview-height: unquote('max(320px, calc(100dvh - 475px))');
-	$gallery-thumbnail-gap: 1rem;
+	$gallery-preview-height: unquote(
+		'clamp(320px, calc(100dvh - 475px), 100cqw)'
+	);
+	$gallery-thumbnail-gap: $spacer;
 	$gallery-thumbnail-width: 190px;
+
+	// stylelint-disable-next-line property-no-unknown
+	container-type: inline-size;
 
 	&__preview {
 		height: $gallery-preview-height;
@@ -11,14 +16,14 @@
 		.c-empty-state {
 			align-self: center;
 			margin: 0;
-		}
 
-		.c-empty-state-image {
-			max-width: 200px;
-		}
+			&-image {
+				max-width: 200px;
+			}
 
-		.c-empty-state-title {
-			margin-top: 1rem;
+			&-title {
+				margin-top: $spacer;
+			}
 		}
 
 		&-wrapper > * {
@@ -31,30 +36,44 @@
 		}
 	}
 
-	.preview-file .preview-file-container.preview-file-max-height {
+	.preview-file {
+		display: flex;
+		flex-direction: column;
 		height: $gallery-preview-height;
-		max-height: 100%;
+
+		.preview-file-container.preview-file-max-height {
+			flex: 1 1 auto;
+			height: auto;
+			max-height: 100%;
+			min-height: 0;
+		}
+
+		.preview-toolbar-container {
+			bottom: auto;
+			position: relative;
+			top: auto;
+		}
 	}
 
-	.fds-gallery-view__thumbnails {
-		gap: $gallery-thumbnail-gap;
-		justify-content: center;
-		min-width: 0;
-	}
+	.fds-gallery-view {
+		&__thumbnails {
+			gap: $gallery-thumbnail-gap;
+			min-width: 0;
+		}
+		&__thumbnail {
+			flex: 0 0 $gallery-thumbnail-width;
+			max-width: $gallery-thumbnail-width;
 
-	.fds-gallery-view__thumbnail {
-		flex: 0 0 $gallery-thumbnail-width;
-		max-width: $gallery-thumbnail-width;
-
-		&.drop-target {
-			.card {
+			&.drop-target .card {
 				background-color: $info-l2;
 				box-shadow: 0 0 0 2px $info;
 			}
-		}
 
-		&.selected {
-			.card {
+			.form-check-card {
+				margin-bottom: 0;
+			}
+
+			&.selected .card {
 				box-shadow: 0 0 0 2px $primary-l1;
 			}
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
@@ -2,6 +2,8 @@
 
 .fds-gallery-view {
 	$gallery-preview-height: unquote('max(320px, calc(100dvh - 475px))');
+	$gallery-thumbnail-gap: 1rem;
+	$gallery-thumbnail-width: 190px;
 
 	&__preview {
 		height: $gallery-preview-height;
@@ -35,11 +37,14 @@
 	}
 
 	.fds-gallery-view__thumbnails {
+		gap: $gallery-thumbnail-gap;
+		justify-content: center;
 		min-width: 0;
 	}
 
 	.fds-gallery-view__thumbnail {
-		max-width: 20%;
+		flex: 0 0 $gallery-thumbnail-width;
+		max-width: $gallery-thumbnail-width;
 
 		&.drop-target {
 			.card {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/hooks/useResizeObserver.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/hooks/useResizeObserver.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {RefObject, useEffect, useRef} from 'react';
+
+export default function useResizeObserver(
+	ref: RefObject<HTMLElement>,
+	onResize: (element: HTMLElement) => void
+) {
+	const onResizeRef = useRef(onResize);
+
+	useEffect(() => {
+		onResizeRef.current = onResize;
+	}, [onResize]);
+
+	useEffect(() => {
+		const element = ref.current;
+
+		if (!element) {
+			return;
+		}
+
+		const resizeObserver = new ResizeObserver(() =>
+			onResizeRef.current(element)
+		);
+
+		resizeObserver.observe(element);
+
+		onResizeRef.current(element);
+
+		return () => resizeObserver.disconnect();
+	}, [ref]);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
@@ -19,6 +19,7 @@ import React, {Context, useContext, useEffect, useRef, useState} from 'react';
 import {useDropzone} from 'react-dropzone';
 
 import AssetPreview from '../../../common/components/AssetPreview';
+import useResizeObserver from '../../../common/hooks/useResizeObserver';
 
 import '../../../../css/props_transformer/GalleryView.scss';
 
@@ -51,31 +52,15 @@ const GalleryView = ({
 		Math.max(0, items.length - 1)
 	);
 
-	useEffect(() => {
-		const container = thumbnailsRef.current;
+	useResizeObserver(thumbnailsRef, (element) => {
+		const {width} = element.getBoundingClientRect();
 
-		if (!container) {
-			return;
-		}
+		const fittingCount = Math.floor(
+			(width + THUMBNAIL_GAP) / (THUMBNAIL_WIDTH + THUMBNAIL_GAP)
+		);
 
-		const updateVisibleItemsCount = () => {
-			const {width} = container.getBoundingClientRect();
-
-			const fittingCount = Math.floor(
-				(width + THUMBNAIL_GAP) / (THUMBNAIL_WIDTH + THUMBNAIL_GAP)
-			);
-
-			setVisibleItemsCount(Math.max(1, fittingCount));
-		};
-
-		updateVisibleItemsCount();
-
-		const resizeObserver = new ResizeObserver(updateVisibleItemsCount);
-
-		resizeObserver.observe(container);
-
-		return () => resizeObserver.disconnect();
-	}, []);
+		setVisibleItemsCount(Math.max(1, fittingCount));
+	});
 
 	useEffect(() => {
 		setVisibleStartIndex((start) => {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/views/GalleryView.tsx
@@ -3,29 +3,28 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {ClayButtonWithIcon} from '@clayui/button';
 import ClayEmptyState from '@clayui/empty-state';
 import {
 	Card,
 	ICardSchema,
 	IFileDropSettings,
 } from '@liferay/frontend-data-set-web';
-import React, {Context, useContext, useMemo, useState} from 'react';
-import {useDropzone} from 'react-dropzone';
-
-import '../../../../css/props_transformer/GalleryView.scss';
-
-import {ClayButtonWithIcon} from '@clayui/button';
 
 // eslint-disable-next-line
 import {IFrontendDataSetContext} from '@liferay/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext';
 import classNames from 'classnames';
 import {getObjectValueFromPath, sub} from 'frontend-js-web';
+import React, {Context, useContext, useEffect, useRef, useState} from 'react';
+import {useDropzone} from 'react-dropzone';
 
 import AssetPreview from '../../../common/components/AssetPreview';
 
-const VISIBLE_ITEMS_COUNT = 5;
-const MAX_VISIBLE_INDEX = (itemsLength: number) =>
-	Math.max(0, itemsLength - VISIBLE_ITEMS_COUNT);
+import '../../../../css/props_transformer/GalleryView.scss';
+
+const THUMBNAIL_WIDTH = 190;
+const THUMBNAIL_GAP = 16;
+const DEFAULT_VISIBLE_ITEMS_COUNT = 5;
 
 const GalleryView = ({
 	fileDropSettings,
@@ -42,73 +41,71 @@ const GalleryView = ({
 	const {selectedItems} = useContext(frontendDataSetContext);
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const [visibleStartIndex, setVisibleStartIndex] = useState(0);
+	const [visibleItemsCount, setVisibleItemsCount] = useState(
+		DEFAULT_VISIBLE_ITEMS_COUNT
+	);
+	const thumbnailsRef = useRef<HTMLDivElement>(null);
+
+	const safeSelectedIndex = Math.min(
+		selectedIndex,
+		Math.max(0, items.length - 1)
+	);
+
+	useEffect(() => {
+		const container = thumbnailsRef.current;
+
+		if (!container) {
+			return;
+		}
+
+		const updateVisibleItemsCount = () => {
+			const {width} = container.getBoundingClientRect();
+
+			const fittingCount = Math.floor(
+				(width + THUMBNAIL_GAP) / (THUMBNAIL_WIDTH + THUMBNAIL_GAP)
+			);
+
+			setVisibleItemsCount(Math.max(1, fittingCount));
+		};
+
+		updateVisibleItemsCount();
+
+		const resizeObserver = new ResizeObserver(updateVisibleItemsCount);
+
+		resizeObserver.observe(container);
+
+		return () => resizeObserver.disconnect();
+	}, []);
+
+	useEffect(() => {
+		setVisibleStartIndex((start) => {
+			const maxStart = Math.max(0, items.length - visibleItemsCount);
+
+			if (safeSelectedIndex < start) {
+				return safeSelectedIndex;
+			}
+
+			if (safeSelectedIndex >= start + visibleItemsCount) {
+				return Math.min(
+					safeSelectedIndex - visibleItemsCount + 1,
+					maxStart
+				);
+			}
+
+			return Math.min(start, maxStart);
+		});
+	}, [items.length, safeSelectedIndex, visibleItemsCount]);
 
 	const handlePrevClick = () => {
-		const itemsLength = items.length;
-
-		let newSelectedIndex;
-		let newVisibleIndex;
-
-		if (selectedIndex === 0) {
-			newSelectedIndex = itemsLength - 1;
-			newVisibleIndex = MAX_VISIBLE_INDEX(itemsLength);
-		}
-		else {
-			newSelectedIndex = selectedIndex - 1;
-			newVisibleIndex = visibleStartIndex;
-
-			if (newSelectedIndex < visibleStartIndex) {
-				newVisibleIndex = visibleStartIndex - 1;
-			}
-		}
-
-		setSelectedIndex(newSelectedIndex);
-		setVisibleStartIndex(newVisibleIndex);
+		setSelectedIndex(
+			safeSelectedIndex === 0 ? items.length - 1 : safeSelectedIndex - 1
+		);
 	};
 
 	const handleNextClick = () => {
-		const itemsLength = items.length;
-		const maxVisibleIndex = MAX_VISIBLE_INDEX(itemsLength);
-
-		let newSelectedIndex;
-		let newVisibleIndex;
-
-		if (selectedIndex === itemsLength - 1) {
-			newSelectedIndex = 0;
-			newVisibleIndex = 0;
-		}
-		else {
-			newSelectedIndex = selectedIndex + 1;
-			newVisibleIndex = visibleStartIndex;
-
-			if (newSelectedIndex >= visibleStartIndex + VISIBLE_ITEMS_COUNT) {
-				newVisibleIndex = Math.min(
-					maxVisibleIndex,
-					visibleStartIndex + 1
-				);
-			}
-		}
-
-		setSelectedIndex(newSelectedIndex);
-		setVisibleStartIndex(newVisibleIndex);
-	};
-
-	const handleItemClick = (index: number) => {
-		setSelectedIndex(index);
-
-		const itemsLength = items.length;
-		const maxVisibleIndex = MAX_VISIBLE_INDEX(itemsLength);
-
-		if (itemsLength > VISIBLE_ITEMS_COUNT) {
-			if (index < visibleStartIndex) {
-				setVisibleStartIndex(index);
-			}
-			else if (index >= visibleStartIndex + VISIBLE_ITEMS_COUNT) {
-				setVisibleStartIndex(
-					Math.min(maxVisibleIndex, index - VISIBLE_ITEMS_COUNT + 1)
-				);
-			}
-		}
+		setSelectedIndex(
+			safeSelectedIndex === items.length - 1 ? 0 : safeSelectedIndex + 1
+		);
 	};
 
 	const handleKeyDown = (event: React.KeyboardEvent, index: number) => {
@@ -118,21 +115,16 @@ const GalleryView = ({
 
 		if (event.key === 'Enter' || event.key === ' ') {
 			event.preventDefault();
-			handleItemClick(index);
+			setSelectedIndex(index);
 		}
 	};
 
 	const visibleItems = items.slice(
 		visibleStartIndex,
-		visibleStartIndex + VISIBLE_ITEMS_COUNT
+		visibleStartIndex + visibleItemsCount
 	);
 
-	const currentItem = useMemo(
-		() => items[selectedIndex],
-		[items, selectedIndex]
-	);
-
-	const cardWidth = `calc((100% - ${VISIBLE_ITEMS_COUNT - 1}rem) / ${VISIBLE_ITEMS_COUNT})`;
+	const currentItem = items[safeSelectedIndex];
 
 	const isNavigationDisabled = items.length === 1;
 
@@ -155,7 +147,7 @@ const GalleryView = ({
 					) : (
 						<AssetPreview
 							item={currentItem}
-							key={selectedIndex}
+							key={safeSelectedIndex}
 							showContentPreview={false}
 							url=""
 						/>
@@ -174,23 +166,25 @@ const GalleryView = ({
 					symbol="angle-left"
 				/>
 
-				<div className="c-gap-3 d-flex fds-gallery-view__thumbnails flex-grow-1">
+				<div
+					className="d-flex fds-gallery-view__thumbnails flex-grow-1 justify-content-center mb-3"
+					ref={thumbnailsRef}
+				>
 					{visibleItems.map((item, index) => {
 						const actualIndex = visibleStartIndex + index;
 
 						return (
 							<GalleryThumbnail
-								cardWidth={cardWidth}
 								fileDropSettings={fileDropSettings}
 								item={item}
 								items={items}
-								key={actualIndex}
-								onClick={() => handleItemClick(actualIndex)}
+								key={item.id}
+								onClick={() => setSelectedIndex(actualIndex)}
 								onKeyDown={(event) =>
 									handleKeyDown(event, actualIndex)
 								}
 								schema={schema}
-								selected={actualIndex === selectedIndex}
+								selected={actualIndex === safeSelectedIndex}
 								{...otherProps}
 							/>
 						);
@@ -214,7 +208,6 @@ const GalleryView = ({
 export default GalleryView;
 
 function GalleryThumbnail({
-	cardWidth,
 	fileDropSettings,
 	item,
 	items,
@@ -224,7 +217,6 @@ function GalleryThumbnail({
 	selected,
 	...otherProps
 }: {
-	cardWidth: string;
 	fileDropSettings?: IFileDropSettings;
 	item: any;
 	items: any[];
@@ -267,9 +259,6 @@ function GalleryThumbnail({
 			})}
 			onClick={onClick}
 			onKeyDown={onKeyDown}
-			style={{
-				width: cardWidth,
-			}}
 			tabIndex={0}
 		>
 			<Card item={item} items={items} schema={schema} {...otherProps} />

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/views/GalleryView.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/views/GalleryView.test.tsx
@@ -40,6 +40,29 @@ const mockLiferayLanguageGet = jest.fn((key: string) => key);
 	},
 };
 
+class MockResizeObserver {
+	disconnect() {}
+	observe() {}
+	unobserve() {}
+}
+
+(global as any).ResizeObserver = MockResizeObserver;
+
+HTMLElement.prototype.getBoundingClientRect = jest.fn(
+	() =>
+		({
+			bottom: 0,
+			height: 0,
+			left: 0,
+			right: 1100,
+			toJSON: () => ({}),
+			top: 0,
+			width: 1100,
+			x: 0,
+			y: 0,
+		}) as DOMRect
+);
+
 const mockItems = Array.from({length: 10}, (_, i) => ({
 	id: `item-${i}`,
 	title: `Item ${i}`,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/views/GalleryView.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/views/GalleryView.test.tsx
@@ -48,16 +48,18 @@ class MockResizeObserver {
 
 (global as any).ResizeObserver = MockResizeObserver;
 
+let mockThumbnailsWidth = 1100;
+
 HTMLElement.prototype.getBoundingClientRect = jest.fn(
 	() =>
 		({
 			bottom: 0,
 			height: 0,
 			left: 0,
-			right: 1100,
+			right: mockThumbnailsWidth,
 			toJSON: () => ({}),
 			top: 0,
-			width: 1100,
+			width: mockThumbnailsWidth,
 			x: 0,
 			y: 0,
 		}) as DOMRect
@@ -76,6 +78,7 @@ describe('GalleryView', () => {
 	let frontendDataSetContext: Context<any>;
 
 	beforeEach(() => {
+		mockThumbnailsWidth = 1100;
 		frontendDataSetContext = createContext({
 			selectedItems: [],
 		});
@@ -94,6 +97,34 @@ describe('GalleryView', () => {
 		expect(screen.getAllByTestId('card-item').length).toBe(5);
 		expect(screen.getAllByTestId('card-item')[0]).toHaveTextContent(
 			'item-0'
+		);
+	});
+
+	describe('the number of thumbnails shown per container width', () => {
+		it.each([
+			{expectedCount: 1, width: 300},
+			{expectedCount: 2, width: 450},
+			{expectedCount: 3, width: 700},
+			{expectedCount: 4, width: 900},
+			{expectedCount: 5, width: 1100},
+			{expectedCount: 6, width: 1300},
+		])(
+			'shows $expectedCount thumbnails when the strip is $width px wide',
+			({expectedCount, width}) => {
+				mockThumbnailsWidth = width;
+
+				render(
+					<GalleryView
+						frontendDataSetContext={frontendDataSetContext}
+						items={mockItems}
+						schema={mockSchema}
+					/>
+				);
+
+				expect(screen.getAllByTestId('card-item')).toHaveLength(
+					expectedCount
+				);
+			}
 		);
 	});
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
@@ -457,7 +457,9 @@ test(
 
 			await expect(page.getByRole('dialog')).toBeVisible();
 
-			await expect(page.getByText(imageName)).toBeVisible();
+			await expect(page.getByTestId('modal-header-name')).toHaveText(
+				imageName
+			);
 			await expect(
 				page.getByRole('link', {name: 'Download'})
 			).toBeVisible();

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
@@ -66,9 +66,9 @@ definition {
 				-d privateLayout=false
 		''';
 
-		var liveLayoutId = JSONCurlUtil.post(${liveLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+		var liveLayoutNames = JSONCurlUtil.post(${liveLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 
-		if (${liveLayoutId} != "") {
+		if (${liveLayoutNames} != "") {
 			var stagingLayoutsCurl = '''
 				${portalURL}/api/jsonws/layout/get-layouts \
 					-u ${userLoginInfo} \
@@ -76,10 +76,10 @@ definition {
 					-d privateLayout=false
 			''';
 
-			var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+			var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 
-			while ((${stagingLayoutId} == "")) {
-				var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+			while (${stagingLayoutNames} != ${liveLayoutNames}) {
+				var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94445

## What Is Being Fixed

The CMS Files gallery view did not match the design mockups: the thumbnail cards stretched or collapsed at different widths, the preview pane reserved a disproportionately tall area on narrow viewports (leaving a large empty space above the content), and the document-library zoom toolbar overlapped the previewed image.

## How It Is Being Fixed

Thumbnails now keep a fixed width and the view renders only the ones that fully fit the container — computed from the strip width with a ResizeObserver — while the rest stay reachable through the navigation arrows as a sliding-window carousel. The selection logic was simplified to a single derived, range-clamped index. The preview pane height is capped relative to its own width through a container query, so it still fills the viewport height on wide layouts but never grows disproportionately tall on narrow ones, and the zoom toolbar now flows just below the preview instead of floating over it. The ResizeObserver lifecycle was extracted into a reusable useResizeObserver hook. Jest tests were added that assert the number of thumbnails shown for each container width.

## PR Check

**pr-check: PASS** — tested on `77c3a171c1fe9103e37120427f9a4a21120fea1a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "77c3a171c1fe9103e37120427f9a4a21120fea1a"} -->
