### PR TITLE
LPD-96571 Initialize the CMS group in asset library REST tests

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/build.gradle
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/build.gradle
@@ -15,5 +15,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:sharing:sharing-api")
+	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +54,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -62,6 +64,14 @@ import org.junit.runner.RunWith;
 @FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		CMSTestUtil.getOrAddGroup(AssetLibraryResourceTest.class);
+	}
 
 	@Override
 	@Test

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -46,6 +46,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -78,6 +79,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
+
+		CMSTestUtil.getOrAddGroup(RoleResourceTest.class);
 
 		_userGroup = UserGroupTestUtil.addUserGroup();
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -69,6 +70,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
+
+		CMSTestUtil.getOrAddGroup(UserAccountResourceTest.class);
 
 		_spaceDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96571

## What Is Being Fixed

The Asset Library headless REST integration tests (`RoleResourceTest`, `AssetLibraryResourceTest`, `UserAccountResourceTest`) fail on CI. All three classes carry a class-level `@FeatureFlag("LPD-17564")`, so every depot permission check runs `PermissionUtil.hasCMSAdministratorRole`, which resolves the `CMS Administrator` role by name via `RoleLocalServiceUtil.hasUserRole`. On CI that role is never created, because the CMS site initializer does not run during instance initialization, so the lookup throws `NoSuchRoleException` and the server-hitting tests fail. Locally the role exists, so the failure only reproduces on CI (and on a fresh bundle booted with the flag off at init).

## How It Is Being Fixed

Each affected class initializes the CMS group in `setUp` with `CMSTestUtil.getOrAddGroup`, which runs the CMS site initializer the way production does and registers the `CMS Administrator` role. `getOrAddGroup` is get-or-add against the CMS system group, so it initializes once and is a no-op when the group already exists. This matches the pattern introduced for the same root cause in LPD-96894.

## How to Test

```
gradlew -p modules/apps/headless/headless-asset-library/headless-asset-library-test testIntegration --tests RoleResourceTest --tests AssetLibraryResourceTest --tests UserAccountResourceTest
```

Verified locally on a fresh bundle that reproduces the CI condition (CMS feature flag off at instance init, `CMS Administrator` role absent): the `NoSuchRoleException` failures are resolved. `RoleResourceTest` (including the original `testGetAssetLibraryRolesPage`) and `UserAccountResourceTest` pass in full.

Note: `AssetLibraryResourceTest` still shows two non-deterministic failures unrelated to this change (`testPatchAssetLibrary` raises a `StaleObjectStateException` optimistic-lock race on the depot group, and `_assertGroupDepotEntryType` intermittently fails expected `0`/was `4`, rotating between `testPut`/`testPost` across runs). These are pre-existing flakes in the depot type/settings + trash domain (the LPD-91035 churn area), previously masked by the class-wide `setUp` abort; they are tracked separately.

## PR Check

**pr-check: PASS** — tested on `dc6ab26dffd38e39e227f60284aa164cd0b61823`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
