### PR TITLE
LPD-95795 Limit Recent Assets to 16 items and remove its pagination

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/home/Home.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/home/Home.scss
@@ -1,8 +1,3 @@
-.home-link {
-	font-weight: bold;
-	text-decoration: underline;
-}
-
 .cms-section.home-custom-empty-state .c-empty-state-image {
 	display: none;
 }
@@ -13,10 +8,4 @@
 
 .cms-section.home-custom-empty-state .c-empty-state-animation {
 	margin: 12rem 5rem;
-}
-
-.cms-section.recent-assets-fds {
-	.text-2 {
-		font-size: 0.875rem;
-	}
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
@@ -38,6 +38,7 @@ export default function HomeRecentAssetsFDSPropsTransformer({
 		...otherProps,
 		additionalAPIURLParameters,
 		additionalProps: remainingAdditionalProps,
+		apiURL: `${otherProps.apiURL}&pageSize=16`,
 		customRenderers: {
 			tableCell: [
 				{

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer.tsx
@@ -110,7 +110,7 @@ export default function AssetRenderer({
 					</ClayLink>
 				</div>
 
-				<div className="text-2 text-secondary">
+				<div className="text-3 text-secondary">
 					{sub(
 						Liferay.Language.get('modified-at-x-by-x'),
 						formatDate(itemData.dateModified),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/WorkflowTaskRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/WorkflowTaskRenderer.tsx
@@ -31,7 +31,7 @@ const WorkflowTaskRenderer = ({itemData}: {itemData: WorkflowTask}) => {
 					{`${itemData.auditUser} sent you `}
 
 					<a
-						className="home-link"
+						className="font-weight-bold text-decoration-underline"
 						href={createPortletURL(itemData.myWorkflowTasksURL, {
 							mvcPath: '/edit_workflow_task.jsp',
 							workflowTaskId: itemData.id,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_home_recent_assets.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_home_recent_assets.jsp
@@ -34,9 +34,9 @@ ViewHomeRecentAssetsSectionDisplayContext viewHomeRecentAssetsSectionDisplayCont
 				fdsActionDropdownItems="<%= viewHomeRecentAssetsSectionDisplayContext.getFDSActionDropdownItems() %>"
 				formName="fm"
 				id="<%= CMSSiteInitializerFDSNames.HOME_RECENT_ASSETS_SECTION %>"
-				itemsPerPage="<%= 20 %>"
 				propsTransformer="{HomeRecentAssetsFDSPropsTransformer} from site-cms-site-initializer"
 				showManagementBar="<%= false %>"
+				showPagination="<%= false %>"
 				showSearch="<%= false %>"
 				style="fluid"
 			/>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_home_recent_assets.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_home_recent_assets.jsp
@@ -11,7 +11,7 @@
 ViewHomeRecentAssetsSectionDisplayContext viewHomeRecentAssetsSectionDisplayContext = (ViewHomeRecentAssetsSectionDisplayContext)request.getAttribute(ViewHomeRecentAssetsSectionDisplayContext.class.getName());
 %>
 
-<div class="cms-section p-2 p-sm-3">
+<div class="p-2 p-sm-3">
 	<div class="container-fluid-max">
 		<div class="align-items-center d-flex justify-content-between">
 			<span aria-level=2 class="font-weight-semi-bold text-4" role="heading"><liferay-ui:message key="recent-assets" /></span>

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -558,6 +558,59 @@ test(
 );
 
 test(
+	'Recent Assets shows at most the 16 most recent items',
+	{tag: '@LPD-95795'},
+	async ({apiHelpers, homePage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const spaceName = 'Default';
+
+		const objectEntries = [];
+
+		const oldestAssetTitle = `recent asset ${getRandomString()}`;
+
+		try {
+			for (let index = 0; index < 17; index++) {
+				objectEntries.push(
+					await apiHelpers.objectEntry.postObjectEntry(
+						{
+							objectEntryFolderExternalReferenceCode:
+								'L_CONTENTS',
+							title:
+								index === 0
+									? oldestAssetTitle
+									: `recent asset ${getRandomString()}`,
+						},
+						applicationName,
+						spaceName
+					)
+				);
+			}
+
+			await homePage.goto();
+
+			const recentAssets = page.locator('.recent-assets-fds');
+
+			await expect(recentAssets.locator('tbody tr')).toHaveCount(16);
+			await expect(
+				recentAssets.locator('.pagination-bar')
+			).not.toBeAttached();
+
+			await expect(
+				recentAssets.getByText(oldestAssetTitle, {exact: true})
+			).toHaveCount(0);
+		}
+		finally {
+			for (const objectEntry of objectEntries) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(objectEntry.id)
+				);
+			}
+		}
+	}
+);
+
+test(
 	'Can only see Recent Assets the user has VIEW permission on',
 	{tag: '@LPD-87568'},
 	async ({apiHelpers, homePage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95795

## What Is Being Fixed

The Recent Assets section on the CMS site home is meant to be a short preview of the most recent items, with a "View All" link to the full list. It rendered a pagination bar that served no purpose in that context, the number of items it showed was not bounded to a small preview, and the section carried styling overrides that were no longer needed.

## How It Is Being Fixed

The data set in `view_home_recent_assets.jsp` now passes `showPagination="false"`, so the pagination bar no longer renders. Because the data set no longer paginates, the `itemsPerPage` attribute became inert and is removed; the item count is instead bounded in the data set's props transformer, `HomeRecentAssetsFDSPropsTransformer`, which appends `pageSize=16` to the data set's `apiURL`. The section already sorts by `dateModified:desc`, so the widget now shows only the 16 most recent assets and the rest stay reachable through "View All".

Alongside that, the now-unused `.home-link` and `.cms-section.recent-assets-fds .text-2` rules are removed from `Home.scss`: the asset metadata line in `AssetRenderer` moves to the standard `text-3` utility class, and the workflow task link in `WorkflowTaskRenderer` uses the Clay `font-weight-bold text-decoration-underline` utilities instead of the custom class. The redundant `cms-section` class is also dropped from the recent assets wrapper.

The `home.spec.ts` Playwright test gains a case that creates 17 recent assets and asserts the Recent Assets data set renders exactly 16 rows, that no pagination bar is attached, and that the oldest created asset is not shown — covering both the removed pagination and the 16-most-recent limit.

## PR Check

**pr-check: PASS** — tested on `2c1081884fffb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2c1081884fffb61e92b0cd21660b9225c176c17b"} -->
