### PR TITLE
LPD-96295 Add missing feature flag check on deleteDepotEntry

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
@@ -119,7 +119,10 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 
 		DepotEntry depotEntry = getDepotEntry(depotEntryId);
 
-		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
+		if (FeatureFlagManagerUtil.isEnabled(
+				depotEntry.getCompanyId(), "LPD-17564") &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
+
 			ObjectEntryFolderUtil.deleteObjectEntryFolders(depotEntry);
 
 			_deleteCMSDefaultPermissions(depotEntry.getGroup());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96295

## What Is Being Fixed

The `deleteDepotEntry(long)` override in `CMSObjectEntryFolderDepotEntryLocalServiceWrapper` was missing the `LPD-17564` feature flag guard that its three sibling overrides (`addDepotEntry` x2 and `deleteDepotEntry(DepotEntry)`) already have. As a result, on that deletion path the CMS object-entry-folder cleanup and default-permission removal ran unconditionally, even with the feature off. Because `GroupModelListener.onAfterRemove` deletes the depot entry in a transaction-commit callback that fires after the group is already gone, the unguarded `depotEntry.getGroup()` call threw `NoSuchGroupException`, which logged an ERROR and failed `PortalLogAssertorTest`.

## How It Is Being Fixed

Wrap the `DepotConstants.TYPE_SPACE` block in `deleteDepotEntry(long)` with the same `FeatureFlagManagerUtil.isEnabled(depotEntry.getCompanyId(), "LPD-17564")` check used by the other three overrides, bringing this overload in line with its siblings.

## Why Are There No Tests?

This change only adds a feature flag guard already present and tested on the sibling methods; it introduces no new behavior. The guarded paths are exercised by the existing `site-cms-site-initializer` integration tests.

## PR Check

**pr-check: PASS** — tested on `844a8c42e00fa78321ce89964a02f4b6c1bb9fad`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "844a8c42e00fa78321ce89964a02f4b6c1bb9fad"} -->
