### PR TITLE
LPD-96916 Fix geolocation maps not rendering from duplicate API load

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -59,29 +59,41 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 		Liferay.Maps.gmapsReady
 	) {
 		callback();
+
+		return;
 	}
-	else {
-		Liferay.namespace('Maps').onGMapsReady = function () {
-			Liferay.Maps.gmapsReady = true;
-			Liferay.fire('gmapsReady');
-		};
 
-		Liferay.once('gmapsReady', () => callback());
+	Liferay.namespace('Maps').onGMapsReady = function () {
+		Liferay.Maps.gmapsReady = true;
+		Liferay.fire('gmapsReady');
+	};
 
-		let apiURL = `${location.protocol}//maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady`;
+	Liferay.once('gmapsReady', () => callback());
 
-		if (googleMapsAPIKey) {
-			apiURL += '&key=' + googleMapsAPIKey;
-		}
-
-		let script = document.createElement('script');
-
-		script.setAttribute('src', apiURL);
-
-		document.head.appendChild(script);
-
-		script = null;
+	if (
+		Liferay.Maps.gmapsLoading ||
+		document.querySelector(
+			'script[src*="maps.googleapis.com/maps/api/js"][src*="callback=Liferay.Maps.onGMapsReady"]'
+		)
+	) {
+		return;
 	}
+
+	Liferay.Maps.gmapsLoading = true;
+
+	let apiURL = `${location.protocol}//maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady`;
+
+	if (googleMapsAPIKey) {
+		apiURL += '&key=' + googleMapsAPIKey;
+	}
+
+	let script = document.createElement('script');
+
+	script.setAttribute('src', apiURL);
+
+	document.head.appendChild(script);
+
+	script = null;
 };
 
 export function useGeolocation({

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -121,14 +121,10 @@ export function useGeolocation({
 			const mapConfig = {
 				...MAP_CONFIG,
 				boundingBox: `#map_${instanceId}`,
+				position: {
+					location: value ? parseJSONValue(value) : {lat: 0, lng: 0},
+				},
 			};
-
-			if (value) {
-				mapConfig.position.location = parseJSONValue(value);
-			}
-			else {
-				mapConfig.position.location = {lat: 0, lng: 0};
-			}
 
 			const registerMapBase = (MapProvider, mapConfig) => {
 				mapRef.current = new MapProvider(mapConfig);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -89,6 +89,12 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 
 	let script = document.createElement('script');
 
+	script.addEventListener('error', (event) => {
+		Liferay.Maps.gmapsLoading = false;
+
+		event.currentTarget.remove();
+	});
+
 	script.setAttribute('src', apiURL);
 
 	document.head.appendChild(script);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -29,11 +29,19 @@ beforeAll(() => {
 			CONTROLS: {},
 			register: jest.fn(),
 		},
+		Maps: {},
 		ThemeDisplay: {
 			getPathThemeImages: () => '',
 		},
 		detach: jest.fn(),
+		fire: jest.fn(),
+		namespace: jest.fn((name) => {
+			window.Liferay[name] = window.Liferay[name] || {};
+
+			return window.Liferay[name];
+		}),
 		on: jest.fn(),
+		once: jest.fn(),
 	};
 });
 
@@ -173,5 +181,143 @@ describe('Geolocation', () => {
 
 		expect(previousListener.removeListener).toHaveBeenCalledTimes(1);
 		expect(currentListener.removeListener).not.toHaveBeenCalled();
+	});
+});
+
+describe('Geolocation Google Maps loader', () => {
+	const gmapsScriptSelector =
+		'script[src*="maps.googleapis.com/maps/api/js"]';
+
+	const renderGoogleMapsField = (instanceId, name) =>
+		render(
+			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
+				<FormProvider
+					initialState={{editingLanguageId: 'en_US', pages: []}}
+					reducers={[languageReducer]}
+				>
+					<PageProvider value={{pageIndex: 0}}>
+						<Geolocation
+							instanceId={instanceId}
+							mapProviderKey="GoogleMaps"
+							name={name}
+							onChange={jest.fn()}
+							value={{lat: 1, lng: 1}}
+						/>
+					</PageProvider>
+				</FormProvider>
+			</ConfigProvider>
+		);
+
+	beforeEach(() => {
+		delete window.google;
+
+		window.Liferay.Maps = {};
+
+		document
+			.querySelectorAll(gmapsScriptSelector)
+			.forEach((script) => script.remove());
+	});
+
+	afterEach(() => {
+		document
+			.querySelectorAll(gmapsScriptSelector)
+			.forEach((script) => script.remove());
+	});
+
+	it('injects the Google Maps API script only once for two fields', () => {
+		render(
+			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
+				<FormProvider
+					initialState={{
+						editingLanguageId: 'en_US',
+						pages: [],
+					}}
+					reducers={[languageReducer]}
+				>
+					<PageProvider value={{pageIndex: 0}}>
+						<>
+							<Geolocation
+								instanceId="first"
+								mapProviderKey="GoogleMaps"
+								name="geoFirst"
+								onChange={jest.fn()}
+								value={{lat: 1, lng: 1}}
+							/>
+
+							<Geolocation
+								instanceId="second"
+								mapProviderKey="GoogleMaps"
+								name="geoSecond"
+								onChange={jest.fn()}
+								value={{lat: 2, lng: 2}}
+							/>
+						</>
+					</PageProvider>
+				</FormProvider>
+			</ConfigProvider>
+		);
+
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
+	});
+
+	it('re-injects the Google Maps API script after a failed load', () => {
+		renderGoogleMapsField('first', 'geoFirst');
+
+		const [script] = document.querySelectorAll(gmapsScriptSelector);
+
+		expect(script).toBeTruthy();
+		expect(window.Liferay.Maps.gmapsLoading).toBe(true);
+
+		script.dispatchEvent(new Event('error'));
+
+		expect(window.Liferay.Maps.gmapsLoading).toBe(false);
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(0);
+
+		renderGoogleMapsField('second', 'geoSecond');
+
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
+	});
+});
+
+describe('Geolocation map configuration', () => {
+	it('builds an isolated position for each field', () => {
+		MapOpenStreetMap.mockClear();
+
+		render(
+			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
+				<FormProvider
+					initialState={{editingLanguageId: 'en_US', pages: []}}
+					reducers={[languageReducer]}
+				>
+					<PageProvider value={{pageIndex: 0}}>
+						<>
+							<Geolocation
+								instanceId="a"
+								mapProviderKey="OpenStreetMap"
+								name="geoA"
+								onChange={jest.fn()}
+								value={{lat: 1, lng: 1}}
+							/>
+
+							<Geolocation
+								instanceId="b"
+								mapProviderKey="OpenStreetMap"
+								name="geoB"
+								onChange={jest.fn()}
+								value={{lat: 2, lng: 2}}
+							/>
+						</>
+					</PageProvider>
+				</FormProvider>
+			</ConfigProvider>
+		);
+
+		const [firstConfig, secondConfig] = MapOpenStreetMap.mock.calls.map(
+			([config]) => config
+		);
+
+		expect(firstConfig.position.location).toEqual({lat: 1, lng: 1});
+		expect(secondConfig.position.location).toEqual({lat: 2, lng: 2});
+		expect(firstConfig.position).not.toBe(secondConfig.position);
 	});
 });

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
@@ -48,6 +48,12 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 
 			var script = document.createElement('script');
 
+			script.addEventListener('error', function (event) {
+				Liferay.Maps.gmapsLoading = false;
+
+				event.currentTarget.remove();
+			});
+
 			script.setAttribute('src', apiURL);
 
 			document.head.appendChild(script);

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
@@ -29,7 +29,15 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 			Liferay.fire('gmapsReady');
 		};
 
