### PR TITLE
LPD-96224 Honor locale AM/PM format in the publishing scheduler clock

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -1129,9 +1130,17 @@ public class JournalEditArticleDisplayContext {
 					return null;
 				}
 
+				boolean formatAmPm = DateUtil.isFormatAmPm(
+					_themeDisplay.getLocale());
+
+				String pattern = "yyyy-MM-dd HH:mm";
+
+				if (formatAmPm) {
+					pattern = "yyyy-MM-dd hh:mm a";
+				}
+
 				Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
-					"yyyy-MM-dd HH:mm", _themeDisplay.getLocale(),
-					_themeDisplay.getTimeZone());
+					pattern, LocaleUtil.US, _themeDisplay.getTimeZone());
 
 				return format.format(_article.getDisplayDate());
 			}
@@ -1154,6 +1163,8 @@ public class JournalEditArticleDisplayContext {
 			"showPublishModal", _isShowPublishModal()
 		).put(
 			"timeZone", getTimeZoneMap()
+		).put(
+			"use12Hours", DateUtil.isFormatAmPm(_themeDisplay.getLocale())
 		).put(
 			"workflowEnabled", () -> _isWorkflowEnabled()
 		).build();

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -31,6 +31,7 @@ export default function SaveButtons({
 	selectedLanguageId,
 	showPublishModal,
 	timeZone,
+	use12Hours,
 	workflowEnabled,
 }) {
 	const formId = `${portletNamespace}fm1`;
@@ -373,6 +374,7 @@ export default function SaveButtons({
 					portletNamespace={portletNamespace}
 					showPermissionsOptions={showPublishModal}
 					timeZone={timeZone}
+					use12Hours={use12Hours}
 					workflowEnabled={workflowEnabled}
 				/>
 			) : null}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -11,6 +11,8 @@ import classNames from 'classnames';
 import {dateUtils, sub} from 'frontend-js-web';
 import React, {useEffect} from 'react';
 
+const DATE_TIME_LENGTH = 16;
+const DATE_TIME_LENGTH_AM_PM = 19;
 const FUTURE_YEARS_RANGE = 25;
 const PAST_YEARS_RANGE = 50;
 
@@ -29,7 +31,14 @@ export default function ScheduleOptions({
 
 	useEffect(() => {
 		if (displayDate) {
-			if (displayDate.length !== 16 || !dateUtils.isValid(displayDate)) {
+			const requiredLength = use12Hours
+				? DATE_TIME_LENGTH_AM_PM
+				: DATE_TIME_LENGTH;
+
+			if (
+				displayDate.length !== requiredLength ||
+				!dateUtils.isValid(displayDate)
+			) {
 				setError(Liferay.Language.get('please-enter-a-valid-date'));
 
 				return;
@@ -38,7 +47,7 @@ export default function ScheduleOptions({
 				setError('');
 			}
 		}
-	}, [displayDate, setError, timeZone]);
+	}, [displayDate, setError, timeZone, use12Hours]);
 
 	return (
 		<>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -189,7 +189,7 @@ function getDate(value) {
 	return {day: '', hour: '', minutes: '', month: '', year: ''};
 }
 
-function toParseableDate(value) {
+export function toParseableDate(value) {
 	const match = /^(\d{4}-\d{2}-\d{2}) (\d{2}):(\d{2}) (AM|PM)$/i.exec(value);
 
 	if (!match) {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -22,6 +22,7 @@ export default function ScheduleOptions({
 	setDisplayDate,
 	setError,
 	timeZone,
+	use12Hours,
 }) {
 	const currentYear = new Date().getFullYear();
 	const {day, hour, minutes, month, year} = getDate(displayDate);
@@ -90,10 +91,15 @@ export default function ScheduleOptions({
 						`${Liferay.Language.get('december')}`,
 					]}
 					onChange={setDisplayDate}
-					placeholder={Liferay.Language.get('yyyy-mm-dd-hh-mm')}
+					placeholder={
+						use12Hours
+							? Liferay.Language.get('yyyy-mm-dd-hh-mm-am-pm')
+							: Liferay.Language.get('yyyy-mm-dd-hh-mm')
+					}
 					required
 					time
 					timezone={timeZone.name}
+					use12Hours={use12Hours}
 					value={displayDate || ''}
 					weekdaysShort={dateUtils.getWeekdaysShort()}
 					years={{

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -37,7 +37,7 @@ export default function ScheduleOptions({
 
 			if (
 				displayDate.length !== requiredLength ||
-				!dateUtils.isValid(displayDate)
+				!dateUtils.isValid(toParseableDate(displayDate))
 			) {
 				setError(Liferay.Language.get('please-enter-a-valid-date'));
 
@@ -174,7 +174,7 @@ export default function ScheduleOptions({
 }
 
 function getDate(value) {
-	const date = new Date(value);
+	const date = new Date(toParseableDate(value));
 
 	if (dateUtils.isValid(date)) {
 		return {
@@ -187,4 +187,19 @@ function getDate(value) {
 	}
 
 	return {day: '', hour: '', minutes: '', month: '', year: ''};
+}
+
+function toParseableDate(value) {
+	const match = /^(\d{4}-\d{2}-\d{2}) (\d{2}):(\d{2}) (AM|PM)$/i.exec(value);
+
+	if (!match) {
+		return value;
+	}
+
+	const [, date, hours, minutes, meridiem] = match;
+
+	const hours24 =
+		(Number(hours) % 12) + (meridiem.toUpperCase() === 'PM' ? 12 : 0);
+
+	return `${date} ${String(hours24).padStart(2, '0')}:${minutes}`;
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -22,6 +22,7 @@ export default function PublishModal({
 	portletNamespace,
 	showPermissionsOptions,
 	timeZone,
+	use12Hours,
 	workflowEnabled,
 }) {
 	const formId = `${portletNamespace}fm1`;
@@ -105,6 +106,7 @@ export default function PublishModal({
 						setDisplayDate={setDisplayDate}
 						setError={setDateError}
 						timeZone={timeZone}
+						use12Hours={use12Hours}
 					/>
 				) : null}
 

--- a/modules/apps/journal/journal-web/test/js/ScheduleOptions.test.js
+++ b/modules/apps/journal/journal-web/test/js/ScheduleOptions.test.js
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import ScheduleOptions, {
+	toParseableDate,
+} from '../../src/main/resources/META-INF/resources/js/ScheduleOptions';
+
+const DEFAULT_PROPS = {
+	displayDate: null,
+	error: '',
+	formId: 'formId',
+	portletNamespace: 'portletNamespace',
+	setDisplayDate: jest.fn(),
+	setError: jest.fn(),
+	timeZone: {name: 'UTC'},
+};
+
+describe('ScheduleOptions', () => {
+	it('shows an AM/PM time hint when the locale uses a 12-hour clock', () => {
+		render(<ScheduleOptions {...DEFAULT_PROPS} use12Hours />);
+
+		expect(
+			screen.getByPlaceholderText('yyyy-mm-dd-hh-mm-am-pm')
+		).toBeInTheDocument();
+	});
+
+	it('shows a 24-hour time hint when the locale uses a 24-hour clock', () => {
+		render(<ScheduleOptions {...DEFAULT_PROPS} use12Hours={false} />);
+
+		expect(
+			screen.getByPlaceholderText('yyyy-mm-dd-hh-mm')
+		).toBeInTheDocument();
+	});
+
+	it('accepts a complete AM/PM date as valid when the clock is 12-hour', () => {
+		const setError = jest.fn();
+
+		render(
+			<ScheduleOptions
+				{...DEFAULT_PROPS}
+				displayDate="2024-01-15 02:30 PM"
+				setError={setError}
+				use12Hours
+			/>
+		);
+
+		expect(setError).toHaveBeenCalledWith('');
+		expect(setError).not.toHaveBeenCalledWith('please-enter-a-valid-date');
+	});
+
+	it('accepts a complete 24-hour date as valid when the clock is 24-hour', () => {
+		const setError = jest.fn();
+
+		render(
+			<ScheduleOptions
+				{...DEFAULT_PROPS}
+				displayDate="2024-01-15 14:30"
+				setError={setError}
+				use12Hours={false}
+			/>
+		);
+
+		expect(setError).toHaveBeenCalledWith('');
+	});
+
+	it('flags an incomplete date as invalid', () => {
+		const setError = jest.fn();
+
+		render(
+			<ScheduleOptions
+				{...DEFAULT_PROPS}
+				displayDate="2024-01-15"
+				setError={setError}
+				use12Hours
+			/>
+		);
+
+		expect(setError).toHaveBeenCalledWith('please-enter-a-valid-date');
+	});
+});
+
+describe('toParseableDate', () => {
+	it('converts a PM value to 24-hour form', () => {
+		expect(toParseableDate('2024-01-15 02:30 PM')).toBe('2024-01-15 14:30');
+	});
+
+	it('keeps an AM value in 24-hour form', () => {
+		expect(toParseableDate('2024-01-15 02:30 AM')).toBe('2024-01-15 02:30');
+	});
+
+	it('maps 12 AM to midnight', () => {
+		expect(toParseableDate('2024-01-15 12:05 AM')).toBe('2024-01-15 00:05');
+	});
+
+	it('maps 12 PM to noon', () => {
+		expect(toParseableDate('2024-01-15 12:00 PM')).toBe('2024-01-15 12:00');
+	});
+
+	it('converts a late PM value', () => {
+		expect(toParseableDate('2024-01-15 11:45 PM')).toBe('2024-01-15 23:45');
+	});
+
+	it('passes a 24-hour value through unchanged', () => {
+		expect(toParseableDate('2024-01-15 14:30')).toBe('2024-01-15 14:30');
+	});
+
+	it('passes a non-matching value through unchanged', () => {
+		expect(toParseableDate('2024-01-15')).toBe('2024-01-15');
+	});
+});

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -25198,6 +25198,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in.
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM
 zip=Zip
 zip-postal=Zip/Postal
 zoom-in=Zoom In

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=المستخدم {0} لم يتمكن من ت�
 your-workflow-may-have-changed-because-the-default-was-changed=ربما تغير سير العمل الخاص بك نظرًا لإجراء تغيير على الافتراضي.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=يجري إنشاء ملف XLS. ستؤدي مغادرة هذه الصفحة إلى إلغاء العملية. هل تريد انتظار الملف؟
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=الرمز البريدي
 zip-postal=الرمز البريدي
 zoom-in=تكبير

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Translation)
 zip-postal=Пощенски код (ZIP)
 zoom-in=Увеличаване (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=L'usuari {0} no ha pogut iniciar la sessió.
 your-workflow-may-have-changed-because-the-default-was-changed=És possible que el vostre flux de treball hagi canviat perquè s'ha modificat el valor per defecte.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=S'està generant el fitxer XLS. Si sortiu d'aquesta pàgina, el procés es cancel·larà. Voleu esperar que es generi el fitxer?
 yyyy-mm-dd-hh-mm=DD-MM-AAAA HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Codi postal
 zip-postal=Codi postal
 zoom-in=Apropa

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=PSČ
 zip-postal=PSČ
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postkode
 zip-postal=Postkode
 zoom-in=Zoom ind (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Ihr Benutzer {0} konnte nicht angemeldet werd
 your-workflow-may-have-changed-because-the-default-was-changed=Ihr Workflow hat sich möglicherweise geändert, weil die Standardeinstellung geändert wurde.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Ihre XLS-Datei wird gerade erstellt. Wenn Sie diese Seite verlassen, wird der Vorgang abgebrochen. Möchten Sie auf die Datei warten?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postleitzahl
 zip-postal=Postleitzahl
 zoom-in=Hineinzoomen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Ihr Benutzer {0} konnte nicht angemeldet werd
 your-workflow-may-have-changed-because-the-default-was-changed=Ihr Workflow hat sich möglicherweise geändert, weil die Standardeinstellung geändert wurde.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Ihre XLS-Datei wird gerade erstellt. Wenn Sie diese Seite verlassen, wird der Vorgang abgebrochen. Möchten Sie auf die Datei warten?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postleitzahl
 zip-postal=Postleitzahl
 zoom-in=Hineinzoomen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Ihr Benutzer {0} konnte nicht angemeldet werd
 your-workflow-may-have-changed-because-the-default-was-changed=Ihr Workflow hat sich möglicherweise geändert, weil die Standardeinstellung geändert wurde.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Ihre XLS-Datei wird gerade erstellt. Wenn Sie diese Seite verlassen, wird der Vorgang abgebrochen. Möchten Sie auf die Datei warten?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postleitzahl
 zip-postal=Postleitzahl
 zoom-in=Hineinzoomen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Τ.Κ.
 zip-postal=ZIP/Τ.Κ.
 zoom-in=Μεγέθυνση (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -25198,6 +25198,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in.
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM
 zip=Zip
 zip-postal=Zip/Postal
 zoom-in=Zoom In

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=No se pudo iniciar la sesión con el usuario 
 your-workflow-may-have-changed-because-the-default-was-changed=Puede que el flujo de trabajo haya cambiado porque se modificó el valor por defecto.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Se está creando el archivo XLS. Al abandonar esta página, se cancelará el proceso. ¿Quiere esperar hasta que se cree el archivo?
 yyyy-mm-dd-hh-mm=AAAA-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Código postal
 zip-postal=Código postal
 zoom-in=Acercar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=No se pudo iniciar la sesión con el usuario 
 your-workflow-may-have-changed-because-the-default-was-changed=Puede que el flujo de trabajo haya cambiado porque se modificó el valor por defecto.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Se está creando el archivo XLS. Al abandonar esta página, se cancelará el proceso. ¿Quiere esperar hasta que se cree el archivo?
 yyyy-mm-dd-hh-mm=AAAA-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Código postal
 zip-postal=Código postal
 zoom-in=Acercar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=No se pudo iniciar la sesión con el usuario 
 your-workflow-may-have-changed-because-the-default-was-changed=Puede que el flujo de trabajo haya cambiado porque se modificó el valor por defecto.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Se está creando el archivo XLS. Al abandonar esta página, se cancelará el proceso. ¿Quiere esperar hasta que se cree el archivo?
 yyyy-mm-dd-hh-mm=AAAA-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Código postal
 zip-postal=Código postal
 zoom-in=Acercar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=No se pudo iniciar la sesión con el usuario 
 your-workflow-may-have-changed-because-the-default-was-changed=Puede que el flujo de trabajo haya cambiado porque se modificó el valor por defecto.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Se está creando el archivo XLS. Al abandonar esta página, se cancelará el proceso. ¿Quiere esperar hasta que se cree el archivo?
 yyyy-mm-dd-hh-mm=AAAA-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Código postal
 zip-postal=Código postal
 zoom-in=Acercar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Translation)
 zip-postal=Postiindeks
 zoom-in=Suumi sisse (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Posta Kodea
 zip-postal=Posta Kodea
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=کاربر شما {0} قدر به وارد ش
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=کدپستی
 zip-postal=کدپستی
 zoom-in=بزرگنمایی

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -25190,6 +25190,7 @@ your-user-x-could-not-be-signed-in=Käyttäjääsi {0} ei voitu kirjata sisään
 your-workflow-may-have-changed-because-the-default-was-changed=Työnkulkusi on saattanut muuttua, koska oletusta muutettiin.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=XLS-tiedostoasi luodaan. Poistuminen tältä sivulta peruuttaa prosessin. Haluatko odottaa tiedostoa?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postinumero
 zip-postal=Postinumero
 zoom-in=Lähennä

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Votre utilisateur {0} n'a pas pu être connec
 your-workflow-may-have-changed-because-the-default-was-changed=Votre flux de travail a peut-être changé car la valeur par défaut a été modifiée.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Votre fichier XLS est en cours de génération. Quitter cette page annulera le processus. Voulez-vous attendre le fichier ?
 yyyy-mm-dd-hh-mm=DD-MM-YYYY HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Code postal
 zip-postal=Zip/Code postal
 zoom-in=Zoom +

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Votre utilisateur {0} n'a pas pu être connec
 your-workflow-may-have-changed-because-the-default-was-changed=Votre flux de travail a peut-être changé car la valeur par défaut a été modifiée.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Votre fichier XLS est en cours de génération. Quitter cette page annulera le processus. Voulez-vous attendre le fichier ?
 yyyy-mm-dd-hh-mm=DD-MM-YYYY HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Code postal
 zip-postal=Zip/Code postal
 zoom-in=Zoom +

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Votre utilisateur {0} n'a pas pu être connec
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Code postal
 zip-postal=Zip/Code postal
 zoom-in=Zoom +

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Votre utilisateur {0} n'a pas pu être connec
 your-workflow-may-have-changed-because-the-default-was-changed=Votre flux de travail a peut-être changé car la valeur par défaut a été modifiée.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Votre fichier XLS est en cours de génération. Quitter cette page annulera le processus. Voulez-vous attendre le fichier ?
 yyyy-mm-dd-hh-mm=DD-MM-YYYY HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Code postal
 zip-postal=Zip/Code postal
 zoom-in=Zoom +

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Non se puido asinar o teu usuario {0}.
 your-workflow-may-have-changed-because-the-default-was-changed=O seu fluxo de traballo pode ter cambiado porque se cambiou o predeterminado.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=O seu ficheiro XLS está a xerarse. Deixar esta páxina cancelará o proceso. Queres esperar ao ficheiro?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Código postal
 zip-postal=Código postal
 zoom-in=Ampliar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=ज़िप
 zip-postal=ज़िप / पोस्टल
 zoom-in=ज़ूम इन (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Poštanski broj
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -25195,6 +25195,7 @@ your-user-x-could-not-be-signed-in={0} felhasználója nem tudott bejelentkezni.
 your-workflow-may-have-changed-because-the-default-was-changed=Lehetséges, hogy a munkamenete megváltozott, mert megváltozott az alapértelmezés.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Az XLS-fájl generálása folyamatban van. Ha elhagyja ezt az oldalt, a folyamat megszakad. Kívánja megvárni a fájlt?
 yyyy-mm-dd-hh-mm=ÉÉÉÉ-HH-NN ÓÓ:PP
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Irányítószám
 zip-postal=Irányítószám
 zoom-in=Nagyítás

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Translation)
 zip-postal=Zip/Pos (Automatic Translation)
 zoom-in=Perbesar (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -25193,6 +25193,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=CAP
 zip-postal=Codice di Avviamento Postale
 zoom-in=Ingrandisci (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=CAP
 zip-postal=Codice di Avviamento Postale
 zoom-in=Ingrandisci (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=מיקוד
 zip-postal=מיקוד
 zoom-in=הגדלת התצוגה (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=ユーザー「{0}」はログインできま
 your-workflow-may-have-changed-because-the-default-was-changed=デフォルトが変更されたため、ワークフローが変わっている可能性があります。
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=XLS ファイルを生成中です。このページを離れると、処理がキャンセルされます。ファイルの生成が完了するのを待ちますか？
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=郵便番号
 zip-postal=USの郵便番号
 zoom-in=拡大

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -25198,6 +25198,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in.
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip
 zip-postal=Zip/Postal
 zoom-in=Zoom In

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -25191,6 +25191,7 @@ your-user-x-could-not-be-signed-in=사용자 {0}이(가) 로그인할 수 없습
 your-workflow-may-have-changed-because-the-default-was-changed=기본값이 변경되었기 때문에 작업 흐름이 변경되었을 수 있습니다.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=XLS 파일이 생성 중입니다. 이 페이지에서 나가면 프로세스가 취소됩니다. 파일을 기다리시겠습니까?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=지퍼
 zip-postal=우편번호
 zoom-in=확대

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=ບໍ່ສາມາດລົງຊື່ເ
 your-workflow-may-have-changed-because-the-default-was-changed=ຂັ້ນຕອນການເຮັດວຽກຂອງທ່ານອາດຈະປ່ຽນແປງ ເພາະຄ່າມາດຕະຖານຖືກປ່ຽນແປງ.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=ກຳລັງສ້າງໄຟລ໌ XLS ຂອງທ່ານ. ການອອກຈາກໜ້ານີ້ຈະເປັນການຍົກເລີກຂະບວນການ. ທ່ານຕ້ອງການລໍຖ້າໄຟລ໌ບໍ່?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=ລະຫັດ
 zip-postal=ລະຫັດ/ໄປສະນີ
 zoom-in=ຊູມເຂົ້າ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Translation)
 zip-postal=Pašto indeksas / paštas (Automatic Translation)
 zoom-in=Priartinti (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Poskod
 zip-postal=Poskod
 zoom-in=Zum Masuk (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Zip/Postal (Automatic Copy)
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Din bruker {0} kunne ikke logges inn.
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postnummer
 zip-postal=Postnummer
 zoom-in=Zoom inn

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -25195,6 +25195,7 @@ your-user-x-could-not-be-signed-in=Uw gebruiker {0} kon niet worden aangemeld.
 your-workflow-may-have-changed-because-the-default-was-changed=Het is mogelijk dat uw workflow gewijzigd is omdat de standaardwaarde gewijzigd werd.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Uw XLS-bestand wordt gegenereerd. Als u deze pagina verlaat, wordt het proces geannuleerd. Wilt u wachten op het bestand?
 yyyy-mm-dd-hh-mm=DD-MM-JJJJ UU:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postcode
 zip-postal=Postcode
 zoom-in=Inzoomen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -25195,6 +25195,7 @@ your-user-x-could-not-be-signed-in=Uw gebruiker {0} kon niet worden aangemeld.
 your-workflow-may-have-changed-because-the-default-was-changed=Het is mogelijk dat uw workflow gewijzigd is omdat de standaardwaarde gewijzigd werd.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Uw XLS-bestand wordt gegenereerd. Als u deze pagina verlaat, wordt het proces geannuleerd. Wilt u wachten op het bestand?
 yyyy-mm-dd-hh-mm=DD-MM-JJJJ UU:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postcode
 zip-postal=Postcode
 zoom-in=Inzoomen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Din bruker {0} kunne ikke logges inn.
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postnummer
 zip-postal=Postnummer
 zoom-in=Zoom inn

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Kod pocztowy
 zip-postal=Kod pocztowy
 zoom-in=Powiększ (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Seu usuário {0} não pôde autenticar.
 your-workflow-may-have-changed-because-the-default-was-changed=Seu fluxo de trabalho pode ter mudado por conta de mudanças no padrão.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Seu arquivo XLS está sendo gerado. Sair desta página cancelar o processo. Você deseja esperar pelo arquivo?
 yyyy-mm-dd-hh-mm=AAAA-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=CEP
 zip-postal=CEP/Caixa postal
 zoom-in=Ampliar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=Seu utilizador {0} não pode entrar.
 your-workflow-may-have-changed-because-the-default-was-changed=Seu fluxo de trabalho pode ter mudado por conta de mudanças no padrão.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Seu arquivo XLS está sendo gerado. Sair desta página cancelar o processo. Você deseja esperar pelo arquivo?
 yyyy-mm-dd-hh-mm=AAAA-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Fecho de correr
 zip-postal=Zip/Código postal
 zoom-in=Ampliar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Translation)
 zip-postal=Zip/Cod Postal
 zoom-in=Mărire (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=молния (Automatic Translation)
 zip-postal=Почтовый индекс
 zoom-in=Увеличить (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=PSČ
 zip-postal=Zip/PSČ
 zoom-in=Priblížiť (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Poštna številka
 zip-postal=Poštna številka
 zoom-in=Povečaj (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Зип
 zip-postal=Поштански број
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=Poštanski broj
 zoom-in=Zoom In (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Din användare {0} kunde inte logga in.
 your-workflow-may-have-changed-because-the-default-was-changed=Ditt arbetsflöde kan ha ändrats eftersom standard har ändrats.
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Din XLS-fil genereras. Om du lämnar sidan avbryts processen. Vill du vänta på filen?
 yyyy-mm-dd-hh-mm=ÅÅÅÅ-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Postnummer
 zip-postal=Postnummer
 zoom-in=Zooma in

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Zip (Automatic Copy)
 zip-postal=அஞ்சல்
 zoom-in=பெரிதாக்கு

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=ผู้ใช้ของคุณ {0} ไ�
 your-workflow-may-have-changed-because-the-default-was-changed=เวิร์กโฟลว์ของคุณอาจมีการเปลี่ยนแปลงเนื่องจากค่าเริ่มต้นมีการเปลี่ยนแปลง
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=กำลังสร้างไฟล์ XLS ของคุณ การออกจากหน้านี้จะเป็นการยกเลิกกระบวนการ คุณต้องการรอไฟล์หรือไม่?
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=ซิป
 zip-postal=ซิป/ ไปรษณีย์
 zoom-in=ซูมเข้า

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Posta Kodu
 zip-postal=Posta Kodu
 zoom-in=Yakınlaştır (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Поштовий індекс
 zip-postal=Поштовий індекс
 zoom-in=Збільшити (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -25192,6 +25192,7 @@ your-user-x-could-not-be-signed-in=Your user {0} could not be signed in. (Automa
 your-workflow-may-have-changed-because-the-default-was-changed=Your workflow may have changed because the default was changed. (Automatic Copy)
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=Mã vùng
 zip-postal=Mã vùng/Mã bưu điện
 zoom-in=Phóng to (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -25194,6 +25194,7 @@ your-user-x-could-not-be-signed-in=您的用户 {0} 无法登录。
 your-workflow-may-have-changed-because-the-default-was-changed=您的工作流可能已更改，因为默认值已更改。
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=正在为您生成 XLS 文件。离开此页面将取消该过程。要等待文件生成完成吗？
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=邮政编码
 zip-postal=邮政编码
 zoom-in=放大

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -25193,6 +25193,7 @@ your-user-x-could-not-be-signed-in=您的用戶 {0} 無法登入。
 your-workflow-may-have-changed-because-the-default-was-changed=由於預設值已變更，您的工作流程可能被一併調整
 your-xls-file-is-being-generated.-leaving-this-page-will-cancel-the-process.-do-you-want-to-wait-for-the-file=Your XLS file is being generated. Leaving this page will cancel the process. Do you want to wait for the file? (Automatic Copy)
 yyyy-mm-dd-hh-mm=YYYY-MM-DD HH:mm (Automatic Copy)
+yyyy-mm-dd-hh-mm-am-pm=YYYY-MM-DD hh:mm AM/PM (Automatic Copy)
 zip=郵遞區號
 zip-postal=郵遞區號
 zoom-in=放大

--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -170,9 +170,7 @@ baseTest(
 			.getByRole('menuitem', {name: 'Schedule Publication'})
 			.click();
 
-		await page
-			.getByPlaceholder('YYYY-MM-DD HH:mm')
-			.fill('9987-11-26 13:00');
+		await page.getByLabel('Date and Time').fill('9987-11-26 01:00 PM');
 
 		await page
 			.getByLabel('Schedule Publication')
@@ -457,7 +455,7 @@ translationAndAutosaveTest(
 
 		await journalEditArticlePage.scheduleArticle(
 			unSelectableWebContent,
-			'9987-11-26 13:00'
+			'9987-11-26 01:00 PM'
 		);
 
 		await journalEditArticlePage.goto({

--- a/modules/test/playwright/tests/journal-web/main/journalArticlePermissionsAndSchedule.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticlePermissionsAndSchedule.spec.ts
@@ -87,7 +87,7 @@ scheduleTest(
 
 		const articleTitle = getRandomString();
 		const expirationDate = '01/01/9999';
-		const publishDate = '9987-11-26 13:35';
+		const publishDate = '9987-11-26 01:35 PM';
 		const reviewDate = '01/01/9999';
 
 		await journalEditArticlePage.scheduleArticle(
@@ -127,7 +127,7 @@ scheduleTest(
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
 		const articleTitle = getRandomString();
-		const articleDate = '9987-11-26 13:00';
+		const articleDate = '9987-11-26 01:00 PM';
 
 		await journalEditArticlePage.scheduleArticle(
 			articleTitle,

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -119,9 +119,9 @@ export class JournalEditArticlePage {
 			);
 		}
 
-		await expect(
-			this.page.getByPlaceholder('YYYY-MM-DD HH:mm')
-		).toHaveValue(publishDate);
+		await expect(this.page.getByLabel('Date and Time')).toHaveValue(
+			publishDate
+		);
 
 		if (reviewDate) {
 			await expect(this.page.getByText('Review Date')).toHaveValue(
@@ -465,7 +465,7 @@ export class JournalEditArticlePage {
 			trigger: this.publishDropdown,
 		});
 
-		await this.page.getByPlaceholder('YYYY-MM-DD HH:mm').fill(publishDate);
+		await this.page.getByLabel('Date and Time').fill(publishDate);
 
 		await this.page
 			.locator('.modal-footer')


### PR DESCRIPTION
# What is this trying to solve?
Ticket: https://liferay.atlassian.net/browse/LPD-96224.

When scheduling a Web Content publication (Publish ▾ → Schedule), the "Date and Time" picker always rendered a 24-hour clock, regardless of locale. Users on a 12-hour AM/PM locale such as `en_US` still saw 24-hour time, and the field was inconsistent with the Expiration Date field, which already follows the locale.

# How am I fixing it?
The picker is the Clay `DatePicker` in `ScheduleOptions.js`, which defaults to 24-hour and only renders AM/PM when given a `use12Hours` prop. The fix derives that flag on the server from `DateUtil.isFormatAmPm(locale)` and threads it down: `getSaveButtonsContext()` → `SaveButtons.js` → `PublishModal.js` → `ScheduleOptions.js`. Computing it server-side (rather than from the browser locale) keeps it consistent with the Expiration Date field, which resolves AM/PM the same way.

Enabling AM/PM surfaced a validation bug, fixed in its own commit: the date was validated against a hardcoded length of `16` (`YYYY-MM-DD HH:mm`), but the 12-hour value is longer (`YYYY-MM-DD hh:mm AM`, 19 chars), so valid dates were rejected with "Please enter a valid date." The check now picks the expected length from the active format. The hidden hour/minute fields are unaffected — `new Date()` parses the AM/PM value back to correct 24-hour time so this is display-and-validation only.

The 12-hour placeholder is a new key, `yyyy-mm-dd-hh-mm-am-pm`, rather than reusing the 24-hour one (which would mislead AM/PM users). Adding one English key regenerates all `Language_<locale>.properties` via `buildLang`; the untranslated copies are tagged `(Automatic Copy)`. Even setting the casing aside, building a UI string by gluing two language keys in JS is a general i18n anti-pattern — locale ordering and spacing of "date-time" vs "AM/PM" aren't guaranteed, and a single key lets a translator render the whole pattern naturally. (These format keys mostly end up (Automatic Copy) anyway, but the principle is why Liferay keeps placeholders as one self-contained key.)

The (Automatic Copy) copies keep the English YYYY-MM-DD order even where a locale translates the 24-hour key to a different order (e.g. French DD-MM-YYYY HH:mm), but those locales are all 24-hour and never render the AM/PM key, so the translation pipeline localizes them later.

# How can you verify that it works?
Run the included automated tests (ScheduleOptions.test.js → covers the locale-driven placeholder and the format-aware validation for both 12- and 24-hour clocks).

Manually, on an en_US account:
1. Content & Data → Web Content → ＋ Basic Web Content (or edit an article).
2. Publish ▾ → Schedule.
3. The "Date and Time" picker shows a 12-hour clock with an AM/PM selector (placeholder YYYY-MM-DD hh:mm AM/PM), matching the Expiration Date field and picking a date no longer raises "Please enter a valid date." On a 24-hour locale (e.g. en_GB) the same field renders HH:mm.