### PR TITLE
LPD-83766 Hide the Spaces tab when selecting web content

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/build.gradle
+++ b/modules/apps/item-selector/item-selector-taglib/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
+	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
@@ -7,10 +7,12 @@ package com.liferay.item.selector.taglib.internal.display.context;
 
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
 import com.liferay.item.selector.provider.GroupItemSelectorProvider;
 import com.liferay.item.selector.taglib.internal.servlet.item.selector.ItemSelectorUtil;
 import com.liferay.item.selector.taglib.internal.util.EntryURLUtil;
 import com.liferay.item.selector.taglib.internal.util.GroupItemSelectorProviderRegistryUtil;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -29,6 +31,7 @@ import com.liferay.site.search.GroupSearch;
 import jakarta.portlet.PortletURL;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -112,7 +115,9 @@ public class GroupSelectorDisplayContext {
 			List<String> parts = StringUtil.split(criterion);
 
 			if (parts.contains("file") || parts.contains("folder") ||
-				parts.contains("image")) {
+				parts.contains("image") ||
+				(parts.contains("infoitem") &&
+				 _isJournalArticleItemSelectorCriterion())) {
 
 				groupItemSelectorProviderTypes.remove("space-depot");
 
@@ -237,6 +242,33 @@ public class GroupSelectorDisplayContext {
 			_liferayPortletRequest, "selectedTab");
 
 		return _selectedTab;
+	}
+
+	private boolean _isJournalArticleItemSelectorCriterion() {
+		ItemSelector itemSelector = _getItemSelector();
+
+		for (ItemSelectorCriterion itemSelectorCriterion :
+				itemSelector.getItemSelectorCriteria(
+					_liferayPortletRequest.getParameterMap())) {
+
+			if (!(itemSelectorCriterion instanceof
+					InfoItemItemSelectorCriterion)) {
+
+				continue;
+			}
+
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion =
+				(InfoItemItemSelectorCriterion)itemSelectorCriterion;
+
+			if (Objects.equals(
+					infoItemItemSelectorCriterion.getItemType(),
+					JournalArticle.class.getName())) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isScopeGroupType() {

--- a/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
@@ -5,12 +5,17 @@
 
 package com.liferay.item.selector.taglib.internal.display.context;
 
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
 import com.liferay.item.selector.provider.GroupItemSelectorProvider;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.PortletRequest;
@@ -19,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -59,17 +65,43 @@ public class GroupSelectorDisplayContextTest {
 			RandomTestUtil.randomLong()
 		);
 
-		_serviceRegistration = bundleContext.registerService(
-			GroupItemSelectorProvider.class,
-			new MockGroupItemSelectorProvider(), null);
+		Mockito.when(
+			PortalUtil.getHttpServletRequest(
+				Mockito.any(LiferayPortletRequest.class))
+		).thenAnswer(
+			invocationOnMock -> {
+				LiferayPortletRequest liferayPortletRequest =
+					invocationOnMock.getArgument(0);
+
+				return liferayPortletRequest.getHttpServletRequest();
+			}
+		);
+
+		_groupItemSelectorProviderServiceRegistration =
+			bundleContext.registerService(
+				GroupItemSelectorProvider.class,
+				new MockGroupItemSelectorProvider("test"), null);
+		_itemSelectorServiceRegistration = bundleContext.registerService(
+			ItemSelector.class, _itemSelector, null);
+		_spaceDepotGroupItemSelectorProviderServiceRegistration =
+			bundleContext.registerService(
+				GroupItemSelectorProvider.class,
+				new MockGroupItemSelectorProvider("space-depot"), null);
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
-		_serviceRegistration.unregister();
+		_groupItemSelectorProviderServiceRegistration.unregister();
+		_itemSelectorServiceRegistration.unregister();
+		_spaceDepotGroupItemSelectorProviderServiceRegistration.unregister();
 
 		_frameworkUtilMockedStatic.close();
 		_portalUtilMockedStatic.close();
+	}
+
+	@After
+	public void tearDown() {
+		Mockito.reset(_itemSelector);
 	}
 
 	@Test
@@ -94,6 +126,76 @@ public class GroupSelectorDisplayContextTest {
 
 	@Test
 	public void testGetGroupTypes() {
+		_testGetGroupTypesWithoutCMSFeatureFlag();
+		_testGetGroupTypesWithFileItemSelectorCriterion();
+		_testGetGroupTypesWithJournalArticleInfoItemItemSelectorCriterion();
+		_testGetGroupTypesWithoutJournalArticleInfoItemItemSelectorCriterion();
+	}
+
+	private MockedStatic<FeatureFlagManagerUtil> _enableCMSFeatureFlag() {
+		MockedStatic<FeatureFlagManagerUtil>
+			featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+				FeatureFlagManagerUtil.class);
+
+		featureFlagManagerUtilMockedStatic.when(
+			() -> FeatureFlagManagerUtil.isEnabled(
+				Mockito.anyLong(), Mockito.eq("LPD-17564"))
+		).thenReturn(
+			true
+		);
+
+		return featureFlagManagerUtilMockedStatic;
+	}
+
+	private void _testGetGroupTypesWithFileItemSelectorCriterion() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "file");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithJournalArticleInfoItemItemSelectorCriterion() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion =
+				new InfoItemItemSelectorCriterion();
+
+			infoItemItemSelectorCriterion.setItemType(
+				"com.liferay.journal.model.JournalArticle");
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(infoItemItemSelectorCriterion)
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithoutCMSFeatureFlag() {
 		GroupSelectorDisplayContext groupSelectorDisplayContext =
 			new GroupSelectorDisplayContext(new MockLiferayResourceRequest());
 
@@ -102,15 +204,49 @@ public class GroupSelectorDisplayContextTest {
 			groupSelectorDisplayContext.getGroupTypes());
 	}
 
+	private void _testGetGroupTypesWithoutJournalArticleInfoItemItemSelectorCriterion() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				SetUtil.fromArray("space-depot", "test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
 	private static final MockedStatic<FrameworkUtil>
 		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
+	private static ServiceRegistration<GroupItemSelectorProvider>
+		_groupItemSelectorProviderServiceRegistration;
+	private static final ItemSelector _itemSelector = Mockito.mock(
+		ItemSelector.class);
+	private static ServiceRegistration<ItemSelector>
+		_itemSelectorServiceRegistration;
 	private static final MockedStatic<PortalUtil> _portalUtilMockedStatic =
 		Mockito.mockStatic(PortalUtil.class);
 	private static ServiceRegistration<GroupItemSelectorProvider>
-		_serviceRegistration;
+		_spaceDepotGroupItemSelectorProviderServiceRegistration;
 
 	private static class MockGroupItemSelectorProvider
 		implements GroupItemSelectorProvider {
+
+		public MockGroupItemSelectorProvider(String groupType) {
+			_groupType = groupType;
+		}
 
 		@Override
 		public String getEmptyResultsMessage() {
@@ -133,7 +269,7 @@ public class GroupSelectorDisplayContextTest {
 
 		@Override
 		public String getGroupType() {
-			return "test";
+			return _groupType;
 		}
 
 		@Override
@@ -145,6 +281,8 @@ public class GroupSelectorDisplayContextTest {
 		public String getLabel(Locale locale) {
 			return "label";
 		}
+
+		private final String _groupType;
 
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83766

## What Is Being Fixed

When selecting a web content article through the item selector, for example from the Web Content Display widget's "Select Web Content", the "Sites and Libraries" screen offered a "Spaces" tab. CMS Spaces cannot contain DXP web content articles, so the tab only led to empty results and should not appear in this flow.

## How It Is Being Fixed

The group selector's top bar buttons come from the group item selector provider types, filtered in GroupSelectorDisplayContext.getGroupTypes(). That filter already removes the space-depot type for the Documents and Media criteria (file, folder, and image tokens), but the web content flow uses InfoItemItemSelectorCriterion, whose generic infoitem token was not handled. The filter now also removes the type when an info item criterion's item type is a web content article, resolving the type from the serialized criteria since only criteria-derived state survives the group selector's URL regeneration on tab switches and pagination. Generic info item selection keeps the tab because Spaces legitimately hold other info items, such as CMS content mapped in the page editor.

Coverage: unit tests verify the three behaviors on GroupSelectorDisplayContext (web content criterion hides the tab, a generic info item criterion keeps it, and the preexisting Documents and Media filtering, which had no test). Both behaviors were also verified against a running bundle by rendering the group selector with each criterion payload.

## PR Check

**pr-check: PASS** — tested on `49f5b4a2bf668c1f13a3987ddc9ba8dd8b57fdb3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "49f5b4a2bf668c1f13a3987ddc9ba8dd8b57fdb3"} -->
