### PR TITLE
LPD-96540 Enable LPD-34594 before LPD-17564 in Site CMS setup

### DIFF
--- a/modules/test/playwright/tests/setup/site-cms-site/main/setup.spec.ts
+++ b/modules/test/playwright/tests/setup/site-cms-site/main/setup.spec.ts
@@ -20,8 +20,12 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-11235': {enabled: false},
-		'LPD-17564': {enabled: true},
 		'LPD-34594': {enabled: true},
+
+		// LPD-17564 depends on LPD-34594, which must be enabled first.
+
+		// eslint-disable-next-line sort-keys
+		'LPD-17564': {enabled: true},
 	}),
 	loginTest()
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96540

Added @veroglez as reviewer because she's great.

## What Is Being Fixed

The Site CMS Playwright setup (`tests/setup/site-cms-site/main/setup.spec.ts`) enabled the feature flag `LPD-17564` before its dependency `LPD-34594`. The `featureFlagsTest` fixture POSTs to `/set-enabled` one flag at a time in declared (ascending key) order, so `LPD-17564` was turned on while `LPD-34594` was still off. At that point `AttachmentObjectFieldDownloadActionFeatureFlagListener` runs on the raw enabled value, but the resource-action registration is gated by the dependency-aware effective state, which is false until the dependency is on. The `DOWNLOAD_FILE` and `DOWNLOAD_COVER_IMAGE` resource actions were therefore never registered, and the listener logged `NoSuchResourceActionException` for the CMS site-initializer object definitions (CMSBasicDocument and CMSBlog).

## How It Is Being Fixed

The two flags are reordered so the dependency `LPD-34594` is enabled before the dependent `LPD-17564`. Because `34594` sorts after `17564` and the repository's `sort-keys` lint enforces ascending key order, the dependent flag carries an `// eslint-disable-next-line sort-keys` with a comment explaining the dependency, so the intentional order survives `yarn format`.

## Why Are There No Tests?

The change is a one-line reordering of feature-flag enablement inside an existing Playwright setup spec — test infrastructure rather than product code. It removes swallowed-exception log noise during CMS setup, and correctness is confirmed by the existing Site CMS setup running without the listener error. A new automated test adds no meaningful coverage for a flag-ordering fix.

## PR Check

**pr-check: PASS** — `28f6625e45d3ae7e41b16fe7539d6520eea9daee`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Per-Module Compile and JavaScript Unit Tests matched the diff by extension but have no applicable target for a Playwright test project (no OSGi compile, `npm test` is Playwright/out of scope, no jest suite); TypeScript validity is covered by Source Format.

<!-- pr-check {"result": "success", "sha": "28f6625e45d3ae7e41b16fe7539d6520eea9daee"} -->
