### PR TITLE
LPD-96562 Hide the connected sites actions in the standalone CMS

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -70,6 +70,8 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -830,9 +832,12 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		new AssetLibraryEntityModel();
 
 	@Reference(
-		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.AssetLibraryDTOConverter)"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(dto.class.name=com.liferay.depot.model.DepotEntry)"
 	)
-	private DTOConverter<DepotEntry, AssetLibrary> _assetLibraryDTOConverter;
+	private volatile DTOConverter<DepotEntry, AssetLibrary>
+		_assetLibraryDTOConverter;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -9,6 +9,8 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryPin;
 import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -41,6 +43,7 @@ import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -50,13 +53,13 @@ import java.util.Map;
 public class BreadcrumbDisplayContext {
 
 	public BreadcrumbDisplayContext(
-		ModelResourcePermission<DepotEntry> depotEntryModelResourcePermission,
+		AssetLibraryResource.Factory assetLibraryResourceFactory,
 		DepotEntryPinLocalService depotEntryPinLocalService, long groupId,
 		GroupLocalService groupLocalService,
 		ModelResourcePermission<Group> groupModelResourcePermission,
 		HttpServletRequest httpServletRequest, String size) {
 
-		_depotEntryModelResourcePermission = depotEntryModelResourcePermission;
+		_assetLibraryResourceFactory = assetLibraryResourceFactory;
 		_depotEntryPinLocalService = depotEntryPinLocalService;
 		_groupId = groupId;
 		_groupLocalService = groupLocalService;
@@ -223,31 +226,38 @@ public class BreadcrumbDisplayContext {
 							).put(
 								"target", "manageMembersModal"
 							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "view-connected-sites")
-							).put(
-								"manageConnectedSitesData",
-								HashMapBuilder.<String, Object>put(
-									"externalReferenceCode",
-									group.getExternalReferenceCode()
+
+						Map<String, Map<String, String>> actions =
+							_getAssetLibraryActions(group);
+
+						if (actions.containsKey("connect-sites") ||
+							actions.containsKey("view-connected-sites")) {
+
+							unsafeConsumer.accept(
+								JSONUtil.put(
+									"href", StringPool.BLANK
 								).put(
-									"hasConnectSitesPermission",
-									_depotEntryModelResourcePermission.contains(
-										permissionChecker, group.getClassPK(),
-										ActionKeys.UPDATE)
-								).build()
-							).put(
-								"redirect", _themeDisplay.getURLCurrent()
-							).put(
-								"symbolLeft", "globe"
-							).put(
-								"target", "manageConnectedSitesModal"
-							));
+									"label",
+									LanguageUtil.get(
+										_httpServletRequest,
+										"view-connected-sites")
+								).put(
+									"manageConnectedSitesData",
+									HashMapBuilder.<String, Object>put(
+										"externalReferenceCode",
+										group.getExternalReferenceCode()
+									).put(
+										"hasConnectSitesPermission",
+										actions.containsKey("connect-sites")
+									).build()
+								).put(
+									"redirect", _themeDisplay.getURLCurrent()
+								).put(
+									"symbolLeft", "globe"
+								).put(
+									"target", "manageConnectedSitesModal"
+								));
+						}
 					}
 
 					if (permissionChecker.hasPermission(
@@ -393,6 +403,32 @@ public class BreadcrumbDisplayContext {
 		).build();
 	}
 
+	private Map<String, Map<String, String>> _getAssetLibraryActions(
+			Group group)
+		throws Exception {
+
+		AssetLibraryResource assetLibraryResource =
+			_assetLibraryResourceFactory.create(
+			).httpServletRequest(
+				_httpServletRequest
+			).preferredLocale(
+				_themeDisplay.getLocale()
+			).user(
+				_themeDisplay.getUser()
+			).build();
+
+		AssetLibrary assetLibrary = assetLibraryResource.getAssetLibrary(
+			group.getExternalReferenceCode());
+
+		Map<String, Map<String, String>> actions = assetLibrary.getActions();
+
+		if (actions == null) {
+			return Collections.emptyMap();
+		}
+
+		return actions;
+	}
+
 	private String _getControlPanelPortletURL(String portletId)
 		throws Exception {
 
@@ -426,8 +462,7 @@ public class BreadcrumbDisplayContext {
 		return jsonArray;
 	}
 
-	private final ModelResourcePermission<DepotEntry>
-		_depotEntryModelResourcePermission;
+	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
 	private final DepotEntryPinLocalService _depotEntryPinLocalService;
 	private final long _groupId;
 	private final GroupLocalService _groupLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
@@ -5,10 +5,10 @@
 
 package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -53,7 +53,7 @@ public class BreadcrumbComponentSectionFragmentRenderer
 
 		BreadcrumbDisplayContext breadcrumbDisplayContext =
 			new BreadcrumbDisplayContext(
-				_depotEntryModelResourcePermission, _depotEntryPinLocalService,
+				_assetLibraryResourceFactory, _depotEntryPinLocalService,
 				InfoItemUtil.getGroupId(httpServletRequest), _groupLocalService,
 				_groupModelResourcePermission, httpServletRequest,
 				CMSSpaceConstants.SPACE_STICKER_MD);
@@ -61,9 +61,8 @@ public class BreadcrumbComponentSectionFragmentRenderer
 		return breadcrumbDisplayContext.getProps();
 	}
 
-	@Reference(target = "(model.class.name=com.liferay.depot.model.DepotEntry)")
-	private ModelResourcePermission<DepotEntry>
-		_depotEntryModelResourcePermission;
+	@Reference
+	private AssetLibraryResource.Factory _assetLibraryResourceFactory;
 
 	@Reference
 	private DepotEntryPinLocalService _depotEntryPinLocalService;

--- a/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
@@ -25,6 +26,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:headless:headless-asset-library:headless-asset-library-api")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:knowledge-base:knowledge-base-api")
@@ -37,6 +39,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:notification:notification-api")
 	compileOnly project(":apps:on-demand-admin:on-demand-admin-api")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:push-notifications:push-notifications-api")

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/dto/v1_0/converter/CMSAssetLibraryDTOConverter.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/dto/v1_0/converter/CMSAssetLibraryDTOConverter.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.dto.v1_0.converter;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"dto.class.name=com.liferay.depot.model.DepotEntry",
+		"service.ranking:Integer=100"
+	},
+	service = DTOConverter.class
+)
+public class CMSAssetLibraryDTOConverter
+	implements DTOConverter<DepotEntry, AssetLibrary> {
+
+	@Override
+	public String getContentType() {
+		return _dtoConverter.getContentType();
+	}
+
+	@Override
+	public String getJaxRsLink(long classPK, UriInfo uriInfo) {
+		return _dtoConverter.getJaxRsLink(classPK, uriInfo);
+	}
+
+	@Override
+	public AssetLibrary toDTO(DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		_removeConnectedSitesActions(dtoConverterContext);
+
+		return _dtoConverter.toDTO(dtoConverterContext);
+	}
+
+	@Override
+	public AssetLibrary toDTO(
+			DTOConverterContext dtoConverterContext, DepotEntry depotEntry)
+		throws Exception {
+
+		_removeConnectedSitesActions(dtoConverterContext);
+
+		return _dtoConverter.toDTO(dtoConverterContext, depotEntry);
+	}
+
+	private void _removeConnectedSitesActions(
+		DTOConverterContext dtoConverterContext) {
+
+		Map<String, Map<String, String>> actions =
+			dtoConverterContext.getActions();
+
+		if (actions == null) {
+			return;
+		}
+
+		actions.remove("connect-sites");
+		actions.remove("view-connected-sites");
+	}
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.AssetLibraryDTOConverter)"
+	)
+	private DTOConverter<DepotEntry, AssetLibrary> _dtoConverter;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96562

