### PR TITLE
LPD-96913 Fall back to the category ID for over-long friendly URLs

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageObjectProvider.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -94,7 +95,11 @@ public class AssetCategoryLayoutDisplayPageObjectProvider
 			if (FeatureFlagManagerUtil.isEnabled(
 					_assetCategory.getCompanyId(), "LPD-70396")) {
 
-				return _getUrlTitle(locale);
+				String urlTitle = _getUrlTitle(locale);
+
+				if (urlTitle.length() <= Http.URL_MAXIMUM_LENGTH) {
+					return urlTitle;
+				}
 			}
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -67,6 +68,13 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 		_testGetLayoutDisplayPageObjectProviderNestedAssetCategory();
 	}
 
+	@FeatureFlag("LPD-70396")
+	@Test
+	public void testGetURLTitle() throws Exception {
+		_testGetURLTitleWithMaximumLengthExceeded();
+		_testGetURLTitleWithMaximumLengthNotExceeded();
+	}
+
 	private AssetCategory _addAssetCategory(
 			long assetVocabularyId, long parentAssetCategoryId, String title)
 		throws Exception {
@@ -85,6 +93,17 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 		return AssetTestUtil.addVocabulary(
 			_group.getGroupId(),
 			StringUtil.toLowerCase(StringUtil.randomString()));
+	}
+
+	private LayoutDisplayPageObjectProvider<?>
+		_getLayoutDisplayPageObjectProvider(AssetCategory assetCategory) {
+
+		return _layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+			assetCategory.getGroupId(),
+			new InfoItemReference(
+				AssetCategory.class.getName(),
+				new ERCInfoItemIdentifier(
+					assetCategory.getExternalReferenceCode())));
 	}
 
 	private void _testGetLayoutDisplayPageObjectProviderERCInfoItemIdentifier()
@@ -190,6 +209,58 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 			assetCategory4,
 			layoutDisplayPageObjectProvider2.getDisplayObject());
 	}
+
+	private void _testGetURLTitleWithMaximumLengthExceeded() throws Exception {
+		AssetVocabulary assetVocabulary = _addAssetVocabulary();
+
+		long parentCategoryId =
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID;
+
+		AssetCategory assetCategory = null;
+
+		int categoryCount =
+			(Http.URL_MAXIMUM_LENGTH / _CATEGORY_TITLE_LENGTH) + 2;
+
+		for (int i = 0; i < categoryCount; i++) {
+			assetCategory = _addAssetCategory(
+				assetVocabulary.getVocabularyId(), parentCategoryId,
+				StringUtil.toLowerCase(
+					StringUtil.randomString(_CATEGORY_TITLE_LENGTH)));
+
+			parentCategoryId = assetCategory.getCategoryId();
+		}
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_getLayoutDisplayPageObjectProvider(assetCategory);
+
+		Assert.assertEquals(
+			String.valueOf(assetCategory.getCategoryId()),
+			layoutDisplayPageObjectProvider.getURLTitle(
+				LocaleUtil.getDefault()));
+	}
+
+	private void _testGetURLTitleWithMaximumLengthNotExceeded()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = _addAssetVocabulary();
+
+		String urlTitle = StringUtil.toLowerCase(StringUtil.randomString());
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, urlTitle);
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_getLayoutDisplayPageObjectProvider(assetCategory);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				assetVocabulary.getName(), StringPool.SLASH, urlTitle),
+			layoutDisplayPageObjectProvider.getURLTitle(
+				LocaleUtil.getDefault()));
+	}
+
+	private static final int _CATEGORY_TITLE_LENGTH = 250;
 
 	@Inject
 	private AssetCategoryLocalService _assetCategoryLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96913

## What Is Being Fixed

When feature flag `LPD-70396` is enabled, `AssetCategoryLayoutDisplayPageObjectProvider` generates the display page friendly URL of a category by concatenating the vocabulary name and the localized slug of every ancestor plus the category itself (`vocabulary/ancestor1/.../leaf`). Each individual slug is capped at 255 characters, but the concatenated path has no upper bound, so a deep category hierarchy (or long names) can produce a path that is unusable as a URL.

## How It Is Being Fixed

`getURLTitle` now falls back to the numeric category ID URL — the same value already returned when the flag is off or resolution fails — whenever the generated path exceeds `Http.URL_MAXIMUM_LENGTH` (2083, the Internet Explorer maximum URL length, which is the constant the portal already uses as its "URL too long" reference, e.g. in `PortletDisplay.setURLBack`).

The check intentionally compares only the category path segment, not the full URL, and this matches existing portal precedent. Trailing query parameters (`redirect`, `p_l_back_url`, `doAsUserId`, `p_auth`, ...) are not this layer's concern: `HttpComponentsUtil.shortenURL` already trims an over-length assembled URL by dropping query parameters, sacrificing `_redirect` / `_backURL` / `_returnToFullPageURL` / `redirect` last, and `PortletDisplay.setURLBack` uses it and blanks the value if it is still too long. That utility only ever trims the query string, never the path, so the path length is the one thing this provider must bound — which is exactly the unbounded input this feature introduces. No portal code reserves headroom by subtracting a margin from `URL_MAXIMUM_LENGTH`; every usage compares against it directly, and nested Layout friendly URLs are likewise unguarded for total path length, so reserving a margin for the host/prefix would be unprecedented. As an acknowledged residual, a path near the limit plus the host and display page prefix could still nudge the pre-query URL over 2083, and `shortenURL` cannot help there because it does not touch the path; this is the same pre-existing, unguarded condition that already applies to nested Layout friendly URLs across the portal.

## PR Check

**pr-check: PASS** — tested on `e2bba6e324a560231f371bc07d7558263e346e67`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e2bba6e324a560231f371bc07d7558263e346e67"} -->