-		if (!Liferay.Maps.gmapsReady) {
+		if (
+			!Liferay.Maps.gmapsReady &&
+			!Liferay.Maps.gmapsLoading &&
+			!document.querySelector(
+				'script[src*="maps.googleapis.com/maps/api/js"][src*="callback=Liferay.Maps.onGMapsReady"]'
+			)
+		) {
+			Liferay.Maps.gmapsLoading = true;
+
 			var apiURL =
 				'<%= protocol %>' +
 				'://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96916

## What Is Being Fixed

A web content page with two geolocation fields rendered no map. Each React geolocation field loaded the Google Maps JavaScript API on its own, so with two fields the API script was injected twice; Google reported that the API was included multiple times and every map failed to render. The map display JSP shared the same uncoordinated load. Once the maps did render, a second defect surfaced: both maps showed the same location.

## How It Is Being Fixed

The API load is now guarded by a shared gmapsLoading flag and a check for an already injected loader script, so the script is requested only once and every field initializes off that single load and the shared gmapsReady event. Because the guard latched the flag before appending the script and never cleared it, a transient load failure would have disabled maps for the rest of the page session, so an error listener now clears the flag and removes the dead script to allow a later mount to retry. Finally, the map configuration was built by spreading a module level constant and mutating its shared nested position object, so every field pointed at the same coordinates and the last field to mount won; each field now builds its own position object. Tests cover the single load guard, the retry after a failed load, and the per-field position.

## PR Check

**pr-check: PASS** — tested on `2a98b6f97b32fecdc20ab4e2e7e76d710cdfdf94`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2a98b6f97b32fecdc20ab4e2e7e76d710cdfdf94"} -->