## What Is Being Fixed

In the standalone CMS, an asset library ("Space") has no notion of being connected to other sites, so the "View Connected Sites" action should not be offered. It was still showing in the asset library listings (via the headless API actions) and in the Space breadcrumb menu.

## How It Is Being Fixed

The asset library DTO actions are the single source of truth for which actions the UI offers. A new `CMSAssetLibraryDTOConverter` is registered only in the standalone CMS build (the module ships without `.lfrbuild-portal`), with a higher service ranking. It delegates to the default converter and strips the `connect-sites` and `view-connected-sites` actions from the response, so nothing in the standalone CMS advertises them while full DXP is unaffected.

To let the override win, `AssetLibraryResourceImpl` no longer pins the converter by component name; it now selects it by `dto.class.name` with a dynamic, greedy reference, so the higher-ranked converter is bound whenever it is present, regardless of activation order.

Finally, the Space breadcrumb (`BreadcrumbDisplayContext`) no longer performs its own permission check for the connected sites menu item. It fetches the asset library through the local `AssetLibraryResource` and shows the item based on the presence of the connected sites actions, so it transparently follows the same override.

## Why Are There No Tests?

This change only applies to the standalone CMS build, and there is currently no way to run tests exclusively for that build, so the change cannot be covered by an automated test.

## PR Check

**pr-check: PASS** — tested on `54ba65c1c45f77bd5e4e1c335b238d082b101445`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "54ba65c1c45f77bd5e4e1c335b238d082b101445"} -->
