### PR TITLE
LPD-96894 Initialize CMS group to get CMS_ADMINISTRATOR

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:site-navigation:site-navigation-api")
 	testIntegrationImplementation project(":apps:site-navigation:site-navigation-menu-item-api")
 	testIntegrationImplementation project(":apps:site:site-api")
+	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
 	testIntegrationImplementation project(":apps:style-book:style-book-api")
 	testIntegrationImplementation project(":apps:template:template-api")
 	testIntegrationImplementation project(":apps:template:template-test-util")

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -67,6 +68,8 @@ public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 	@Test
 	public void testGetSiteTemplatesPage() throws Exception {
 		super.testGetSiteTemplatesPage();
+
+		CMSTestUtil.getOrAddGroup(SiteTemplateResourceTest.class);
 
 		_testGetSiteTemplatesPageWithAssetLibraryMember();
 		_testGetSiteTemplatesPageWithExcludedSiteExternalReferenceCodes();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96894

## What Is Being Fixed

SiteTemplateResourceTest.testGetSiteTemplatesPage runs sub-scenarios that depend on the CMS role CMS_ADMINISTRATOR being present. That role is created when the CMS group is initialized, but the test never initialized it, so the assertions ran without the role in place.

## How It Is Being Fixed

The test now calls CMSTestUtil.getOrAddGroup at the start of testGetSiteTemplatesPage to initialize the CMS group, which registers the CMS_ADMINISTRATOR role before the sub-scenarios run. The test module's build.gradle gains a testIntegration dependency on site-cms-site-initializer-test-util so CMSTestUtil is available.

## PR Check

**pr-check: PASS** — tested on `e4b495ba1fd305c7f01a8a0a455b45623dc08193`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS* |

\* `ModulesStructureTest` reported two failures (`testScanGradleFiles` on the repo-root `modules/build.gradle`, and a `testScanCircularProjectDependencies` NPE from a module missing in the local checkout). Both are pre-existing local-environment conditions unrelated to this diff, which only adds one line to a `-test` `build.gradle` and three lines to a test class.

<!-- pr-check {"result": "success", "sha": "e4b495ba1fd305c7f01a8a0a455b45623dc08193"} -->
