### PR TITLE
LPD-95534 Add Playwright tests for Space setup and configuration

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -189,15 +189,14 @@ public abstract class SecretsUtil {
 	}
 
 	private static byte[] _convertPEMToDER(String pem) {
-		String base64 = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----END [^-]+-----", "");
 
-		base64 = base64.replaceAll("-----END [^-]+-----", "");
-
-		base64 = base64.replaceAll("\\s", "");
+		pem = pem.replaceAll("\\s", "");
 
 		Base64.Decoder decoder = Base64.getDecoder();
 
-		return decoder.decode(base64);
+		return decoder.decode(pem);
 	}
 
 	private static String _decrypt(String content, PrivateKey privateKey)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -10,7 +10,6 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthoriza
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
 
 import java.nio.charset.StandardCharsets;
 
@@ -28,9 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -70,8 +66,14 @@ public abstract class SecretsUtil {
 	public static String getSecret(
 		String vaultName, String itemTitle, String fieldLabel) {
 
-		String cachedSecret = _getCachedSecret(
-			_getSecretReference(vaultName, itemTitle, fieldLabel));
+		String secretReference = _getSecretReference(
+			vaultName, itemTitle, fieldLabel);
+
+		if (_secrets.containsKey(secretReference)) {
+			return _secrets.get(secretReference);
+		}
+
+		String cachedSecret = _getCachedSecret(secretReference);
 
 		if (cachedSecret != null) {
 			return cachedSecret;
@@ -90,8 +92,7 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
-	public static void writeCachedSecrets(
-			File cachedSecretsFile, File rootDirectory)
+	public static void writeCachedSecrets(File cachedSecretsFile)
 		throws IOException {
 
 		if (!_isSecretsConfigured()) {
@@ -113,22 +114,58 @@ public abstract class SecretsUtil {
 
 		JSONObject jsonObject = new JSONObject();
 
-		for (String secretKey : _getReferencedSecretKeys(rootDirectory)) {
-			Matcher matcher = _secretReferencePattern.matcher(secretKey);
+		for (Vault vault : Vault.getInstances()) {
+			String vaultName = vault.getName();
 
-			if (!matcher.matches()) {
-				continue;
-			}
+			for (Item item : vault.getItems()) {
+				String itemId = item.getId();
+				String itemTitle = item.getTitle();
 
-			String secret = _getSecretFromConnect(
-				matcher.group("vaultName"), matcher.group("itemTitle"),
-				matcher.group("fieldLabel"));
+				for (ItemField itemField : item.getItemFields()) {
+					String itemFieldValue = itemField.getValue();
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
-				jsonObject.put(secretKey, secret);
-			}
-			else {
-				System.out.println("Unable to resolve secret: " + secretKey);
+					if (JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
+
+						continue;
+					}
+
+					String itemFieldLabel = itemField.getLabel();
+					String itemFieldId = itemField.getId();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemId, itemFieldLabel),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(
+							vaultName, itemTitle, itemFieldLabel),
+						itemFieldValue
+					);
+				}
+
+				for (ItemFile itemFile : item.getItemFiles()) {
+					String itemFileValue = itemFile.getValue();
+
+					if (JenkinsResultsParserUtil.isNullOrEmpty(itemFileValue)) {
+						continue;
+					}
+
+					String itemFileName = itemFile.getName();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFileName),
+						itemFileValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFileName),
+						itemFileValue
+					);
+				}
 			}
 		}
 
@@ -565,38 +602,6 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
-	private static Set<String> _getReferencedSecretKeys(File rootDirectory) {
-		Set<String> secretKeys = new TreeSet<>();
-
-		List<File> propertiesFiles = JenkinsResultsParserUtil.findFiles(
-			rootDirectory, ".*\\.properties");
-
-		for (File propertiesFile : propertiesFiles) {
-			Properties properties = new Properties();
-
-			try {
-				String content = JenkinsResultsParserUtil.read(propertiesFile);
-
-				if (!JenkinsResultsParserUtil.isNullOrEmpty(content)) {
-					properties.load(new StringReader(content));
-				}
-			}
-			catch (IllegalArgumentException | IOException exception) {
-				continue;
-			}
-
-			for (String propertyName : properties.stringPropertyNames()) {
-				String value = properties.getProperty(propertyName);
-
-				if (isSecretProperty(value)) {
-					secretKeys.add(value);
-				}
-			}
-		}
-
-		return secretKeys;
-	}
-
 	private static String _getSecretFromConnect(
 		String vaultName, String itemTitle, String fieldLabel) {
 
@@ -622,12 +627,7 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
-		String secretReference = _getSecretReference(
-			vaultName, itemTitle, fieldLabel);
-
-		if (_secrets.containsKey(secretReference)) {
-			return _secrets.get(secretReference);
-		}
+		String itemId = item.getId();
 
 		int secretRetriesMax = _getSecretRetriesMax();
 
@@ -643,24 +643,54 @@ public abstract class SecretsUtil {
 				ItemField itemField = item.getItemField(fieldLabel);
 
 				if (itemField != null) {
-					String value = itemField.getValue();
+					String itemFieldValue = itemField.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
 
-						return value;
+						String itemFieldId = itemField.getId();
+						String itemFieldLabel = itemField.getLabel();
+
+						_secrets.put(
+							_getSecretReference(vaultName, itemId, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFieldLabel),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldLabel),
+							itemFieldValue);
+
+						return itemFieldValue;
 					}
 				}
 
 				ItemFile itemFile = item.getItemFile(fieldLabel);
 
 				if (itemFile != null) {
-					String value = itemFile.getValue();
+					String itemFileValue = itemFile.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFileValue)) {
 
-						return value;
+						String itemFileName = itemFile.getName();
+
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFileName),
+							itemFileValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFileName),
+							itemFileValue);
+
+						return itemFileValue;
 					}
 				}
 			}
