### PR TITLE
LPD-97134 Fix journal tests

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -400,7 +400,15 @@ test(
 
 		await page.getByLabel('Filter', {exact: true}).click();
 
-		await page.getByRole('menuitem', {name: 'Web Content'}).click();
+		const webContentFilter = page.getByRole('menuitem', {
+			name: 'Web Content',
+		});
+
+		if ((await webContentFilter.getAttribute('aria-selected')) !== 'true') {
+			await webContentFilter.click();
+		}
+
+		await page.keyboard.press('Escape');
 
 		const foldersList = await page
 			.getByRole('link')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97134

## What Is Being Fixed

The journal "Folders come first when having multiple pages and filtering by Approved" Playwright test timed out. After reopening the Filter menu it clicked the "Web Content" type entry, but that type is selected by default (JournalDisplayContext.getType() defaults to "web-content"), so clicking the already-active Clay menu item was intercepted by its section wrapper and never completed.

## How It Is Being Fixed

The test now reads the entry's selected state and clicks it only when it is not already active, then closes the menu with Escape. The Approved status and Web Content type filters end up applied exactly as before, and the folder-ordering assertion is unchanged. The default-selected behavior was confirmed in the product code, so no regression is being masked.

## PR Check

**pr-check: PASS** — tested on `0b9ed20ebe43ca03a1806fc6276a6f8e25776404`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "0b9ed20ebe43ca03a1806fc6276a6f8e25776404"} -->
