### PR TITLE
LPD-96739 Fix content management unit and integration test failures

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
@@ -6,6 +6,7 @@
 package com.liferay.frontend.data.set.internal.sharing.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.frontend.data.set.test.util.FrontendDataSetTestUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -62,6 +63,9 @@ public class DataSetSnapshotSharingEntryInterpreterTest {
 
 	@Before
 	public void setUp() throws Exception {
+		FrontendDataSetTestUtil.initialize(
+			DataSetSnapshotSharingEntryInterpreterTest.class);
+
 		_objectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(

--- a/modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/ScheduleKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/ScheduleKBArticle.js
@@ -85,7 +85,7 @@ describe('ScheduleKBArticle', () => {
 			});
 
 			const cancelButton = await result.getByText('cancel');
-			const scheduleButton = await result.getByText('schedule');
+			const scheduleButton = await result.getByText('schedule[verb]');
 
 			expect(cancelButton).toBeInTheDocument();
 			expect(scheduleButton).toBeInTheDocument();
@@ -149,7 +149,7 @@ describe('ScheduleKBArticle', () => {
 			act(() => {
 				jest.runAllTimers();
 			});
-			const scheduleButton = await result.getByText('schedule');
+			const scheduleButton = await result.getByText('schedule[verb]');
 
 			expect(scheduleButton).not.toBeDisabled();
 		});
@@ -158,7 +158,7 @@ describe('ScheduleKBArticle', () => {
 			act(() => {
 				jest.runAllTimers();
 			});
-			const scheduleButton = await result.getByText('schedule');
+			const scheduleButton = await result.getByText('schedule[verb]');
 
 			act(() => {
 				fireEvent.click(scheduleButton);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96739
https://liferay.atlassian.net/browse/LPD-96577

## What Is Being Fixed

Two Content Management test failures surfaced in the LPD-96553 triage. The ScheduleKBArticle Jest suite failed because the component's Schedule button now renders the qualified language key `schedule[verb]` (introduced by LPD-96069), while the test still queried for `schedule`. DataSetSnapshotSharingEntryInterpreterTest failed on CI because the `L_DATA_SET_SNAPSHOT` object definition was never provisioned, so the test's `_objectDefinition` assertion was null.

## How It Is Being Fixed

The ScheduleKBArticle test now queries the qualified `schedule[verb]` key that the component actually renders, matching the source change from LPD-96069. The DataSetSnapshotSharingEntryInterpreterTest now calls `FrontendDataSetTestUtil.initialize(...)` in setup before fetching the object definition, mirroring how its sibling SystemFDSSerializerTest provisions the same definition, so the object definition exists on CI where the feature-flag-gated instance initializer does not run.

## How To Run The Tests

cd modules/apps/knowledge-base/knowledge-base-web && yarn test test/admin/js/components/ScheduleKBArticle.js

cd modules/apps/frontend-data-set/frontend-data-set-test && gradlew testIntegration --tests "DataSetSnapshotSharingEntryInterpreterTest"

## PR Check

**pr-check: SKIPPED** — Test-only changes (two test files, no product code); each verified green by running the exact tests locally.

<!-- pr-check {"reason": "Test-only changes verified by running the tests directly", "result": "skipped", "sha": "fb27864614edf39d902b3777e0bf1f340679cb59"} -->
