### PR TITLE
LPD-96554 Create staged model test dependents with local services

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
@@ -667,8 +667,8 @@ public class FileEntryStagedModelDataHandlerTest
 		addDependentStagedModel(
 			dependentStagedModelsMap, DDMStructure.class, ddmStructure);
 
-		Folder folder = _dlAppService.addFolder(
-			null, group.getGroupId(),
+		Folder folder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -202,8 +202,8 @@ public class FolderStagedModelDataHandlerTest
 		addDependentStagedModel(
 			dependentStagedModelsMap, DLFileEntryType.class, dlFileEntryType);
 
-		Folder folder = DLAppServiceUtil.addFolder(
-			null, group.getGroupId(),
+		Folder folder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/RepositoryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/RepositoryStagedModelDataHandlerTest.java
@@ -7,7 +7,7 @@ package com.liferay.document.library.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.HashMap;
@@ -63,8 +64,8 @@ public class RepositoryStagedModelDataHandlerTest
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		Folder mountFolder = DLAppServiceUtil.addFolder(
-			null, group.getGroupId(),
+		Folder mountFolder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -142,6 +143,9 @@ public class RepositoryStagedModelDataHandlerTest
 		Assert.assertEquals(
 			repository.getDescription(), importedRepository.getDescription());
 	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
 
 	private Repository _repository;
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBMessageStagedModelDataHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBMessageStagedModelDataHandlerTest.java
@@ -19,7 +19,7 @@ import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
-import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
+import com.liferay.message.boards.service.MBCategoryLocalService;
 import com.liferay.message.boards.service.MBCategoryServiceUtil;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
 import com.liferay.message.boards.service.MBThreadLocalService;
@@ -170,7 +170,7 @@ public class MBMessageStagedModelDataHandlerTest
 		Map<String, List<StagedModel>> dependentStagedModelsMap =
 			new HashMap<>();
 
-		MBCategory category = MBCategoryServiceUtil.addCategory(
+		MBCategory category = _mbCategoryLocalService.addCategory(
 			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
@@ -350,7 +350,7 @@ public class MBMessageStagedModelDataHandlerTest
 
 		MBCategory category = (MBCategory)dependentStagedModels.get(0);
 
-		MBCategoryLocalServiceUtil.getMBCategoryByUuidAndGroupId(
+		_mbCategoryLocalService.getMBCategoryByUuidAndGroupId(
 			category.getUuid(), group.getGroupId());
 	}
 
@@ -395,6 +395,9 @@ public class MBMessageStagedModelDataHandlerTest
 			message.isAllowPingbacks(), importedMessage.isAllowPingbacks());
 		Assert.assertEquals(message.isAnswer(), importedMessage.isAnswer());
 	}
+
+	@Inject
+	private MBCategoryLocalService _mbCategoryLocalService;
 
 	@Inject
 	private MBThreadLocalService _mbThreadLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96554

## What Is Being Fixed

Several Documents and Media and Message Boards staged model data handler integration tests fail with PrincipalException$MustHavePermission ("must have ADD_FOLDER permission" for Documents and Media, "ADD_CATEGORY" for Message Boards). After LPD-86316 generalized testImportStagedModelWithExternalReferenceCode into BaseStagedModelDataHandlerTestCase, these subclasses build the "existing" model's dependents on the live group, creating the parent folder or category through the permission-checked DLAppService / MBCategoryService. The staging permission correctly forbids direct modification of a group that has a staging counterpart, so the live-group add is denied while the staging-group add passes. Affected: FileEntryStagedModelDataHandlerTest, FileEntryRemoteStagedModelDataHandlerTest, RepositoryStagedModelDataHandlerTest, FolderStagedModelDataHandlerTest, and MBMessageStagedModelDataHandlerTest.

## How It Is Being Fixed

The dependent folder and category are test-data setup, not the permission under test, so they are now created through the local services (DLAppLocalService.addFolder and MBCategoryLocalService.addCategory), which do not run the staging permission check. The local services are injected rather than accessed through the static *Util classes, matching the existing injection style in these tests.

## How to Test

cd modules/apps/document-library/document-library-test && gradlew testIntegration --tests com.liferay.document.library.internal.exportimport.data.handler.test.FileEntryStagedModelDataHandlerTest --tests com.liferay.document.library.internal.exportimport.data.handler.test.FileEntryRemoteStagedModelDataHandlerTest --tests com.liferay.document.library.internal.exportimport.data.handler.test.RepositoryStagedModelDataHandlerTest --tests com.liferay.document.library.internal.exportimport.data.handler.test.FolderStagedModelDataHandlerTest

cd modules/apps/message-boards/message-boards-test && gradlew testIntegration --tests com.liferay.message.boards.exportimport.data.handler.test.MBMessageStagedModelDataHandlerTest

## PR Check

**pr-check: PASS** — tested on `1b409ae12ae465ffe4f48b1c9bcd0ad5b66af884`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1b409ae12ae465ffe4f48b1c9bcd0ad5b66af884"} -->
