### PR TITLE
LPD-97057 Keep repeated translations populating the source view

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.tsx
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.tsx
@@ -215,6 +215,10 @@ const TranslateFieldEditor = ({
 				textarea.value = targetContent;
 
 				sourceEditingArea!.dataset.value = targetContent;
+
+				lastSourceInputRef.current = targetContent;
+
+				sourceEditingPlugin.updateEditorData();
 			}
 		}
 

--- a/modules/apps/translation/translation-web/test/js/translate/components/TranslateFieldSetEntries.tsx
+++ b/modules/apps/translation/translation-web/test/js/translate/components/TranslateFieldSetEntries.tsx
@@ -12,46 +12,84 @@ import TranslateFieldSetEntries from '../../../../src/main/resources/META-INF/re
 jest.mock('frontend-editor-ckeditor-web', () => {
 	const React = require('react');
 
+	const normalize = (value: string) =>
+		value === '' || value.startsWith('<') ? value : `<p>${value}</p>`;
+
 	return {
 		CKEditor5ClassicEditor: ({data, onReady}: any) => {
 			const wrapperRef = React.useRef(null);
+			const readyRef = React.useRef(false);
+			const stateRef = React.useRef({dataFromRoots: '', model: ''});
+
+			const getArea = () =>
+				wrapperRef.current.querySelector('.ck-source-editing-area');
+
+			const updateEditorData = () => {
+				const editorState = stateRef.current;
+
+				const newData = getArea().dataset.value;
+
+				if (editorState.dataFromRoots !== newData) {
+					editorState.model = normalize(newData);
+					editorState.dataFromRoots = newData;
+				}
+			};
+
+			const getData = () => {
+				updateEditorData();
+
+				return stateRef.current.model;
+			};
 
 			React.useEffect(() => {
-				const wrapper = wrapperRef.current;
+				const area = getArea();
+				const textarea = area.querySelector('textarea');
+				const editorState = stateRef.current;
 
-				const textarea = wrapper.querySelector('textarea');
-
+				area.dataset.value = data;
 				textarea.value = data;
+				editorState.dataFromRoots = data;
+				editorState.model = data;
 
-				const sourceEditingPlugin = {
-					isSourceEditingMode: true,
-					on: (event: string, callback: () => void) => {
-						if (event === 'change:isSourceEditingMode') {
-							callback();
-						}
-					},
-				};
+				textarea.addEventListener('input', () => {
+					area.dataset.value = textarea.value;
+				});
 
 				onReady({
-					getData: () =>
-						textarea.value.startsWith('<')
-							? textarea.value
-							: `<p>${textarea.value}</p>`,
+					getData,
 					plugins: {
-						get: () => sourceEditingPlugin,
+						get: () => ({
+							isSourceEditingMode: true,
+							on: (event: string, callback: () => void) => {
+								if (event === 'change:isSourceEditingMode') {
+									callback();
+								}
+							},
+							updateEditorData,
+						}),
 					},
 					ui: {
-						element: wrapper,
+						element: wrapperRef.current,
 					},
 				});
+
+				readyRef.current = true;
 
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, []);
 
+			React.useEffect(() => {
+				if (readyRef.current && getData() !== data) {
+					stateRef.current.model = data;
+				}
+
+				// eslint-disable-next-line react-hooks/exhaustive-deps
+			}, [data]);
+
 			return (
 				<div ref={wrapperRef}>
 					<div className="ck-source-editing-area">
-						<textarea aria-label="source" defaultValue={data} />
+						<textarea aria-label="source" />
 					</div>
 				</div>
 			);
@@ -95,6 +133,29 @@ const buildComponent = (content: string) => (
 		}}
 	/>
 );
+
+const SourceEditingHarness = ({initialContent}: {initialContent: string}) => {
+	const [content, setContent] = React.useState(initialContent);
+
+	return (
+		<>
+			<button onClick={() => setContent(TRANSLATED_TARGET)} type="button">
+				translate
+			</button>
+
+			<TranslateFieldSetEntries
+				autoTranslateEnabled={false}
+				fetchAutoTranslateField={() => {}}
+				infoFieldSetEntries={infoFieldSetEntries}
+				onChange={({content: newContent}) => setContent(newContent)}
+				portletNamespace="_mock_TranslationPortlet_"
+				targetFieldsContent={{
+					[ID]: {content, message: '', status: ''},
+				}}
+			/>
+		</>
+	);
+};
 
 describe('TranslateFieldSetEntries', () => {
 	beforeAll(() => {
@@ -143,5 +204,21 @@ describe('TranslateFieldSetEntries', () => {
 		rerender(buildComponent(TRANSLATED_TARGET));
 
 		expect(textarea).toHaveValue(TRANSLATED_TARGET);
+	});
+
+	it('keeps populating the source view after repeated remove-and-translate cycles', () => {
+		render(<SourceEditingHarness initialContent={ORIGINAL_TARGET} />);
+
+		const textarea = screen.getByLabelText('source');
+
+		for (let cycle = 0; cycle < 3; cycle++) {
+			fireEvent.click(screen.getByText('translate'));
+
+			expect(textarea).toHaveValue(TRANSLATED_TARGET);
+
+			fireEvent.input(textarea, {target: {value: ''}});
+
+			expect(textarea).toHaveValue('');
+		}
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97057

## What Is Being Fixed

In a rich-text field's Source (HTML) editing mode, clicking Auto-Translate, clearing the translated content, and translating again repeatedly caused the translation to stop appearing after two or three cycles — the source textarea stayed empty even though a translation had been requested.

## How It Is Being Fixed

In source editing mode the CKEditor React wrapper writes an incoming translation straight into the editor model, while the SourceEditing plugin only reconciles the textarea into the model when its tracked source value changed. After a clear-and-translate cycle these two fell out of sync, so `editor.getData()` returned the stale prior translation. That stale value propagated back to the field as if it were the user's edit, pinning the target content to the previous translation; because the next identical auto-translation produced no change, the effect that refreshes the source view never fired.

The fix pushes the freshly written source through the plugin's public `updateEditorData` API right after updating the textarea, keeping the model and the plugin's internal data map in sync, and records the written value as the last source input. A clear is now observed correctly and repeated translations keep populating the source view.

## PR Check

**pr-check: PASS** — tested on `73c416904f0690a1aa2f655315c93b3ac897681a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "73c416904f0690a1aa2f655315c93b3ac897681a"} -->
