### PR TITLE
LPD-95408 Remove the extension filter from the CMS recycle bin

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
@@ -43,7 +43,6 @@ import org.osgi.service.component.annotations.Reference;
 		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.ALL_RELATED_ASSETS_SECTION,
 		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.ALL_SECTION,
 		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.FILES_SECTION,
-		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.RECYCLE_BIN_SECTION,
 		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.VIEW_FILES_FOLDER,
 		"service.ranking:Integer=97"
 	},

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -1069,6 +1069,54 @@ test(
 );
 
 test(
+	'The Recycle Bin filter menu does not offer the extension filter',
+	{tag: '@LPD-95408'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = getRandomString();
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('Trash the content', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('The filter menu offers Space but not Extension', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+
+			await page.getByRole('button', {name: 'Filter'}).click();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'Space'})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'Extension'})
+			).toBeHidden();
+		});
+	}
+);
+
+test(
 	'Space General Settings Recycle Bin panel honors trashEnabled and max age validation',
 	{tag: '@LPD-89104'},
 	async ({apiHelpers, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95408

## What Is Being Fixed

The CMS Recycle Bin offered an Extension filter that always rendered without options. The filter builds its options from a search aggregation over the live index, which can never match the trashed entries the Recycle Bin lists, so the filter could never work in that view. Per the ticket, it should not be offered there at all.

## How It Is Being Fixed

The ExtensionSelectionFDSFilter component is no longer registered for the recycle bin frontend data set, so the filter disappears from that view while staying available in the file sections that share the component. A Playwright regression test asserts the Recycle Bin filter menu offers the Space filter but not Extension. While verifying the change, a separate pre-existing defect surfaced — the aggregation also never returns options in the remaining sections — and was filed as LPD-96958 rather than folded into this fix.

## PR Check

**pr-check: PASS** — tested on `706c32c74ab4ad5f2dd16d7b7d26be12b5cc93db`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "706c32c74ab4ad5f2dd16d7b7d26be12b5cc93db"} -->


