### PR TITLE
LPD-97156 Shrink the Asset Sharing Poshi test suite

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/BlogsSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/BlogsSharing.testcase
@@ -160,6 +160,40 @@ definition {
 			commentCount = 1,
 			entryComment = "test",
 			userFullName = "userfn userln");
+
+		User.logoutPG();
+
+		User.loginPG(
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
+
+		BlogsNavigator.gotoShare(entryTitle = "Blogs Entry Title");
+
+		Asset.share(
+			sharingPermissions = "View",
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln");
+
+		User.logoutAndLoginPG(
+			userLoginEmailAddress = "userea@liferay.com",
+			userLoginFullName = "userfn userln");
+
+		Notifications.viewBadgeCount(notificationCount = 1);
+
+		Notifications.gotoNotifications();
+
+		Notifications.viewNewSharedContent(
+			contentSharingPermission = "viewing",
+			contentTitle = "Blogs Entry Title",
+			openNotification = "true",
+			ownerName = "Test Test");
+
+		BlogsEntry.viewSharedAsset(
+			contentSharingPermission = "View",
+			entryContent = "Blogs Entry Content",
+			entryTitle = "Blogs Entry Title");
 	}
 
 	@description = "This test ensures a user can update a blog entry once it is shared with him."
@@ -204,36 +238,6 @@ definition {
 		BlogsEntry.viewSharedAsset(
 			entryContent = "Blogs Entry Content Edit",
 			entryTitle = "Blogs Entry Title Edit");
-	}
-
-	@description = "This test ensures a user can only view a blog entry once it is shared with him."
-	@priority = 5
-	test CanShareWithViewPermissions {
-		BlogsNavigator.gotoShare(entryTitle = "Blogs Entry Title");
-
-		Asset.share(
-			sharingPermissions = "View",
-			userEmailAddress = "userea@liferay.com",
-			userName = "userfn userln");
-
-		User.logoutAndLoginPG(
-			userLoginEmailAddress = "userea@liferay.com",
-			userLoginFullName = "userfn userln");
-
-		Notifications.viewBadgeCount(notificationCount = 1);
-
-		Notifications.gotoNotifications();
-
-		Notifications.viewNewSharedContent(
-			contentSharingPermission = "viewing",
-			contentTitle = "Blogs Entry Title",
-			openNotification = "true",
-			ownerName = "Test Test");
-
-		BlogsEntry.viewSharedAsset(
-			contentSharingPermission = "View",
-			entryContent = "Blogs Entry Content",
-			entryTitle = "Blogs Entry Title");
 	}
 
 	@description = "This test asserts that proper notifications are sent based on sharing permissions granted."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/BlogsSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/BlogsSharing.testcase
@@ -122,7 +122,7 @@ definition {
 			value1 = "Notification for Sharing was deleted.");
 	}
 
