### PR TITLE
LPD-96570 Compare XLIFF export output semantically in export tests

### DIFF
--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF12TranslationInfoItemFieldValuesExporterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF12TranslationInfoItemFieldValuesExporterTest.java
@@ -89,18 +89,20 @@ public class XLIFF12TranslationInfoItemFieldValuesExporterTest {
 			_group, _ddmFormDeserializer);
 
 		Assert.assertEquals(
-			StringUtil.replace(
-				TranslationTestUtil.readFileToString(
-					"test-journal-article-v12.xlf"),
-				"[$JOURNAL_ARTICLE_ID$]",
-				String.valueOf(journalArticle.getResourcePrimKey())),
-			StreamUtil.toString(
-				_xliffTranslationInfoItemFieldValuesExporter.
-					exportInfoItemFieldValues(
-						infoItemFieldValuesProvider.getInfoItemFieldValues(
-							journalArticle),
-						LocaleUtil.getDefault(),
-						LocaleUtil.fromLanguageId("es_ES"))));
+			TranslationTestUtil.toFormattedString(
+				StringUtil.replace(
+					TranslationTestUtil.readFileToString(
+						"test-journal-article-v12.xlf"),
+					"[$JOURNAL_ARTICLE_ID$]",
+					String.valueOf(journalArticle.getResourcePrimKey()))),
+			TranslationTestUtil.toFormattedString(
+				StreamUtil.toString(
+					_xliffTranslationInfoItemFieldValuesExporter.
+						exportInfoItemFieldValues(
+							infoItemFieldValuesProvider.getInfoItemFieldValues(
+								journalArticle),
+							LocaleUtil.getDefault(),
+							LocaleUtil.fromLanguageId("es_ES")))));
 	}
 
 	@Inject(filter = "ddm.form.deserializer.type=json")

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
@@ -350,11 +350,13 @@ public class TranslationManagerTest {
 		throws Exception {
 
 		Assert.assertEquals(
-			StringUtil.replace(
-				TranslationTestUtil.readFileToString(expected),
-				"[$JOURNAL_ARTICLE_ID$]",
-				String.valueOf(_journalArticle.getResourcePrimKey())),
-			StringUtil.read(inputStream));
+			TranslationTestUtil.toFormattedString(
+				StringUtil.replace(
+					TranslationTestUtil.readFileToString(expected),
+					"[$JOURNAL_ARTICLE_ID$]",
+					String.valueOf(_journalArticle.getResourcePrimKey()))),
+			TranslationTestUtil.toFormattedString(
+				StringUtil.read(inputStream)));
 	}
 
 	private String _getXLIFFFileName() {

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/test/util/TranslationTestUtil.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/test/util/TranslationTestUtil.java
@@ -25,6 +25,8 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -63,6 +65,12 @@ public class TranslationTestUtil {
 
 	public static String readFileToString(String fileName) throws Exception {
 		return new String(_getBytes(fileName));
+	}
+
+	public static String toFormattedString(String xml) throws Exception {
+		Document document = SAXReaderUtil.read(xml);
+
+		return document.formattedString();
 	}
 
 	public static void withRegularUser(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96570

## What Is Being Fixed

`XLIFF12TranslationInfoItemFieldValuesExporterTest#testExportReturnsTheXLIFFRepresentationOfAJournalArticle` and `TranslationManagerTest#testGetXLIFFFile` were failing with `org.junit.ComparisonFailure`. The XLIFF 1.2 exporter serializes the document with `document.asXML()`, which dom4j emits as a single compact line with an `<?xml version="1.0" encoding="UTF-8"?>` declaration, while the expected fixtures are pretty-printed with tab indentation. Both tests compared the two with an exact-string `assertEquals`, so they failed on framing and whitespace even though the translation-unit content already matched.

## How It Is Being Fixed

Rather than minify the fixtures to match the compact serialization (which would leave the expected XLIFF unreadable), the tests now compare the XLIFF semantically. A shared `TranslationTestUtil.toFormattedString` helper parses each XLIFF string and re-serializes it through `Document.formattedString()`, so both the fixture and the exporter output are canonicalized to the same shape before the assertion. The fixtures stay human-readable and untouched, and because the transform preserves content, attribute order, and CDATA, a real regression still fails the comparison. Source-formatter support for pretty-printing `.xlf` files is tracked separately in LPD-96904.

## How to Test

```
gradlew -p modules/apps/translation/translation-test testIntegration --tests XLIFF12TranslationInfoItemFieldValuesExporterTest --tests TranslationManagerTest
```

## PR Check

**pr-check: PASS** — tested on `d95176977ba66150ad2ccf51a0bd407a83f75311`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d95176977ba66150ad2ccf51a0bd407a83f75311"} -->
