### PR TITLE
LPD-96532 Show a specific error for too many asset categories

### DIFF
--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 38.10.1
+Bundle-Version: 38.11.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
@@ -432,6 +432,39 @@ public class InfoFormValidationException extends InfoFormException {
 
 	}
 
+	public static class TooManyAssetCategories
+		extends InfoFormValidationException {
+
+		public TooManyAssetCategories(
+			AssetCategoryException assetCategoryException,
+			AssetVocabulary assetVocabulary) {
+
+			_assetCategoryException = assetCategoryException;
+			_assetVocabulary = assetVocabulary;
+		}
+
+		public AssetCategoryException getAssetCategoryException() {
+			return _assetCategoryException;
+		}
+
+		public AssetVocabulary getAssetVocabulary() {
+			return _assetVocabulary;
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.format(
+				locale, "you-cannot-select-more-than-one-category-for-x",
+				(_assetVocabulary != null) ?
+					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
+						StringPool.BLANK);
+		}
+
+		private final AssetCategoryException _assetCategoryException;
+		private final AssetVocabulary _assetVocabulary;
+
+	}
+
 	public static class UniqueValueConstraintViolation
 		extends InfoFormValidationException {
 

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
@@ -1,1 +1,1 @@
-version 6.6.0
+version 6.7.0

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -52,6 +52,13 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 					assetCategoryException,
 					assetCategoryException.getVocabulary());
 			}
+			else if (assetCategoryException.getType() ==
+						AssetCategoryException.TOO_MANY_CATEGORIES) {
+
+				throw new InfoFormValidationException.TooManyAssetCategories(
+					assetCategoryException,
+					assetCategoryException.getVocabulary());
+			}
 		}
 
 		if (exception instanceof ModelListenerException) {

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.handler;
+
+import com.liferay.asset.kernel.exception.AssetCategoryException;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.info.exception.InfoFormValidationException;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jan Brychta
+ */
+public class ObjectEntryInfoItemExceptionRequestHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testHandleInfoFormException() throws Exception {
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory();
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories();
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.AT_LEAST_ONE_CATEGORY),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.RequiredAssetCategory
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.TOO_MANY_CATEGORIES),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.TooManyAssetCategories
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -198,7 +198,7 @@ export default function ContentEditorToolbar({
 
 		sessionStorage.removeItem(SUCCESS_MESSAGE_SESSION_KEY);
 
-		if (getForm()?.querySelector('.form-group.has-error')) {
+		if (getForm()?.querySelector('.alert-danger, .form-group.has-error')) {
 			return;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96532

## What Is Being Fixed

When a vocabulary had "Allow multiple categories" disabled and a user tried to publish content through the CMS section, `CardinalityAssetEntryValidator` threw an `AssetCategoryException` with type `TOO_MANY_CATEGORIES`. `ObjectEntryInfoItemExceptionRequestHandler` only handled `AT_LEAST_ONE_CATEGORY` and fell through to a generic `InfoFormException`, so the frontend showed the unhelpful "An error occurred while sending the form information." On top of that, the success toast was shown alongside the error, because the toolbar only detected field-level errors.

## How It Is Being Fixed

The handler now maps `TOO_MANY_CATEGORIES` to a new `InfoFormValidationException.TooManyAssetCategories`, which formats the vocabulary name into a clear message telling the user they cannot select more than one category for that vocabulary. A new baseline version bump on `info-api` accounts for the added exception class. On the frontend, `ContentEditorToolbar` previously suppressed the success toast only when a field-level `.form-group.has-error` element was present; form-level errors render as `.alert-danger`, so the check now covers both and the success toast no longer appears when the publish fails.

## PR Check

**pr-check: PASS** — tested on `9df6b47400c960d1eae4b87fc7f35f57a91fa33d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9df6b47400c960d1eae4b87fc7f35f57a91fa33d"} -->