-	@description = "This test ensures a user can only comment on a blog entry once it is shared with him."
+	@description = "This test ensures a user can view, comment on, and update a blog entry once it is shared with him with the matching permission."
 	@priority = 5
 	@refactordone
 	test CanShareWithPermissions {
@@ -194,13 +194,14 @@ definition {
 			contentSharingPermission = "View",
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry Title");
-	}
 
-	@description = "This test ensures a user can update a blog entry once it is shared with him."
-	@priority = 5
-	@refactordone
-	test CanShareWithUpdatePermissions {
-		property portal.acceptance = "true";
+		User.logoutPG();
+
+		User.loginPG(
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		BlogsNavigator.gotoShare(entryTitle = "Blogs Entry Title");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/BlogsSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/BlogsSharing.testcase
@@ -125,7 +125,7 @@ definition {
 	@description = "This test ensures a user can only comment on a blog entry once it is shared with him."
 	@priority = 5
 	@refactordone
-	test CanShareWithCommentPermissions {
+	test CanShareWithPermissions {
 		property portal.acceptance = "true";
 
 		BlogsNavigator.gotoShare(entryTitle = "Blogs Entry Title");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
@@ -418,7 +418,7 @@ definition {
 	@description = "This test covers LPS-94294. This test asserts that a user can comment on a document it is shared with him"
 	@priority = 4
 	@refactordone
-	test CanShareWithCommentPermissions {
+	test CanShareWithPermissions {
 		JSONDocument.addFileWithUploadedFile(
 			dmDocumentDescription = "DM Document Description",
 			dmDocumentTitle = "DM Document Title",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
@@ -51,7 +51,7 @@ definition {
 		}
 	}
 
-	@description = "This test asserts that a user can change the view permission to the comment permission via the manage collaborators."
+	@description = "This test asserts that a user can change the view permission to the comment permission and then to the update permission via the manage collaborators."
 	@priority = 4
 	@refactordone
 	test CanChangePermissionViaManageCollaborators {
@@ -99,28 +99,12 @@ definition {
 		DMDocumentSharing.viewDocumentViaSharedContent(
 			contentSharingPermission = "Comment",
 			dmDocumentTitle = "DM Document Title");
-	}
 
-	@description = "This test asserts that a user can change the view permission to the update permission via the manage collaborators"
-	@priority = 4
-	@refactordone
-	test CanChangePermissionToUpdateViaManageCollaborators {
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Guest",
-			guestPermissions = "false",
-			mimeType = "application/msword",
-			sourceFileName = "Document_1.doc");
+		User.logoutPG();
 
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
-
-		DMDocument.sharePG(
-			noAutocomplete = "true",
-			userEmailAddress = "userea@liferay.com",
-			userName = "userfn userln");
+		User.loginPG(
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
 
 		Navigator.gotoPage(pageName = "Documents and Media Page");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
@@ -415,7 +415,7 @@ definition {
 		LexiconEntry.viewNoEntryMenu(rowEntry = "DM Document Title");
 	}
 
-	@description = "This test covers LPS-94294. This test asserts that a user can comment on a document it is shared with him"
+	@description = "This test covers LPS-94294, LPS-94448. It asserts that a user can view, comment on, and update a document once it is shared with him with the matching permission."
 	@priority = 4
 	@refactordone
 	test CanShareWithPermissions {
@@ -522,6 +522,64 @@ definition {
 		DMDocumentSharing.viewDocumentViaSharedContent(
 			contentSharingPermission = "View",
 			dmDocumentTitle = "DM Document Title View");
+
+		User.logoutPG();
+
+		User.loginPG(
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "DM Document Title Update",
+			groupName = "Guest",
+			guestPermissions = "false",
+			mimeType = "image/jpeg",
+			sourceFileName = "Document_1.jpg");
+
+		Navigator.gotoPage(pageName = "Documents and Media Page");
+
+		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title Update");
+
+		DMDocument.sharePG(
+			noAutocomplete = "true",
+			sharingPermissions = "Update",
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln");
+
+		Navigator.gotoPage(pageName = "Documents and Media Page");
+
+		LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+		DMDocumentSharing.viewSharedFlag(
+			detailsView = "true",
+			dmDocumentTitle = "DM Document Title Update");
+
+		User.logoutPG();
+
+		User.loginUserPG(
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "userea@liferay.com");
+
+		Notifications.viewBadgeCount(notificationCount = 1);
+
+		Notifications.gotoNotifications();
+
+		Notifications.viewNewSharedContent(
+			contentSharingPermission = "updating",
+			contentTitle = "DM Document Title Update",
+			openNotification = "true",
+			ownerName = "Test Test");
+
+		LexiconEntry.gotoVerticalEllipsisMenuItemNoError(menuItem = "Edit");
+
+		DMDocument.editCmd(dmDocumentTitleEdit = "DM Document Title Update Edit");
+
+		Button.clickPublish();
+
+		DMDocumentSharing.viewDocumentViaSharedContent(
+			contentSharingPermission = "Update",
+			dmDocumentTitle = "DM Document Title Update Edit");
 	}
 
 	@description = "This test covers LPS-94661. It ensures that the user can share a document with an apostrophe in the title."
@@ -567,63 +625,6 @@ definition {
 			contentTitle = '''DM Document's Title''',
 			ownerName = "Test Test",
 			specialCharacter = "true");
-	}
-
-	@description = "This test asserts that a user can update a document once it is shared with him, also covers LPS-94448 and LPS-94294"
-	@priority = 4
-	@refactordone
-	test CanShareWithUpdatePermissions {
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Guest",
-			guestPermissions = "false",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
-
-		DMDocument.sharePG(
-			noAutocomplete = "true",
-			sharingPermissions = "Update",
-			userEmailAddress = "userea@liferay.com",
-			userName = "userfn userln");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		LexiconEntry.changeDisplayStyle(displayStyle = "list");
-
-		DMDocumentSharing.viewSharedFlag(
-			detailsView = "true",
-			dmDocumentTitle = "DM Document Title");
-
-		User.logoutPG();
-
-		User.loginUserPG(
-			password = PropsUtil.get("default.admin.password"),
-			userEmailAddress = "userea@liferay.com");
-
-		Notifications.viewBadgeCount(notificationCount = 1);
-
-		Notifications.gotoNotifications();
-
-		Notifications.viewNewSharedContent(
-			contentSharingPermission = "updating",
-			contentTitle = "DM Document Title",
-			openNotification = "true",
-			ownerName = "Test Test");
-
-		LexiconEntry.gotoVerticalEllipsisMenuItemNoError(menuItem = "Edit");
-
-		DMDocument.editCmd(dmDocumentTitleEdit = "DM Document Title Edit");
-
-		Button.clickPublish();
-
-		DMDocumentSharing.viewDocumentViaSharedContent(
-			contentSharingPermission = "Update",
-			dmDocumentTitle = "DM Document Title Edit");
 	}
 
 	@description = "This test makes sure all collaborators will view all collaborators of the document that was shared to him. This usecase also tests that a user can successfully remove collaborators through Manage Collaborators and asserts that empty message displays when all collaborators are removed."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
@@ -54,7 +54,7 @@ definition {
 	@description = "This test asserts that a user can change the view permission to the comment permission via the manage collaborators."
 	@priority = 4
 	@refactordone
-	test CanChangePermissionToCommentViaManageCollaborators {
+	test CanChangePermissionViaManageCollaborators {
 		JSONDocument.addFileWithUploadedFile(
 			dmDocumentDescription = "DM Document Description",
 			dmDocumentTitle = "DM Document Title",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
@@ -471,6 +471,57 @@ definition {
 			commentCount = 1,
 			entryComment = "test",
 			userFullName = "userfn userln");
+
+		User.logoutPG();
+
+		User.loginPG(
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "DM Document Title View",
+			groupName = "Guest",
+			guestPermissions = "false",
+			mimeType = "application/msword",
+			sourceFileName = "Document_1.doc");
+
+		Navigator.gotoPage(pageName = "Documents and Media Page");
+
+		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title View");
+
+		DMDocument.sharePG(
+			noAutocomplete = "true",
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln");
+
+		Navigator.gotoPage(pageName = "Documents and Media Page");
+
+		LexiconEntry.changeDisplayStyle(displayStyle = "Cards");
+
+		DMDocumentSharing.viewSharedFlag(
+			detailsView = "true",
+			dmDocumentTitle = "DM Document Title View");
+
+		User.logoutPG();
+
+		User.loginUserPG(
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "userea@liferay.com");
+
+		Notifications.viewBadgeCount(notificationCount = 1);
+
+		Notifications.gotoNotifications();
+
+		Notifications.viewNewSharedContent(
+			contentSharingPermission = "viewing",
+			contentTitle = "DM Document Title View",
+			openNotification = "true",
+			ownerName = "Test Test");
+
+		DMDocumentSharing.viewDocumentViaSharedContent(
+			contentSharingPermission = "View",
+			dmDocumentTitle = "DM Document Title View");
 	}
 
 	@description = "This test covers LPS-94661. It ensures that the user can share a document with an apostrophe in the title."
@@ -573,56 +624,6 @@ definition {
 		DMDocumentSharing.viewDocumentViaSharedContent(
 			contentSharingPermission = "Update",
 			dmDocumentTitle = "DM Document Title Edit");
-	}
-
-	@description = "This test asserts that a user can only view a document once it is shared with him"
-	@priority = 4
-	@refactordone
-	test CanShareWithViewPermissions {
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Guest",
-			guestPermissions = "false",
-			mimeType = "application/msword",
-			sourceFileName = "Document_1.doc");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
-
-		DMDocument.sharePG(
-			noAutocomplete = "true",
-			userEmailAddress = "userea@liferay.com",
-			userName = "userfn userln");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		LexiconEntry.changeDisplayStyle(displayStyle = "Cards");
-
-		DMDocumentSharing.viewSharedFlag(
-			detailsView = "true",
-			dmDocumentTitle = "DM Document Title");
-
-		User.logoutPG();
-
-		User.loginUserPG(
-			password = PropsUtil.get("default.admin.password"),
-			userEmailAddress = "userea@liferay.com");
-
-		Notifications.viewBadgeCount(notificationCount = 1);
-
-		Notifications.gotoNotifications();
-
-		Notifications.viewNewSharedContent(
-			contentSharingPermission = "viewing",
-			contentTitle = "DM Document Title",
-			openNotification = "true",
-			ownerName = "Test Test");
-
-		DMDocumentSharing.viewDocumentViaSharedContent(
-			contentSharingPermission = "View",
-			dmDocumentTitle = "DM Document Title");
 	}
 
 	@description = "This test makes sure all collaborators will view all collaborators of the document that was shared to him. This usecase also tests that a user can successfully remove collaborators through Manage Collaborators and asserts that empty message displays when all collaborators are removed."


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97156

## What Is Being Fixed

The Asset Sharing Poshi suite carries overlapping tests ahead of its migration to Playwright (LPD-97157), so the migration would port more tests than the coverage justifies.

## How It Is Being Fixed

Three .testcase files tagged testray.main.component.name = "Asset Sharing" carried overlapping tests. Within DMSharing, the two Manage Collaborators permission-change tests were merged into a single CanChangePermissionViaManageCollaborators, and the three CanShareWith{Comment,View,Update}Permissions tests were consolidated into one CanShareWithPermissions that exercises each permission's capability on its own document. BlogsSharing received the same CanShareWithPermissions consolidation, re-sharing the single fixture entry at each permission level. Each merge folds the source test's unique assertions into the keeper so no scenario coverage is lost. The SharingUsecase disable-scope pair was left intact, because disabling sharing at instance scope already hides the Share action and would make a folded system-scope assertion vacuous.

## Why Are There No Tests?

This is a Poshi test-suite shrink: it merges overlapping tests and adds none. Coverage is preserved by folding each merged scenario's assertions into its keeper.

## PR Check

**pr-check: PASS** — tested on `36e3a90fa51ed4641b9e122a2ddee0f69cfddf31`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "36e3a90fa51ed4641b9e122a2ddee0f69cfddf31"} -->
