### PR TITLE
LPD-96532 Show a specific error when publishing CMS content with too many categories

### DIFF
--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 38.10.1
+Bundle-Version: 38.11.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
@@ -432,6 +432,39 @@ public class InfoFormValidationException extends InfoFormException {
 
 	}
 
+	public static class TooManyAssetCategories
+		extends InfoFormValidationException {
+
+		public TooManyAssetCategories(
+			AssetCategoryException assetCategoryException,
+			AssetVocabulary assetVocabulary) {
+
+			_assetCategoryException = assetCategoryException;
+			_assetVocabulary = assetVocabulary;
+		}
+
+		public AssetCategoryException getAssetCategoryException() {
+			return _assetCategoryException;
+		}
+
+		public AssetVocabulary getAssetVocabulary() {
+			return _assetVocabulary;
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.format(
+				locale, "you-cannot-select-more-than-one-category-for-x",
+				(_assetVocabulary != null) ?
+					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
+						StringPool.BLANK);
+		}
+
+		private final AssetCategoryException _assetCategoryException;
+		private final AssetVocabulary _assetVocabulary;
+
+	}
+
 	public static class UniqueValueConstraintViolation
 		extends InfoFormValidationException {
 

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
@@ -1,1 +1,1 @@
-version 6.6.0
+version 6.7.0

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -52,6 +52,13 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 					assetCategoryException,
 					assetCategoryException.getVocabulary());
 			}
+			else if (assetCategoryException.getType() ==
+						AssetCategoryException.TOO_MANY_CATEGORIES) {
+
+				throw new InfoFormValidationException.TooManyAssetCategories(
+					assetCategoryException,
+					assetCategoryException.getVocabulary());
+			}
 		}
 
 		if (exception instanceof ModelListenerException) {

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.handler;
+
+import com.liferay.asset.kernel.exception.AssetCategoryException;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.info.exception.InfoFormValidationException;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jan Brychta
+ */
+public class ObjectEntryInfoItemExceptionRequestHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testHandleInfoFormException() throws Exception {
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory();
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories();
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.AT_LEAST_ONE_CATEGORY),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.RequiredAssetCategory
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.TOO_MANY_CATEGORIES),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.TooManyAssetCategories
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -198,7 +198,7 @@ export default function ContentEditorToolbar({
 
 		sessionStorage.removeItem(SUCCESS_MESSAGE_SESSION_KEY);
 
-		if (getForm()?.querySelector('.form-group.has-error')) {
+		if (getForm()?.querySelector('.alert-danger, .form-group.has-error')) {
 			return;
 		}
 


### PR DESCRIPTION
## What

  When a vocabulary has "Allow multiple categories" disabled and a user tries to publish content in the new CMS section with more than one category selected, the system now shows:

  > You cannot select more than one category for {vocabulary name}.

  Previously it showed the generic "An error occurred while sending the form information." Additionally, the success toast "X was updated successfully" was incorrectly appearing alongside the error message.

  ## Why

  Three separate issues combined to produce the bug:

  1. `ObjectEntryInfoItemExceptionRequestHandler` handled `AT_LEAST_ONE_CATEGORY` but had no branch for `TOO_MANY_CATEGORIES`, so the exception fell through to a generic `InfoFormException` with no vocabulary context.

  2. `InfoFormValidationException` had no `TooManyAssetCategories` inner class to carry the vocabulary name into the localized message (parallel to the existing `RequiredAssetCategory`).

  3. `ContentEditorToolbar` stores the success message in `sessionStorage` before form submission and suppresses it on reload if `.form-group.has-error` is present in the form. Form-level errors (like category validation) are rendered as `.alert-danger` by `LayoutStructureRenderer`, not as `.form-group.has-error`, so the check was blind to them and always showed the success
  toast.

  ## Changes

  - `InfoFormValidationException` — new `TooManyAssetCategories` inner class that formats `you-cannot-select-more-than-one-category-for-x` with the vocabulary name
  - `ObjectEntryInfoItemExceptionRequestHandler` — maps `TOO_MANY_CATEGORIES` to the new exception
  - `ContentEditorToolbar.tsx` — extends the error check to also match `.alert-danger`
  - `ObjectEntryInfoItemExceptionRequestHandlerTest` — unit tests verifying both `AT_LEAST_ONE_CATEGORY` → `RequiredAssetCategory` and `TOO_MANY_CATEGORIES` → `TooManyAssetCategories`