### PR TITLE
LPD-96958 Show the extension filter in the CMS grouped filters

### DIFF
--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
@@ -143,6 +143,7 @@ export function getCMSItemSelectorGroupedFilters(
 				'objectDefinitionExternalReferenceCode',
 				'taxonomyCategoryIds',
 				'keywords',
+				'extension',
 				'creatorId',
 				'status',
 			],

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/getCMSItemSelectorFilters.test.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/getCMSItemSelectorFilters.test.ts
@@ -90,8 +90,9 @@ describe('getCMSItemSelectorFilters', () => {
 		const groupedFilters = getCMSItemSelectorGroupedFilters();
 
 		expect(groupedFilters.length).toBe(2);
-		expect(groupedFilters[0].filters.length).toBe(6);
+		expect(groupedFilters[0].filters.length).toBe(7);
 		expect(groupedFilters[0].filters[0]).toBe('groupIds');
+		expect(groupedFilters[0].filters).toContain('extension');
 		expect(groupedFilters[1].filters.length).toBe(5);
 	});
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
@@ -12,18 +12,17 @@ import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
-import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.aggregation.Aggregations;
 import com.liferay.portal.search.aggregation.bucket.Bucket;
 import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
-import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
-import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
@@ -76,41 +75,43 @@ public class ExtensionSelectionFDSFilter extends BaseSelectionFDSFilter {
 	}
 
 	private List<String> _getExistingFileExtensions() {
-		SearchContext searchContext = new SearchContext();
-
 		long companyId = CompanyThreadLocal.getCompanyId();
-
-		searchContext.setCompanyId(companyId);
-
-		searchContext.setEnd(QueryUtil.ALL_POS);
 
 		long[] groupIds = TransformUtil.transformToLongArray(
 			_depotEntryLocalService.getDepotEntries(
 				companyId, DepotConstants.TYPE_SPACE),
 			DepotEntry::getGroupId);
 
-		if (ArrayUtil.isNotEmpty(groupIds)) {
-			searchContext.setGroupIds(groupIds);
+		List<ObjectDefinition> objectDefinitions =
+			_objectDefinitionService.getCMSObjectDefinitions(
+				companyId,
+				new String[] {
+					ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+				});
+
+		if (objectDefinitions.isEmpty()) {
+			return Collections.emptyList();
 		}
 
-		searchContext.setStart(0);
-
-		SearchRequestBuilder searchRequestBuilder =
+		SearchResponse searchResponse = _searcher.search(
 			_searchRequestBuilderFactory.builder(
-				searchContext
+			).addAggregation(
+				_aggregations.terms("extensions", "extension")
+			).addComplexQueryPart(
+				_complexQueryPartBuilderFactory.builder(
+				).query(
+					QueriesUtil.matchAll()
+				).build()
+			).companyId(
+				companyId
 			).emptySearchEnabled(
 				true
 			).entryClassNames(
-				ObjectEntry.class.getName()
-			).fields(
-				Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK, Field.UID
-			).highlightEnabled(
-				false
-			);
-
-		SearchResponse searchResponse = _searcher.search(
-			searchRequestBuilder.addAggregation(
-				_aggregations.terms("extensions", "extension")
+				TransformUtil.transformToArray(
+					objectDefinitions, ObjectDefinition::getClassName,
+					String.class)
+			).groupIds(
+				groupIds
 			).size(
 				0
 			).build());
@@ -131,7 +132,13 @@ public class ExtensionSelectionFDSFilter extends BaseSelectionFDSFilter {
 	private Aggregations _aggregations;
 
 	@Reference
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
+
+	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private ObjectDefinitionService _objectDefinitionService;
 
 	@Reference
 	private Searcher _searcher;

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
@@ -126,32 +126,6 @@ public class ExtensionSelectionFDSFilterTest {
 	}
 
 	@Test
-	public void testGetSelectionFDSFilterItemsAggregatesObjectEntryClassNames() {
-		TermsAggregationResult termsAggregationResult = Mockito.mock(
-			TermsAggregationResult.class);
-
-		Mockito.when(
-			termsAggregationResult.getBuckets()
-		).thenReturn(
-			Collections.emptyList()
-		);
-
-		Mockito.when(
-			_searchResponse.getAggregationResult("extensions")
-		).thenReturn(
-			termsAggregationResult
-		);
-
-		_extensionSelectionFDSFilter.getSelectionFDSFilterItems(_locale);
-
-		Mockito.verify(
-			_searchRequestBuilder
-		).entryClassNames(
-			_OBJECT_DEFINITION_CLASS_NAME
-		);
-	}
-
-	@Test
 	public void testGetSelectionFDSFilterItemsWhenNoCMSObjectDefinitions() {
 		Mockito.when(
 			_objectDefinitionService.getCMSObjectDefinitions(
@@ -188,6 +162,32 @@ public class ExtensionSelectionFDSFilterTest {
 		Assert.assertTrue(
 			selectionFDSFilterItems.toString(),
 			selectionFDSFilterItems.isEmpty());
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItemsWithCMSObjectDefinitions() {
+		TermsAggregationResult termsAggregationResult = Mockito.mock(
+			TermsAggregationResult.class);
+
+		Mockito.when(
+			termsAggregationResult.getBuckets()
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			_searchResponse.getAggregationResult("extensions")
+		).thenReturn(
+			termsAggregationResult
+		);
+
+		_extensionSelectionFDSFilter.getSelectionFDSFilterItems(_locale);
+
+		Mockito.verify(
+			_searchRequestBuilder
+		).entryClassNames(
+			_OBJECT_DEFINITION_CLASS_NAME
+		);
 	}
 
 	@Test

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
@@ -8,14 +8,18 @@ package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.aggregation.Aggregations;
 import com.liferay.portal.search.aggregation.bucket.Bucket;
 import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
 import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
-import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilder;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -30,6 +34,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -51,8 +56,14 @@ public class ExtensionSelectionFDSFilterTest {
 		ReflectionTestUtil.setFieldValue(
 			_extensionSelectionFDSFilter, "_aggregations", _aggregations);
 		ReflectionTestUtil.setFieldValue(
+			_extensionSelectionFDSFilter, "_complexQueryPartBuilderFactory",
+			_complexQueryPartBuilderFactory);
+		ReflectionTestUtil.setFieldValue(
 			_extensionSelectionFDSFilter, "_depotEntryLocalService",
 			_depotEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_extensionSelectionFDSFilter, "_objectDefinitionService",
+			_objectDefinitionService);
 		ReflectionTestUtil.setFieldValue(
 			_extensionSelectionFDSFilter, "_searcher", _searcher);
 		ReflectionTestUtil.setFieldValue(
@@ -66,10 +77,29 @@ public class ExtensionSelectionFDSFilterTest {
 		);
 
 		Mockito.when(
+			_complexQueryPartBuilderFactory.builder()
+		).thenReturn(
+			Mockito.mock(ComplexQueryPartBuilder.class, Mockito.RETURNS_SELF)
+		);
+
+		Mockito.when(
 			_depotEntryLocalService.getDepotEntries(
 				Mockito.anyLong(), Mockito.anyInt())
 		).thenReturn(
 			Collections.emptyList()
+		);
+
+		Mockito.when(
+			_objectDefinition.getClassName()
+		).thenReturn(
+			_OBJECT_DEFINITION_CLASS_NAME
+		);
+
+		Mockito.when(
+			_objectDefinitionService.getCMSObjectDefinitions(
+				Mockito.anyLong(), Mockito.any())
+		).thenReturn(
+			List.of(_objectDefinition)
 		);
 
 		Mockito.when(
@@ -78,13 +108,10 @@ public class ExtensionSelectionFDSFilterTest {
 			_searchResponse
 		);
 
-		SearchRequestBuilder searchRequestBuilder = Mockito.mock(
-			SearchRequestBuilder.class, Mockito.RETURNS_SELF);
-
 		Mockito.when(
-			_searchRequestBuilderFactory.builder(Mockito.any())
+			_searchRequestBuilderFactory.builder()
 		).thenReturn(
-			searchRequestBuilder
+			_searchRequestBuilder
 		);
 	}
 
@@ -99,7 +126,56 @@ public class ExtensionSelectionFDSFilterTest {
 	}
 
 	@Test
-	public void testGetSelectionFDSFilterItems1() {
+	public void testGetSelectionFDSFilterItemsAggregatesObjectEntryClassNames() {
+		TermsAggregationResult termsAggregationResult = Mockito.mock(
+			TermsAggregationResult.class);
+
+		Mockito.when(
+			termsAggregationResult.getBuckets()
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			_searchResponse.getAggregationResult("extensions")
+		).thenReturn(
+			termsAggregationResult
+		);
+
+		_extensionSelectionFDSFilter.getSelectionFDSFilterItems(_locale);
+
+		Mockito.verify(
+			_searchRequestBuilder
+		).entryClassNames(
+			_OBJECT_DEFINITION_CLASS_NAME
+		);
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItemsWhenNoCMSObjectDefinitions() {
+		Mockito.when(
+			_objectDefinitionService.getCMSObjectDefinitions(
+				Mockito.anyLong(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			_extensionSelectionFDSFilter.getSelectionFDSFilterItems(_locale);
+
+		Assert.assertTrue(
+			selectionFDSFilterItems.toString(),
+			selectionFDSFilterItems.isEmpty());
+
+		Mockito.verify(
+			_searcher, Mockito.never()
+		).search(
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItemsWhenNoExtensions() {
 		Mockito.when(
 			_searchResponse.getAggregationResult("extensions")
 		).thenReturn(
@@ -115,7 +191,7 @@ public class ExtensionSelectionFDSFilterTest {
 	}
 
 	@Test
-	public void testGetSelectionFDSFilterItems2() {
+	public void testGetSelectionFDSFilterItemsWithExtensions() {
 		Bucket pdfBucket = Mockito.mock(Bucket.class);
 
 		Mockito.when(
@@ -167,8 +243,14 @@ public class ExtensionSelectionFDSFilterTest {
 		Assert.assertEquals("png", pngSelectionFDSFilterItem.getValue());
 	}
 
+	private static final String _OBJECT_DEFINITION_CLASS_NAME =
+		"com.liferay.object.model.ObjectDefinition#TEST";
+
 	@Mock
 	private Aggregations _aggregations;
+
+	@Mock
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
 
 	@Mock
 	private DepotEntryLocalService _depotEntryLocalService;
@@ -178,7 +260,16 @@ public class ExtensionSelectionFDSFilterTest {
 	private final Locale _locale = LocaleUtil.US;
 
 	@Mock
+	private ObjectDefinition _objectDefinition;
+
+	@Mock
+	private ObjectDefinitionService _objectDefinitionService;
+
+	@Mock
 	private Searcher _searcher;
+
+	@Mock(answer = Answers.RETURNS_SELF)
+	private SearchRequestBuilder _searchRequestBuilder;
 
 	@Mock
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
@@ -11,6 +11,7 @@ import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.aggregation.Aggregations;
 import com.liferay.portal.search.aggregation.bucket.Bucket;
@@ -244,7 +245,8 @@ public class ExtensionSelectionFDSFilterTest {
 	}
 
 	private static final String _OBJECT_DEFINITION_CLASS_NAME =
-		"com.liferay.object.model.ObjectDefinition#TEST";
+		"com.liferay.object.model.ObjectDefinition#" +
+			RandomTestUtil.randomString();
 
 	@Mock
 	private Aggregations _aggregations;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -20,6 +20,9 @@ import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
+const _PNG_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgAAACAAEABToPCwAAAABJRU5ErkJggg==';
+
 const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
@@ -1185,6 +1188,67 @@ test(
 
 			await expect(assetsPage.getItem(approvedTitle)).toBeVisible();
 			await expect(assetsPage.getItem(expiredTitle)).toBeHidden();
+		});
+	}
+);
+
+test(
+	'All section can be filtered by Extension',
+	{tag: '@LPD-96958'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-documents';
+		const jpgFileName = `JPG ${getRandomString()}.jpg`;
+		const pngFileName = `PNG ${getRandomString()}.png`;
+
+		await test.step('Upload a PNG file and a JPG file to the Default Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {fileBase64: _PNG_BASE64, name: pngFileName},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: pngFileName,
+				},
+				applicationName,
+				'Default'
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: readFileSync(
+							path.join(
+								__dirname,
+								'/dependencies/file_upload_image_1.jpg'
+							)
+						).toString('base64'),
+						name: jpgFileName,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: jpgFileName,
+				},
+				applicationName,
+				'Default'
+			);
+		});
+
+		await test.step('Both files are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(pngFileName)).toBeVisible();
+			await expect(assetsPage.getItem(jpgFileName)).toBeVisible();
+		});
+
+		// The Extension filter is only offered when the aggregation finds
+		// existing file extensions, so applying it also proves the filter is
+		// mounted with options (LPD-96958).
+
+		await test.step('Filter by Extension png and check only the PNG file is visible', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Extension',
+				value: 'png',
+			});
+
+			await expect(assetsPage.getItem(pngFileName)).toBeVisible();
+			await expect(assetsPage.getItem(jpgFileName)).toBeHidden();
 		});
 	}
 );


### PR DESCRIPTION
Adds an extension filter to the CMS grouped filters so files can be filtered by file extension.

Applies Brian's review feedback from brianchandotcom/liferay-portal#178117: the test object definition class name is now randomized instead of using a fixed `#TEST` suffix.

cc: @jkappler 