### PR TITLE
LPD-96072 Refresh source editing textarea when translation arrives

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.tsx
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.tsx
@@ -37,6 +37,10 @@ const getISO639LanguageCode = (localeId: string): string => {
 	return localeId;
 };
 
+const getSourceEditingArea = (editor: TEditor): HTMLElement | null =>
+	editor.ui?.element?.querySelector<HTMLElement>('.ck-source-editing-area') ??
+	null;
+
 const TranslateAutoTranslateRow = ({
 	autoTranslateEnabled,
 	children,
@@ -148,7 +152,9 @@ const TranslateFieldEditor = ({
 	const [content, setContent] = useState(targetContent);
 
 	const editorRef = useRef<any>();
+	const ckeditor5Ref = useRef<TEditor>();
 	const internalUpdateRef = useRef(true);
+	const lastSourceInputRef = useRef('');
 
 	const handleOnChange = (data: string) => {
 		setContent(data);
@@ -157,6 +163,8 @@ const TranslateFieldEditor = ({
 	};
 
 	const handleOnReady = (editor: TEditor) => {
+		ckeditor5Ref.current = editor;
+
 		const sourceEditingPlugin: SourceEditing =
 			editor.plugins.get('SourceEditing');
 
@@ -169,27 +177,16 @@ const TranslateFieldEditor = ({
 				return;
 			}
 
-			for (const [rootName] of editor.editing.view.domRoots) {
-				const replacedRoot =
+			const textarea =
+				getSourceEditingArea(editor)?.querySelector('textarea');
 
-					// @ts-ignore
+			textarea?.addEventListener('input', () => {
+				const data = editor.getData();
 
-					sourceEditingPlugin._replacedRoots?.get(rootName);
+				lastSourceInputRef.current = data;
 
-				if (!replacedRoot) {
-					continue;
-				}
-
-				const textarea = replacedRoot.querySelector('textarea');
-
-				if (!textarea) {
-					continue;
-				}
-
-				textarea.addEventListener('input', () => {
-					handleOnChange(editor.getData());
-				});
-			}
+				handleOnChange(data);
+			});
 		});
 	};
 
@@ -199,6 +196,26 @@ const TranslateFieldEditor = ({
 		}
 		else {
 			internalUpdateRef.current = false;
+		}
+
+		const editor = ckeditor5Ref.current;
+
+		const sourceEditingPlugin: SourceEditing | undefined =
+			editor?.plugins.get('SourceEditing');
+
+		if (
+			sourceEditingPlugin?.isSourceEditingMode &&
+			targetContent !== lastSourceInputRef.current
+		) {
+			const sourceEditingArea = getSourceEditingArea(editor!);
+
+			const textarea = sourceEditingArea?.querySelector('textarea');
+
+			if (textarea && textarea.value !== targetContent) {
+				textarea.value = targetContent;
+
+				sourceEditingArea!.dataset.value = targetContent;
+			}
 		}
 
 		setContent(targetContent);

--- a/modules/apps/translation/translation-web/test/js/translate/components/TranslateFieldSetEntries.tsx
+++ b/modules/apps/translation/translation-web/test/js/translate/components/TranslateFieldSetEntries.tsx
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import TranslateFieldSetEntries from '../../../../src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries';
+
+jest.mock('frontend-editor-ckeditor-web', () => {
+	const React = require('react');
+
+	return {
+		CKEditor5ClassicEditor: ({data, onReady}: any) => {
+			const wrapperRef = React.useRef(null);
+
+			React.useEffect(() => {
+				const wrapper = wrapperRef.current;
+
+				const textarea = wrapper.querySelector('textarea');
+
+				textarea.value = data;
+
+				const sourceEditingPlugin = {
+					isSourceEditingMode: true,
+					on: (event: string, callback: () => void) => {
+						if (event === 'change:isSourceEditingMode') {
+							callback();
+						}
+					},
+				};
+
+				onReady({
+					getData: () =>
+						textarea.value.startsWith('<')
+							? textarea.value
+							: `<p>${textarea.value}</p>`,
+					plugins: {
+						get: () => sourceEditingPlugin,
+					},
+					ui: {
+						element: wrapper,
+					},
+				});
+
+				// eslint-disable-next-line react-hooks/exhaustive-deps
+			}, []);
+
+			return (
+				<div ref={wrapperRef}>
+					<div className="ck-source-editing-area">
+						<textarea aria-label="source" defaultValue={data} />
+					</div>
+				</div>
+			);
+		},
+		ClassicEditor: () => null,
+	};
+});
+
+const ID = 'infoField--description--0';
+const ORIGINAL_TARGET = '<p>contenido original</p>';
+const TRANSLATED_TARGET = '<p>contenido traducido</p>';
+
+const infoFieldSetEntries = [
+	{
+		fields: [
+			{
+				editorConfiguration: {editorConfig: {}},
+				html: true,
+				id: 'infoField--description--',
+				label: 'Description',
+				multiline: false,
+				sourceContent: ['<p>original content</p>'],
+				sourceContentDir: 'ltr',
+				targetContentDir: 'ltr',
+				targetLanguageId: 'es_ES',
+			},
+		],
+		legend: 'Basic Information',
+	},
+];
+
+const buildComponent = (content: string) => (
+	<TranslateFieldSetEntries
+		autoTranslateEnabled={false}
+		fetchAutoTranslateField={() => {}}
+		infoFieldSetEntries={infoFieldSetEntries}
+		onChange={() => {}}
+		portletNamespace="_mock_TranslationPortlet_"
+		targetFieldsContent={{
+			[ID]: {content, message: '', status: ''},
+		}}
+	/>
+);
+
+describe('TranslateFieldSetEntries', () => {
+	beforeAll(() => {
+		Liferay.FeatureFlags['LPD-11235'] = false;
+	});
+
+	afterAll(() => {
+		delete Liferay.FeatureFlags['LPD-11235'];
+	});
+
+	it('refreshes the source editing textarea when a translation arrives while in source mode', () => {
+		const {rerender} = render(buildComponent(ORIGINAL_TARGET));
+
+		const textarea = screen.getByLabelText('source');
+
+		expect(textarea).toHaveValue(ORIGINAL_TARGET);
+
+		rerender(buildComponent(TRANSLATED_TARGET));
+
+		expect(textarea).toHaveValue(TRANSLATED_TARGET);
+
+		expect((textarea.parentElement as HTMLElement).dataset.value).toBe(
+			TRANSLATED_TARGET
+		);
+	});
+
+	it('does not reformat the source while the user is typing', () => {
+		const {rerender} = render(buildComponent(ORIGINAL_TARGET));
+
+		const textarea = screen.getByLabelText('source');
+
+		fireEvent.input(textarea, {target: {value: 'hola mundo'}});
+
+		rerender(buildComponent('<p>hola mundo</p>'));
+
+		expect(textarea).toHaveValue('hola mundo');
+	});
+
+	it('reflects an auto-translation that arrives after the user edited the source', () => {
+		const {rerender} = render(buildComponent(ORIGINAL_TARGET));
+
+		const textarea = screen.getByLabelText('source');
+
+		fireEvent.input(textarea, {target: {value: 'hola mundo'}});
+
+		rerender(buildComponent(TRANSLATED_TARGET));
+
+		expect(textarea).toHaveValue(TRANSLATED_TARGET);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96072

## What Is Being Fixed

When translating a field with CKEditor's source editing (HTML) mode open, a translation that arrived afterward — such as an asynchronous auto-translation — did not update the visible source editing textarea. The textarea kept showing the previous content even though the underlying target content had changed, so the user saw stale text.

## How It Is Being Fixed

The CKEditor instance is now captured on ready through a ref. When the target content changes while the editor is in source editing mode and the incoming value differs from the last text the user typed into the source textarea, the textarea's value and its backing root dataset value are updated directly to the new target content. A reference to the last source input guards the update so it never clobbers text the user is actively typing. Tests cover the refresh-on-translation case, the no-reformat-while-typing case, and an auto-translation that arrives after the user edited the source.

## PR Check

**pr-check: PASS** — tested on `d86907c64fbfdf1fb386f38860946aa176d0cb86`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d86907c64fbfdf1fb386f38860946aa176d0cb86"} -->
