### PR TITLE
LPD-96793 Expect the project scope for a library-less vocabulary

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -202,21 +203,39 @@ public class AssetVocabularyServiceTest {
 		AssetVocabulary vocabulary = AssetTestUtil.addVocabulary(
 			cmsGroup.getGroupId(), RandomTestUtil.randomString());
 
-		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
+		List<AssetVocabularyGroupRel> spaceAssetVocabularyGroupRels =
 			_assetVocabularyGroupRelLocalService.
-				getAssetVocabularyGroupRelsByVocabularyId(
-					vocabulary.getVocabularyId());
+				getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+					vocabulary.getVocabularyId(), DepotConstants.TYPE_SPACE);
 
 		Assert.assertEquals(
-			assetVocabularyGroupRels.toString(), 1,
-			assetVocabularyGroupRels.size());
+			spaceAssetVocabularyGroupRels.toString(), 1,
+			spaceAssetVocabularyGroupRels.size());
 
-		AssetVocabularyGroupRel assetVocabularyGroupRel =
-			assetVocabularyGroupRels.get(0);
+		AssetVocabularyGroupRel spaceAssetVocabularyGroupRel =
+			spaceAssetVocabularyGroupRels.get(0);
 
 		Assert.assertEquals(
-			assetVocabularyGroupRels.toString(), GroupConstants.GROUP_ID_ALL,
-			assetVocabularyGroupRel.getGroupId());
+			spaceAssetVocabularyGroupRels.toString(),
+			GroupConstants.GROUP_ID_ALL,
+			spaceAssetVocabularyGroupRel.getGroupId());
+
+		List<AssetVocabularyGroupRel> projectAssetVocabularyGroupRels =
+			_assetVocabularyGroupRelLocalService.
+				getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType(
+					vocabulary.getVocabularyId(), DepotConstants.TYPE_PROJECT);
+
+		Assert.assertEquals(
+			projectAssetVocabularyGroupRels.toString(), 1,
+			projectAssetVocabularyGroupRels.size());
+
+		AssetVocabularyGroupRel projectAssetVocabularyGroupRel =
+			projectAssetVocabularyGroupRels.get(0);
+
+		Assert.assertEquals(
+			projectAssetVocabularyGroupRels.toString(),
+			GroupConstants.GROUP_ID_ALL,
+			projectAssetVocabularyGroupRel.getGroupId());
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96793

## Failing Test

`AssetVocabularyServiceTest.testAddVocabularyWithoutAssetLibrary`

`modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java`

```
java.lang.AssertionError: expected:<1> but was:<2>
	at com.liferay.asset.categories.service.test.AssetVocabularyServiceTest.testAddVocabularyWithoutAssetLibrary
```

## Root Cause

Commit `7da09eb6673e` ("LPD-95641 Implement project support in headless api") changed the CMS `AssetVocabularyModelListener.onAfterCreate` to create two `AssetVocabularyGroupRel` rows for a vocabulary created without an asset library — one `DepotConstants.TYPE_SPACE` and one `DepotConstants.TYPE_PROJECT`, both with `GroupConstants.GROUP_ID_ALL` — where it previously created a single space relationship. The test still asserted exactly one relationship, so it failed with expected:<1> but was:<2>.

## Fix

Assert the space and project defaults separately by depot entry type, using `getAssetVocabularyGroupRelsByVocabularyIdAndDepotEntryType`. The test now verifies that a library-less CMS vocabulary is scoped to all spaces and all projects (one relationship each, both `GROUP_ID_ALL`), matching the current product behavior.

- `modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java`

## PR Check

**pr-check: PASS** — tested on `7884601d3efede942611c5c994a6b0ae116018a6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7884601d3efede942611c5c994a6b0ae116018a6"} -->
