### PR TITLE
LPD-95407 Group the recycle bin filters like the other CMS sections

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/RecycleBinFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/RecycleBinFDSPropsTransformer.ts
@@ -7,6 +7,7 @@ import {
 	IBulkActionItem,
 	IInternalRenderer,
 } from '@liferay/frontend-data-set-web';
+import {getCMSItemSelectorGroupedFilters} from '@liferay/frontend-js-item-selector-web';
 import {sub} from 'frontend-js-web';
 
 import {
@@ -76,6 +77,7 @@ export default function RecycleBinFDSPropsTransformer({
 				} as IInternalRenderer,
 			],
 		},
+		groupedFilters: getCMSItemSelectorGroupedFilters('scopeGroupId'),
 		hideManagementBarInEmptyState: true,
 		itemsActions: itemsActions.map((action) => {
 			if (action?.data?.id === 'actionLink') {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -1117,6 +1117,58 @@ test(
 );
 
 test(
+	'The Recycle Bin filter menu groups the filters by type',
+	{tag: '@LPD-95407'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = getRandomString();
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('Trash the content', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('The filter menu shows the filters grouped', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+
+			await page.getByRole('button', {name: 'Filter'}).click();
+
+			await expect(
+				page
+					.getByRole('group', {exact: true, name: 'Filter By'})
+					.getByRole('menuitem', {name: 'Space'})
+			).toBeVisible();
+
+			await expect(
+				page
+					.getByRole('group', {name: 'Filter by Date'})
+					.getByRole('menuitem', {name: 'Create Date'})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
 	'Space General Settings Recycle Bin panel honors trashEnabled and max age validation',
 	{tag: '@LPD-89104'},
 	async ({apiHelpers, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95407

## What Is Being Fixed

The CMS Recycle Bin's Filter menu rendered its filters as a flat list, while every other CMS section groups them under "Filter By" and "Filter by Date".

## How It Is Being Fixed

The CMS sections group their Filter menu client side through the groupedFilters frontend data set prop, built by the shared getCMSItemSelectorGroupedFilters helper, but the recycle bin props transformer never set that prop, so the menu fell back to the ungrouped list. The transformer now passes the same shared grouping the asset sections use, with the space filter id the recycle bin registers. Grouped ids that have no registered filter for the recycle bin data set are simply not rendered, so the change composes with the extension filter work in LPD-95408 and LPD-96958. A Playwright regression test opens the Recycle Bin's Filter menu and asserts both group labels and a representative filter of each group.

## PR Check

**pr-check: PASS** — tested on `86b6492b17be7dcde3b84aeede28dbed30c98a34`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "86b6492b17be7dcde3b84aeede28dbed30c98a34"} -->


