### PR TITLE
LPD-95536 Add CMS folder management E2E Playwright tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -76,6 +76,7 @@ import {config as documentLibraryWebConfig} from './tests/document-library-web/m
 import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-mapping-form-web/main/config';
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
+import {config as e2eCmsDxpFolderConfig} from './tests/e2e-cms-dxp/folder/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
 import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
@@ -321,6 +322,7 @@ export default defineConfig({
 		dynamicDataMappingFormWebConfig,
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
+		e2eCmsDxpFolderConfig,
 		e2eCmsDxpSharingConfig,
 		e2eCmsDxpTranslationsConfig,
 		e2eCmsDxpWorkflowConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'folder.main',
+	testDir: 'tests/e2e-cms-dxp/folder/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/contentFolderHierarchy.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/contentFolderHierarchy.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {
+	addSpaceUserWithSession,
+	openFolder,
+	searchContentList,
+} from './utils/folders';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'A Space Administrator builds a nested content folder hierarchy and a Content Reviewer creates content inside it',
+	{tag: ['@LPD-95536', '@LPD-95536/TC-13.a']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const parentFolderName = `Parent ${getRandomString()}`;
+		const childFolderNameA = `Child A ${getRandomString()}`;
+		const childFolderNameB = `Child B ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const contentReviewer = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Content Reviewer'
+		);
+
+		await test.step('The Space Administrator creates a nested folder hierarchy in Contents', async () => {
+			const spaContext = await browser.newContext();
+
+			const spaPage = await spaContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: spaPage,
+					screenName: spaceAdministrator.alternateName,
+				});
+
+				const spaContentsPage = new ContentsPage(spaPage);
+
+				await spaContentsPage.goto();
+
+				await spaContentsPage.createFolder(parentFolderName, spaceName);
+
+				await openFolder(spaPage, parentFolderName);
+
+				await spaContentsPage.createFolder(childFolderNameA);
+
+				await spaContentsPage.createFolder(childFolderNameB);
+
+				await expect(
+					spaPage.getByRole('link', {
+						exact: true,
+						name: childFolderNameA,
+					})
+				).toBeVisible({timeout: 5000});
+
+				await expect(
+					spaPage.getByRole('link', {
+						exact: true,
+						name: childFolderNameB,
+					})
+				).toBeVisible({timeout: 5000});
+			}
+			finally {
+				await spaContext.close();
+			}
+		});
+
+		const scrContext = await browser.newContext();
+
+		const scrPage = await scrContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: scrPage,
+				screenName: contentReviewer.alternateName,
+			});
+
+			const scrContentsPage = new ContentsPage(scrPage);
+
+			await test.step('The Content Reviewer creates a Basic Web Content inside a child folder', async () => {
+				await scrContentsPage.goto();
+
+				await openFolder(scrPage, parentFolderName);
+
+				await openFolder(scrPage, childFolderNameA);
+
+				await scrContentsPage.createContent('Basic Web Content');
+
+				await scrContentsPage.fillData([
+					{label: 'Title', value: contentTitle},
+				]);
+
+				await scrContentsPage.saveContent();
+			});
+
+			await test.step('The folder structure is preserved and the content sits in the correct folder', async () => {
+				await scrContentsPage.goto();
+
+				await openFolder(scrPage, parentFolderName);
+
+				await expect(
+					scrPage.getByRole('link', {
+						exact: true,
+						name: childFolderNameB,
+					})
+				).toBeVisible({timeout: 5000});
+
+				await openFolder(scrPage, childFolderNameA);
+
+				await expect(
+					scrPage.getByRole('link', {exact: true, name: contentTitle})
+				).toBeVisible({timeout: 5000});
+			});
+
+			await test.step('The content is accessible from the content list', async () => {
+				await scrContentsPage.goto();
+
+				await searchContentList(scrPage, contentTitle);
+			});
+		}
+		finally {
+			await scrContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/deleteFolder.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/deleteFolder.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {addSpaceUserWithSession, deletePopulatedFolder} from './utils/folders';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const FILE_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'Deleting populated folders sends the contained items to the Recycle Bin',
+	{tag: ['@LPD-95536', '@LPD-95536/TC-13.f']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentFolderName = `Contents ${getRandomString()}`;
+		const fileFolderName = `Files ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const fileTitle = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const contentFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: contentFolderName,
+			});
+
+		const fileFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: spaceName,
+				title: fileFolderName,
+			});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode:
+					contentFolder.externalReferenceCode,
+				title: contentTitle,
+			},
+			CONTENT_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode:
+					fileFolder.externalReferenceCode,
+				title: fileTitle,
+			},
+			FILE_APPLICATION_NAME,
+			spaceName
+		);
+
+		const spaContext = await browser.newContext();
+
+		const spaPage = await spaContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: spaPage,
+				screenName: spaceAdministrator.alternateName,
+			});
+
+			const spaAssetsPage = new AssetsPage(spaPage);
+			const spaContentsPage = new ContentsPage(spaPage);
+			const spaRecycleBinPage = new RecycleBinPage(spaPage);
+
+			await test.step('The Space Administrator deletes the populated folders', async () => {
+				await spaContentsPage.goto();
+
+				await deletePopulatedFolder(spaPage, contentFolderName);
+
+				await spaAssetsPage.gotoFiles();
+
+				await deletePopulatedFolder(spaPage, fileFolderName);
+			});
+
+			await test.step('The folders are gone from their sections', async () => {
+				await spaContentsPage.goto();
+
+				await expect(
+					spaPage.getByRole('link', {
+						exact: true,
+						name: contentFolderName,
+					})
+				).toBeHidden({timeout: 5000});
+
+				await spaAssetsPage.gotoFiles();
+
+				await expect(
+					spaPage.getByRole('link', {
+						exact: true,
+						name: fileFolderName,
+					})
+				).toBeHidden({timeout: 5000});
+			});
+
+			await test.step('The trashed folders are in the Recycle Bin with their items preserved inside', async () => {
+				for (const [folderName, itemTitle] of [
+					[contentFolderName, contentTitle],
+					[fileFolderName, fileTitle],
+				]) {
+					await spaRecycleBinPage.goto();
+
+					await spaPage
+						.getByRole('link', {exact: true, name: folderName})
+						.click();
+
+					await spaPage.waitForURL('**/recycle-bin/**');
+
+					await expect(
+						spaPage.getByText(itemTitle, {exact: true})
+					).toBeVisible({timeout: 10000});
+				}
+			});
+		}
+		finally {
+			await spaContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/fileFolderHierarchy.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/fileFolderHierarchy.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {addSpaceUserWithSession, openFolder} from './utils/folders';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const IMAGE_FILE_NAME = 'sample_small_wide_400x300.jpg';
+
+test(
+	'A Space Administrator builds a nested file folder hierarchy and a Content Reviewer uploads a file inside it',
+	{tag: ['@LPD-95536', '@LPD-95536/TC-13.b']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const parentFolderName = `Parent ${getRandomString()}`;
+		const childFolderNameA = `Child A ${getRandomString()}`;
+		const childFolderNameB = `Child B ${getRandomString()}`;
+		const fileTitle = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const contentReviewer = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Content Reviewer'
+		);
+
+		await test.step('The Space Administrator creates a nested folder hierarchy in Files', async () => {
+			const spaContext = await browser.newContext();
+
+			const spaPage = await spaContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: spaPage,
+					screenName: spaceAdministrator.alternateName,
+				});
+
+				const spaAssetsPage = new AssetsPage(spaPage);
+				const spaContentsPage = new ContentsPage(spaPage);
+
+				await spaAssetsPage.gotoFiles();
+
+				await spaContentsPage.createFolder(parentFolderName, spaceName);
+
+				await openFolder(spaPage, parentFolderName);
+
+				await spaContentsPage.createFolder(childFolderNameA);
+
+				await spaContentsPage.createFolder(childFolderNameB);
+
+				await expect(
+					spaPage.getByRole('link', {
+						exact: true,
+						name: childFolderNameA,
+					})
+				).toBeVisible({timeout: 5000});
+
+				await expect(
+					spaPage.getByRole('link', {
+						exact: true,
+						name: childFolderNameB,
+					})
+				).toBeVisible({timeout: 5000});
+			}
+			finally {
+				await spaContext.close();
+			}
+		});
+
+		const scrContext = await browser.newContext();
+
+		const scrPage = await scrContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: scrPage,
+				screenName: contentReviewer.alternateName,
+			});
+
+			const scrAssetsPage = new AssetsPage(scrPage);
+			const scrContentsPage = new ContentsPage(scrPage);
+
+			await test.step('The Content Reviewer uploads a file inside a child folder', async () => {
+				await scrAssetsPage.gotoFiles();
+
+				await openFolder(scrPage, parentFolderName);
+
+				await openFolder(scrPage, childFolderNameA);
+
+				await scrContentsPage.createContent('Single File');
+
+				await scrContentsPage.fillData([
+					{label: 'Title', value: fileTitle},
+				]);
+
+				const fileChooserPromise = scrPage.waitForEvent('filechooser');
+
+				await scrPage
+					.getByRole('button', {exact: true, name: 'Select File'})
+					.click();
+
+				const fileChooser = await fileChooserPromise;
+
+				await fileChooser.setFiles(
+					path.join(
+						__dirname,
+						`../../dependencies/${IMAGE_FILE_NAME}`
+					)
+				);
+
+				await expect(scrPage.getByText(IMAGE_FILE_NAME)).toBeVisible({
+					timeout: 5000,
+				});
+
+				await scrContentsPage.saveContent();
+			});
+
+			await test.step('The folder structure is preserved and the file is accessible in the nested folder', async () => {
+				await scrAssetsPage.gotoFiles();
+
+				await openFolder(scrPage, parentFolderName);
+
+				await expect(
+					scrPage.getByRole('link', {
+						exact: true,
+						name: childFolderNameB,
+					})
+				).toBeVisible({timeout: 5000});
+
+				await openFolder(scrPage, childFolderNameA);
+
+				await expect(
+					scrPage.getByRole('link', {exact: true, name: fileTitle})
+				).toBeVisible({timeout: 5000});
+
+				await scrPage
+					.getByRole('link', {exact: true, name: fileTitle})
+					.click();
+
+				await expect(
+					scrPage.getByRole('heading', {name: fileTitle})
+				).toBeVisible({timeout: 10000});
+			});
+		}
+		finally {
+			await scrContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/folderPermissions.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/folderPermissions.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {addSpaceUserWithSession, openFolder} from './utils/folders';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const FILE_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A Space Member can browse the folder hierarchy but cannot manage folders',
+	{tag: ['@LPD-95536', '@LPD-95536/TC-13.g']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const parentFolderName = `Parent ${getRandomString()}`;
+		const childFolderName = `Child ${getRandomString()}`;
+		const fileFolderName = `Files ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+		const fileTitle = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceMember = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Member'
+		);
+
+		const parentFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: parentFolderName,
+			});
+
+		const childFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode:
+					parentFolder.externalReferenceCode,
+				scopeKey: spaceName,
+				title: childFolderName,
+			});
+
+		const fileFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: spaceName,
+				title: fileFolderName,
+			});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${bodyValue}</p>`,
+				objectEntryFolderExternalReferenceCode:
+					childFolder.externalReferenceCode,
+				title: contentTitle,
+			},
+			CONTENT_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode:
+					fileFolder.externalReferenceCode,
+				title: fileTitle,
+			},
+			FILE_APPLICATION_NAME,
+			spaceName
+		);
+
+		const memberContext = await browser.newContext();
+
+		const memberPage = await memberContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: memberPage,
+				screenName: spaceMember.alternateName,
+			});
+
+			const memberAssetsPage = new AssetsPage(memberPage);
+
+			await test.step('The Space Member browses the content folder hierarchy and sees the content', async () => {
+				await memberAssetsPage.gotoContents();
+
+				await openFolder(memberPage, parentFolderName);
+
+				await openFolder(memberPage, childFolderName);
+
+				await expect(
+					memberPage.getByText(contentTitle, {exact: true})
+				).toBeVisible({timeout: 5000});
+			});
+
+			await test.step('The Space Member browses the file folder and sees the file', async () => {
+				await memberAssetsPage.gotoFiles();
+
+				await openFolder(memberPage, fileFolderName);
+
+				await expect(
+					memberPage.getByText(fileTitle, {exact: true})
+				).toBeVisible({timeout: 5000});
+			});
+
+			await test.step('Folder creation is denied for the Space Member', async () => {
+				for (const goToSection of [
+					() => memberAssetsPage.gotoContents(),
+					() => memberAssetsPage.gotoFiles(),
+				]) {
+					await goToSection();
+
+					await expect(
+						memberPage.getByTestId('fdsCreationActionButton')
+					).toHaveCount(0, {timeout: 2000});
+				}
+			});
+
+			await test.step('Folder rename, move and delete are denied for the Space Member', async () => {
+				await memberAssetsPage.gotoContents();
+
+				await clickAndExpectToBeVisible({
+					autoClick: true,
+					target: memberPage.getByRole('menuitem', {
+						name: 'View Folder',
+					}),
+					trigger: memberPage.getByRole('button', {
+						name: `${parentFolderName} Actions`,
+					}),
+				});
+
+				for (const deniedAction of ['Edit', 'Move', 'Delete']) {
+					await expect(
+						memberPage.getByRole('menuitem', {name: deniedAction})
+					).toHaveCount(0, {timeout: 2000});
+				}
+			});
+		}
+		finally {
+			await memberContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/moveContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/moveContent.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {addSpaceUserWithSession, openFolder} from './utils/folders';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'A Space Administrator moves a Basic Web Content entry to a different folder',
+	{tag: ['@LPD-95536', '@LPD-95536/TC-13.c']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const originFolderName = `Origin ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const originFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: originFolderName,
+			});
+
+		const destinationFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: destinationFolderName,
+			});
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${bodyValue}</p>`,
+				objectEntryFolderExternalReferenceCode:
+					originFolder.externalReferenceCode,
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const spaContext = await browser.newContext();
+
+		const spaPage = await spaContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: spaPage,
+				screenName: spaceAdministrator.alternateName,
+			});
+
+			const spaAssetsPage = new AssetsPage(spaPage);
+			const spaContentsPage = new ContentsPage(spaPage);
+
+			await test.step('The Space Administrator moves the entry to the destination folder', async () => {
+				await spaContentsPage.goto();
+
+				await openFolder(spaPage, originFolderName);
+
+				await spaAssetsPage.moveTo({
+					destinationFolder: destinationFolderName,
+					destinationSpace: spaceName,
+					itemTitle: contentTitle,
+				});
+			});
+
+			await test.step('The entry sits in the destination folder and is gone from the origin', async () => {
+				await expect(async () => {
+					const movedEntry =
+						await apiHelpers.objectEntry.getObjectEntryById(
+							APPLICATION_NAME,
+							String(entry.id)
+						);
+
+					expect(movedEntry.objectEntryFolderId).toBe(
+						destinationFolder.id
+					);
+				}).toPass({timeout: 15000});
+
+				await spaContentsPage.goto();
+
+				await openFolder(spaPage, originFolderName);
+
+				await expect(
+					spaPage.getByRole('link', {exact: true, name: contentTitle})
+				).toBeHidden({timeout: 5000});
+
+				await spaContentsPage.goto();
+
+				await openFolder(spaPage, destinationFolderName);
+
+				await expect(
+					spaPage.getByRole('link', {exact: true, name: contentTitle})
+				).toBeVisible({timeout: 5000});
+			});
+
+			await test.step('The entry detail view is intact after the move', async () => {
+				await spaPage
+					.getByRole('link', {exact: true, name: contentTitle})
+					.click();
+
+				await expect(
+					spaPage.getByText(bodyValue, {exact: true})
+				).toBeVisible({timeout: 10000});
+			});
+		}
+		finally {
+			await spaContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/moveFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/moveFile.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {
+	addSpaceUserWithSession,
+	clickItemAction,
+	openFolder,
+} from './utils/folders';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A Space Administrator moves a CMS file to a different folder',
+	{tag: ['@LPD-95536', '@LPD-95536/TC-13.d']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const originFolderName = `Origin ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const fileTitle = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const originFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: spaceName,
+				title: originFolderName,
+			});
+
+		const destinationFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: spaceName,
+				title: destinationFolderName,
+			});
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode:
+					originFolder.externalReferenceCode,
+				title: fileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const spaContext = await browser.newContext();
+
+		const spaPage = await spaContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: spaPage,
+				screenName: spaceAdministrator.alternateName,
+			});
+
+			const spaAssetsPage = new AssetsPage(spaPage);
+
+			await test.step('The Space Administrator moves the file to the destination folder', async () => {
+				await spaAssetsPage.gotoFiles();
+
+				await openFolder(spaPage, originFolderName);
+
+				await clickItemAction(spaPage, fileTitle, 'Move');
+
+				await spaAssetsPage.selectCopyOrMoveDestination({
+					destinationFolder: destinationFolderName,
+					destinationSpace: spaceName,
+				});
+			});
+
+			await test.step('The file sits in the destination folder and is gone from the origin', async () => {
+				await expect(async () => {
+					const movedEntry =
+						await apiHelpers.objectEntry.getObjectEntryById(
+							APPLICATION_NAME,
+							String(entry.id)
+						);
+
+					expect(movedEntry.objectEntryFolderId).toBe(
+						destinationFolder.id
+					);
+				}).toPass({timeout: 15000});
+
+				await spaAssetsPage.gotoFiles();
+
+				await openFolder(spaPage, originFolderName);
+
+				await expect(
+					spaPage.getByRole('link', {exact: true, name: fileTitle})
+				).toBeHidden({timeout: 5000});
+
+				await spaAssetsPage.gotoFiles();
+
+				await openFolder(spaPage, destinationFolderName);
+
+				await expect(
+					spaPage.getByRole('link', {exact: true, name: fileTitle})
+				).toBeVisible({timeout: 5000});
+			});
+
+			await test.step('The file is still accessible after the move', async () => {
+				const movedEntry =
+					await apiHelpers.objectEntry.getObjectEntryById(
+						APPLICATION_NAME,
+						String(entry.id)
+					);
+
+				const downloadStatus = await spaPage.evaluate(
+					async (href) => (await fetch(href)).status,
+					movedEntry.file.link.href
+				);
+
+				expect(downloadStatus).toBe(200);
+			});
+		}
+		finally {
+			await spaContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/renameFolder.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/renameFolder.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {isImageLoaded} from '../../../../utils/isImageLoaded';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {
+	addSpaceUserWithSession,
+	clickItemAction,
+	openFolder,
+} from './utils/folders';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const FILE_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'Renaming a populated folder keeps its items accessible and mapped page references intact',
+	{tag: ['@LPD-95536', '@LPD-95536/TC-13.e']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(480000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentFolderName = `Contents ${getRandomString()}`;
+		const fileFolderName = `Files ${getRandomString()}`;
+		const renamedContentFolderName = `Renamed ${getRandomString()}`;
+		const renamedFileFolderName = `Renamed ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+		const fileTitle = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const contentFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: contentFolderName,
+			});
+
+		const fileFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: spaceName,
+				title: fileFolderName,
+			});
+
+		const contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${bodyValue}</p>`,
+				objectEntryFolderExternalReferenceCode:
+					contentFolder.externalReferenceCode,
+				title: contentTitle,
+			},
+			CONTENT_APPLICATION_NAME,
+			spaceName
+		);
+
+		const fileEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode:
+					fileFolder.externalReferenceCode,
+				title: fileTitle,
+			},
+			FILE_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			CONTENT_APPLICATION_NAME,
+			contentEntry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			FILE_APPLICATION_NAME,
+			fileEntry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><lfr-editable id="image" type="image"><img alt="" src=""/></lfr-editable></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the folder items into a page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: 'Basic Web Contents (CMS)',
+						entry: contentTitle,
+						field: 'Title',
+					},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.selectEditable(fragmentId, 'image');
+
+			await page.getByLabel('Source Selection').selectOption('Mapping');
+
+			await pageEditorPage.setMappedItem({
+				entity: 'Basic Documents (CMS)',
+				entry: fileTitle,
+				field: 'Preview URL',
+			});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		const spaContext = await browser.newContext();
+
+		const spaPage = await spaContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: spaPage,
+				screenName: spaceAdministrator.alternateName,
+			});
+
+			const spaAssetsPage = new AssetsPage(spaPage);
+			const spaContentsPage = new ContentsPage(spaPage);
+
+			await test.step('The Space Administrator renames the populated folders', async () => {
+				await spaContentsPage.goto();
+
+				await clickItemAction(spaPage, contentFolderName, 'Edit');
+
+				await spaPage
+					.getByLabel('NameRequired')
+					.fill(renamedContentFolderName);
+
+				await spaPage.getByRole('button', {name: 'Save'}).click();
+
+				await spaPage.waitForURL('**/web/cms/contents**');
+
+				await spaAssetsPage.gotoFiles();
+
+				await clickItemAction(spaPage, fileFolderName, 'Edit');
+
+				await spaPage
+					.getByLabel('NameRequired')
+					.fill(renamedFileFolderName);
+
+				await spaPage.getByRole('button', {name: 'Save'}).click();
+
+				await spaPage.waitForURL('**/web/cms/files**');
+			});
+
+			await test.step('The items remain accessible inside the renamed folders', async () => {
+				await spaContentsPage.goto();
+
+				await openFolder(spaPage, renamedContentFolderName);
+
+				await expect(
+					spaPage.getByRole('link', {exact: true, name: contentTitle})
+				).toBeVisible({timeout: 5000});
+
+				await spaAssetsPage.gotoFiles();
+
+				await openFolder(spaPage, renamedFileFolderName);
+
+				await expect(
+					spaPage.getByRole('button', {
+						name: `${fileTitle} Actions`,
+					})
+				).toBeVisible({timeout: 10000});
+			});
+		}
+		finally {
+			await spaContext.close();
+		}
+
+		await test.step('The published page still renders the mapped items', async () => {
+			const guestContext = await browser.newContext({
+				storageState: {cookies: [], origins: []},
+			});
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(contentTitle, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					expect(
+						await isImageLoaded(
+							guestPage.locator('img[src*="/documents/"]').first()
+						)
+					).toBe(true);
+				}).toPass({timeout: 30000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/tests/e2e-cms-dxp/folder/main/utils/folders.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/folder/main/utils/folders.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect} from '@playwright/test';
+
+import {DataApiHelpers} from '../../../../../helpers/ApiHelpers';
+import {addSpaceUser} from '../../../../../utils/addSpaceUser';
+import {clickAndExpectToBeVisible} from '../../../../../utils/clickAndExpectToBeVisible';
+
+export async function addSpaceUserWithSession(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string,
+	roleName: string
+): Promise<TUserAccount> {
+	const user = await addSpaceUser(
+		apiHelpers,
+		spaceExternalReferenceCode,
+		roleName
+	);
+
+	await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+	await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+	return user;
+}
+
+export async function clickItemAction(
+	page: Page,
+	itemTitle: string,
+	action: string
+) {
+	const menuItem = page.getByRole('menuitem', {exact: true, name: action});
+
+	await expect(async () => {
+		if (!(await menuItem.isVisible())) {
+			await page
+				.getByRole('button', {name: `${itemTitle} Actions`})
+				.click({timeout: 5000});
+
+			await expect(menuItem).toBeVisible({timeout: 5000});
+		}
+	}).toPass({timeout: 30000});
+
+	await menuItem.click();
+}
+
+export async function deletePopulatedFolder(page: Page, folderName: string) {
+	await clickItemAction(page, folderName, 'Delete');
+
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page.locator('.alert-success'),
+		trigger: page.getByRole('button', {name: 'Delete Folder'}),
+	});
+}
+
+export async function openFolder(page: Page, folderName: string) {
+	await page.getByRole('link', {exact: true, name: folderName}).click();
+
+	await page.waitForURL('**/view-folder/**');
+
+	await page.locator('.fds').waitFor();
+}
+
+export async function searchContentList(page: Page, title: string) {
+	await expect(async () => {
+		await page.getByPlaceholder('Search').fill(title);
+
+		await page.getByPlaceholder('Search').press('Enter');
+
+		await expect(
+			page.getByRole('link', {exact: true, name: title})
+		).toBeVisible({timeout: 3000});
+	}).toPass({timeout: 30000});
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95536

## What Is Being Fixed

The CMS end-to-end epic (LPD-85582) had no automated coverage for the Folder Management scenarios in LPD-95536: nested folder hierarchies, moving content and files between folders, renaming and deleting populated folders, and the Space Member permission boundary.

## How It Is Being Fixed

This adds a Playwright suite (folder.main) with one spec per scenario. A Space Administrator creates nested folder hierarchies in the Contents and Files sections through the UI while a Content Reviewer creates content and uploads a file inside the child folders. The Space Administrator moves a Basic Web Content entry and a CMS file between folders, verifying the destination, the origin, and that the items stay accessible. Renaming populated folders keeps their items reachable and a DXP page with fields mapped to those items still renders. Deleting populated folders goes through the reference warning modal and lands the folders in the Recycle Bin with their items preserved inside. A Space Member can browse the hierarchy and view items while folder creation, rename, move, and delete stay unavailable.

The suite ships a small view-agnostic action helper because the Files section renders gallery cards whose titles carry no link role, so the table-row based page-object actions hang there.

## PR Check

**pr-check: PASS** — tested on `b97991e8f6efc53f1423cbcd050314bc55725b6d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "b97991e8f6efc53f1423cbcd050314bc55725b6d"} -->

https://claude.ai/code/session_01MjfHA8cbSJn1xbcnTAX15g