@@ -915,6 +945,16 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemField> getItemFields() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+
+				return _itemFields;
+			}
+		}
+
 		public ItemFile getItemFile(String fileName) {
 			List<ItemFile> itemFiles;
 
@@ -939,8 +979,26 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemFile> getItemFiles() {
+			synchronized (_vault) {
+				if (_itemFiles == null) {
+					_init();
+				}
+
+				return _itemFiles;
+			}
+		}
+
 		public String getTitle() {
 			return _title;
+		}
+
+		public void load() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+			}
 		}
 
 		public void refresh() {
@@ -1122,7 +1180,23 @@ public abstract class SecretsUtil {
 	private static class Vault {
 
 		public static Vault getInstance(String name) {
-			return _vaultsMap.get(name);
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			return vaultsMap.get(name);
+		}
+
+		public static List<Vault> getInstances() {
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			List<Vault> vaults = new ArrayList<>();
+
+			for (Vault vault : vaultsMap.values()) {
+				if (!vaults.contains(vault)) {
+					vaults.add(vault);
+				}
+			}
+
+			return vaults;
 		}
 
 		public String getId() {
@@ -1147,8 +1221,62 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<Item> getItems() {
+			synchronized (_vaultsMap) {
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			return _items;
+		}
+
 		public String getName() {
 			return _name;
+		}
+
+		public void loadAllItems() {
+			synchronized (_vaultsMap) {
+				if (_allItemsLoaded) {
+					return;
+				}
+
+				_allItemsLoaded = true;
+
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			for (Item item : _items) {
+				item.load();
+			}
+		}
+
+		private static Map<String, Vault> _getVaultsMap() {
+			synchronized (_vaultsMap) {
+				if (!_vaultsMap.isEmpty()) {
+					return _vaultsMap;
+				}
+
+				JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
+
+				for (int i = 0; i < vaultsJSONArray.length(); i++) {
+					JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(
+						i);
+
+					Vault vault = new Vault(
+						vaultJSONObject.getString("id"),
+						vaultJSONObject.getString("name"));
+
+					_vaultsMap.put(vault.getId(), vault);
+					_vaultsMap.put(vault.getName(), vault);
+
+					vault.loadAllItems();
+				}
+			}
+
+			return _vaultsMap;
 		}
 
 		private Vault(String id, String name) {
@@ -1175,21 +1303,7 @@ public abstract class SecretsUtil {
 
 		private static final Map<String, Vault> _vaultsMap = new HashMap<>();
 
-		static {
-			JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
-
-			for (int i = 0; i < vaultsJSONArray.length(); i++) {
-				JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(i);
-
-				Vault vault = new Vault(
-					vaultJSONObject.getString("id"),
-					vaultJSONObject.getString("name"));
-
-				_vaultsMap.put(vault.getId(), vault);
-				_vaultsMap.put(vault.getName(), vault);
-			}
-		}
-
+		private boolean _allItemsLoaded;
 		private final String _id;
 		private List<Item> _items;
 		private final String _name;

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -77,6 +77,7 @@ import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-ma
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
+import {config as e2eCmsDxpSpaceConfigurationConfig} from './tests/e2e-cms-dxp/space-configuration/main/config';
 import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
 import {config as expandoWebConfig} from './tests/expando-web/main/config';
@@ -322,6 +323,7 @@ export default defineConfig({
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
 		e2eCmsDxpSharingConfig,
+		e2eCmsDxpSpaceConfigurationConfig,
 		e2eCmsDxpTranslationsConfig,
 		e2eCmsDxpWorkflowConfig,
 		expandoWebConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/space-configuration/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/space-configuration/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'space-configuration.main',
+	testDir: 'tests/e2e-cms-dxp/space-configuration/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/space-configuration/main/spaceConfiguration.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/space-configuration/main/spaceConfiguration.spec.ts
@@ -1,0 +1,559 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import {PageEditorPage} from '../../../../pages/layout-content-page-editor-web/PageEditorPage';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+import getFragmentDefinition from '../../../layout-content-page-editor-web/main/utils/getFragmentDefinition';
+import getPageDefinition from '../../../layout-content-page-editor-web/main/utils/getPageDefinition';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {registerUserCredentials} from '../../../site-cms-site-initializer/main/spaces/helpers/roleMembership';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/permissions/fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	isolatedSiteTest,
+	pageEditorPagesTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: false},
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	loginTest()
+);
+
+async function grantContentViewToGuestAndUser(
+	apiHelpers: DataApiHelpers,
+	entryId: number
+) {
+	await apiHelpers.objectEntry.putObjectEntryPermissions(
+		'cms/basic-web-contents',
+		entryId,
+		[
+			{actionIds: ['VIEW'], roleName: 'Guest'},
+			{actionIds: ['VIEW'], roleName: 'User'},
+		]
+	);
+}
+
+async function connectSpaceToSite(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string,
+	siteExternalReferenceCode: string
+) {
+	await apiHelpers.headlessAssetLibrary.connectSite(
+		spaceExternalReferenceCode,
+		siteExternalReferenceCode,
+		{searchable: true}
+	);
+}
+
+async function disconnectSpaceFromSite(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string,
+	siteExternalReferenceCode: string
+) {
+	await apiHelpers.delete(
+		`${apiHelpers.baseUrl}headless-asset-library/v1.0/asset-libraries/${spaceExternalReferenceCode}/connected-sites/${siteExternalReferenceCode}`
+	);
+}
+
+async function mapTitleToHeading(
+	page: Page,
+	pageEditorPage: PageEditorPage,
+	fragmentId: string,
+	entryTitle: string
+) {
+	const iframe = page.frameLocator('iframe[title="Select"]');
+
+	await pageEditorPage.selectEditable(fragmentId, 'element-text');
+
+	await page.getByLabel('Select Item').click();
+
+	const selectItemMenuItem = page.getByRole('menuitem', {
+		name: 'Select Item...',
+	});
+
+	if (await selectItemMenuItem.isVisible()) {
+		await selectItemMenuItem.click();
+	}
+
+	await iframe.getByRole('main').waitFor();
+
+	await iframe.getByText('Basic Web Contents (CMS)', {exact: true}).click();
+
+	await iframe.getByText(entryTitle, {exact: true}).first().click();
+
+	await expect(
+		page.locator('.page-editor__item-selector__content-input')
+	).toHaveValue(entryTitle, {timeout: 10000});
+
+	await page.getByLabel('Field', {exact: true}).selectOption('Title');
+
+	await pageEditorPage.waitForChangesSaved();
+}
+
+async function isContentAvailableInPicker(
+	page: Page,
+	pageEditorPage: PageEditorPage,
+	fragmentId: string,
+	entryTitle: string
+) {
+	const iframe = page.frameLocator('iframe[title="Select"]');
+
+	await pageEditorPage.selectEditable(fragmentId, 'element-text');
+
+	await page.getByLabel('Select Item').click();
+
+	const selectItemMenuItem = page.getByRole('menuitem', {
+		name: 'Select Item...',
+	});
+
+	if (await selectItemMenuItem.isVisible()) {
+		await selectItemMenuItem.click();
+	}
+
+	await iframe.getByRole('main').waitFor();
+
+	const entity = iframe.getByText('Basic Web Contents (CMS)', {exact: true});
+
+	const entityVisible = await entity
+		.waitFor({state: 'visible', timeout: 8000})
+		.then(() => true)
+		.catch(() => false);
+
+	if (!entityVisible) {
+		return false;
+	}
+
+	await entity.click();
+
+	return iframe
+		.getByText(entryTitle, {exact: true})
+		.first()
+		.waitFor({state: 'visible', timeout: 8000})
+		.then(() => true)
+		.catch(() => false);
+}
+
+async function prepareUser(apiHelpers: DataApiHelpers) {
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+	registerUserCredentials(user);
+
+	await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+	await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+	return user;
+}
+
+async function createSpace(apiHelpers: DataApiHelpers) {
+	return apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name: getRandomString(),
+		settings: {},
+		type: 'Space',
+	});
+}
+
+async function addSpaceUser(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string,
+	spaceRoleNames: string[] = []
+) {
+	const user = await prepareUser(apiHelpers);
+
+	await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+		spaceExternalReferenceCode,
+		user.externalReferenceCode
+	);
+
+	if (spaceRoleNames.length) {
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			spaceExternalReferenceCode,
+			user.externalReferenceCode,
+			spaceRoleNames
+		);
+	}
+
+	return user;
+}
+
+async function createBasicWebContent(
+	apiHelpers: DataApiHelpers,
+	spaceName: string,
+	title: string
+) {
+	return apiHelpers.objectEntry.postObjectEntry(
+		{objectEntryFolderExternalReferenceCode: 'L_CONTENTS', title},
+		'cms/basic-web-contents',
+		spaceName
+	);
+}
+
+async function startSessionAs(page: Page, alternateName: string) {
+	await performUserSwitchViaApi(page, alternateName);
+
+	await page.goto(PORTLET_URLS.cmsHome, {waitUntil: 'domcontentloaded'});
+}
+
+test(
+	'Content from a connected Space is available for mapping in the page editor',
+	{tag: ['@LPD-95534', '@LPD-95534/TC-11.f']},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		test.setTimeout(120000);
+
+		const title = `Content ${getRandomString()}`;
+
+		const space = await createSpace(apiHelpers);
+
+		const entry = await createBasicWebContent(
+			apiHelpers,
+			space.name,
+			title
+		);
+
+		await grantContentViewToGuestAndUser(apiHelpers, entry.id);
+
+		await connectSpaceToSite(
+			apiHelpers,
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const headingId = getRandomString();
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: headingId,
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		expect(
+			await isContentAvailableInPicker(
+				page,
+				pageEditorPage,
+				headingId,
+				title
+			)
+		).toBe(true);
+	}
+);
+
+test(
+	'Content from a Space connected to two sites is available for mapping on both',
+	{tag: ['@LPD-95534', '@LPD-95534/TC-11.g']},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		test.setTimeout(150000);
+
+		const title = `Content ${getRandomString()}`;
+
+		const space = await createSpace(apiHelpers);
+
+		const entry = await createBasicWebContent(
+			apiHelpers,
+			space.name,
+			title
+		);
+
+		await grantContentViewToGuestAndUser(apiHelpers, entry.id);
+
+		const secondSite = await apiHelpers.headlessAdminSite.postSite({
+			name: getRandomString(),
+		});
+
+		await connectSpaceToSite(
+			apiHelpers,
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+		await connectSpaceToSite(
+			apiHelpers,
+			space.externalReferenceCode,
+			secondSite.externalReferenceCode
+		);
+
+		const isAvailableOnSite = async (targetSite: Site) => {
+			const headingId = getRandomString();
+
+			const layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([
+					getFragmentDefinition({
+						id: headingId,
+						key: 'BASIC_COMPONENT-heading',
+					}),
+				]),
+				siteId: targetSite.id,
+				title: getRandomString(),
+			});
+
+			await pageEditorPage.goto(layout, targetSite.friendlyUrlPath);
+
+			return isContentAvailableInPicker(
+				page,
+				pageEditorPage,
+				headingId,
+				title
+			);
+		};
+
+		expect(await isAvailableOnSite(site)).toBe(true);
+		expect(await isAvailableOnSite(secondSite)).toBe(true);
+	}
+);
+
+test(
+	'After disconnecting a Space, its content is unavailable for mapping and already-mapped content degrades gracefully',
+	{tag: ['@LPD-95534', '@LPD-95534/TC-11.h']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(180000);
+
+		const title = `Content ${getRandomString()}`;
+
+		const space = await createSpace(apiHelpers);
+
+		const entry = await createBasicWebContent(
+			apiHelpers,
+			space.name,
+			title
+		);
+
+		await grantContentViewToGuestAndUser(apiHelpers, entry.id);
+
+		await connectSpaceToSite(
+			apiHelpers,
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const mappedHeadingId = getRandomString();
+
+		const mappedLayout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: mappedHeadingId,
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		const mappedUrl = `/web${site.friendlyUrlPath}${mappedLayout.friendlyUrlPath}`;
+
+		await test.step('SiteA maps the content and it renders while connected', async () => {
+			await pageEditorPage.goto(mappedLayout, site.friendlyUrlPath);
+
+			await mapTitleToHeading(
+				page,
+				pageEditorPage,
+				mappedHeadingId,
+				title
+			);
+
+			await pageEditorPage.publishPage();
+
+			await page.goto(mappedUrl, {waitUntil: 'domcontentloaded'});
+
+			await expect(page.getByText(title).first()).toBeVisible();
+		});
+
+		await test.step('SPA disconnects the Space from the site', async () => {
+			await disconnectSpaceFromSite(
+				apiHelpers,
+				space.externalReferenceCode,
+				site.externalReferenceCode
+			);
+		});
+
+		await test.step('The content is no longer available for mapping', async () => {
+			const headingId = getRandomString();
+
+			const layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([
+					getFragmentDefinition({
+						id: headingId,
+						key: 'BASIC_COMPONENT-heading',
+					}),
+				]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+
+			await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+			expect(
+				await isContentAvailableInPicker(
+					page,
+					pageEditorPage,
+					headingId,
+					title
+				)
+			).toBe(false);
+		});
+
+		await test.step('The already-mapped page still loads gracefully', async () => {
+			const guestContext = await browser.newContext();
+
+			try {
+				const guestPage = await guestContext.newPage();
+
+				const response = await guestPage.goto(mappedUrl, {
+					waitUntil: 'domcontentloaded',
+				});
+
+				expect(response?.status()).toBeLessThan(500);
+
+				await expect(guestPage.getByText('Powered by')).toBeVisible();
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);
+
+test(
+	'A Space Administrator can rename a Space and the new name is reflected in the navigation and header',
+	{tag: ['@LPD-95534', '@LPD-95534/TC-11.d']},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const space = await createSpace(apiHelpers);
+		const newName = `Renamed ${getRandomString()}`;
+
+		const spaceAdministrator = await addSpaceUser(
+			apiHelpers,
+			space.externalReferenceCode,
+			['Asset Library Administrator']
+		);
+
+		await startSessionAs(page, spaceAdministrator.alternateName);
+
+		await test.step('Space Administrator updates the Space name', async () => {
+			await spaceSummaryPage.goto(space.name);
+
+			await page.getByRole('button', {name: 'More Actions'}).click();
+			await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+			await page.getByRole('textbox', {name: 'Space Name'}).fill(newName);
+
+			await page.getByRole('button', {name: 'Save'}).click();
+
+			await waitForAlert(page, 'Success');
+		});
+
+		await test.step('The new name is reflected in the Spaces navigation', async () => {
+			await page.goto(PORTLET_URLS.cms);
+
+			await expect(
+				page.getByRole('menuitem', {name: newName})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('menuitem', {name: space.name})
+			).toBeHidden();
+		});
+
+		await test.step('The new name is reflected in the Space header', async () => {
+			await spaceSummaryPage.goto(newName);
+
+			await expect(
+				page.getByRole('heading', {exact: true, name: newName})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'A removed Space member can no longer access the Space',
+	{tag: ['@LPD-95534', '@LPD-95534/TC-11.e']},
+	async ({apiHelpers, page}) => {
+		const space = await createSpace(apiHelpers);
+
+		const member = await addSpaceUser(
+			apiHelpers,
+			space.externalReferenceCode
+		);
+
+		await test.step('The member can access the Space', async () => {
+			await startSessionAs(page, member.alternateName);
+
+			await page.goto(PORTLET_URLS.cms);
+
+			await expect(
+				page.getByRole('menuitem', {name: space.name})
+			).toBeVisible();
+		});
+
+		await test.step('The administrator removes the member', async () => {
+			await performUserSwitchViaApi(page, 'test');
+
+			await apiHelpers.delete(
+				`${apiHelpers.baseUrl}headless-asset-library/v1.0/asset-libraries/${space.externalReferenceCode}/user-accounts/${member.externalReferenceCode}`
+			);
+		});
+
+		await test.step('The removed member can no longer access the Space', async () => {
+			await startSessionAs(page, member.alternateName);
+
+			await page.goto(PORTLET_URLS.cms);
+
+			await expect(
+				page.getByRole('menuitem', {name: space.name})
+			).toBeHidden();
+		});
+	}
+);
+
+test(
+	'Deleting a Space permanently deletes its content instead of moving it to the Recycle Bin',
+	{tag: ['@LPD-95534', '@LPD-95534/TC-11.i']},
+	async ({apiHelpers, page}) => {
+		const recycleBinPage = new RecycleBinPage(page);
+
+		const space = await createSpace(apiHelpers);
+
+		const contentTitle = `Content ${getRandomString()}`;
+
+		await createBasicWebContent(apiHelpers, space.name, contentTitle);
+
+		await test.step('CA deletes the Space from the All Spaces view', async () => {
+			await page.goto(PORTLET_URLS.cmsAllSpaces);
+
+			await page
+				.getByRole('button', {name: `${space.name} Actions`})
+				.click();
+			await page.getByRole('menuitem', {name: 'Delete'}).click();
+			await page.getByRole('button', {name: 'Delete'}).click();
+
+			await waitForAlert(
+				page,
+				`Success:${space.name} was successfully deleted.`
+			);
+		});
+
+		await test.step('The content is not moved to the Recycle Bin', async () => {
+			await recycleBinPage.goto();
+
+			await expect(page.getByText(contentTitle)).toHaveCount(0);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/space-configuration/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/space-configuration/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95534

## What Is Being Fixed

The CMS end-to-end epic (LPD-85582) had no automated coverage for the Space setup and configuration scenarios in LPD-95534.

## How It Is Being Fixed

This adds a Playwright suite covering Space lifecycle and site-connection behavior: a Space Administrator renaming a Space with the new name reflected in the navigation and header; a removed member losing access to the Space; content from a connected Space being available for mapping in the page editor, on two connected sites independently, and becoming unavailable after the Space is disconnected while an already-mapped page still loads gracefully.

Scenarios for creating a Space, role-based section access, and Space Member and Content Reviewer permissions (TC-11.a, TC-11.b, TC-11.c) are intentionally not duplicated here, as they are already covered by spaceManagement, rolePageAccess, and roleBasedActions.

Deleting a Space permanently deletes its content rather than moving it to the Recycle Bin. This is the intended behavior per LPD-96467 (resolved as Won't Fix), so TC-11.i asserts it directly as a passing scenario, not a recorded failure.

## PR Check

**pr-check: PASS** — tested on `6c4a01567f84a06e4599a1541fe3d3a63e6fb804`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "6c4a01567f84a06e4599a1541fe3d3a63e6fb804"} -->

