### PR TITLE
LPD-95537 Add CMS bulk operations E2E Playwright tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -74,6 +74,7 @@ import {config as designLibraryWebConfig} from './tests/design-library-web/main/
 import {config as dispatchWebConfig} from './tests/dispatch-web/main/config';
 import {config as documentLibraryWebConfig} from './tests/document-library-web/main/config';
 import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-mapping-form-web/main/config';
+import {config as e2eCmsDxpBulkOperationsConfig} from './tests/e2e-cms-dxp/bulk-operations/main/config';
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
@@ -319,6 +320,7 @@ export default defineConfig({
 		dispatchWebConfig,
 		documentLibraryWebConfig,
 		dynamicDataMappingFormWebConfig,
+		e2eCmsDxpBulkOperationsConfig,
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
 		e2eCmsDxpSharingConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkAssignCategoriesContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkAssignCategoriesContent.spec.ts
@@ -1,0 +1,310 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi, userData} from '../../../../utils/performLogin';
+import {waitForModal} from '../../../../utils/waitFor';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {
+	addCMSAdministratorUser,
+	clearFirstSignInWalls,
+	disconnectSite,
+	execBulkAction,
+} from './utils/bulkOperations';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+const BASIC_WEB_CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'Bulk assigned categories and tags make content entries discoverable in site search for USER',
+	{tag: ['@LPD-95537', '@LPD-95537/TC-14.e']},
+	async ({apiHelpers, browser, structureBuilderPage}) => {
+		test.setTimeout(600000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const categoryName = `category${getRandomInt()}`;
+		const tagName = `tag${getRandomInt()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const guestSite = await apiHelpers.headlessAdminSite.getSite('L_GUEST');
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			guestSite.externalReferenceCode,
+			{searchable: true}
+		);
+
+		try {
+			const cmsAdministrator = await addCMSAdministratorUser(apiHelpers);
+
+			const cmsSite =
+				await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
+					'cms'
+				);
+
+			const vocabulary =
+				await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary(
+					{
+						assetLibraries: [{id: -1}],
+						assetTypes: [
+							{
+								required: false,
+								subtype: 'AllAssetSubtypes',
+								type: 'AllAssetTypes',
+							},
+						],
+						name: `Vocabulary ${getRandomString()}`,
+						siteId: cmsSite.id,
+						visibilityType: 'PUBLIC',
+					}
+				);
+
+			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+				{
+					name: categoryName,
+					vocabularyId: vocabulary.id,
+				}
+			);
+
+			const tag = await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+				name: tagName,
+				siteId: cmsSite.id,
+			});
+
+			apiHelpers.data.push({
+				id: tag.id,
+				type: 'keyword',
+			});
+
+			const objectDefinitionId =
+				await test.step('Build a custom Event structure', async () => {
+					return await structureBuilderPage.createStructureFromData({
+						label: structureLabel,
+						name: structureName,
+						page: structureBuilderPage,
+						publish: true,
+						spaces: [spaceName],
+					});
+				});
+
+			const objectDefinition = await apiHelpers.get(
+				`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+			);
+
+			const structuredContentApplicationName =
+				objectDefinition.restContextPath.replace('/o/', '');
+
+			const entries = [];
+
+			for (const applicationName of [
+				BASIC_WEB_CONTENT_APPLICATION_NAME,
+				structuredContentApplicationName,
+			]) {
+				const titleField =
+					applicationName === BASIC_WEB_CONTENT_APPLICATION_NAME
+						? 'title'
+						: objectDefinition.titleObjectFieldName;
+
+				const entry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						[titleField]: `Title ${getRandomString()}`,
+					},
+					applicationName,
+					spaceName
+				);
+
+				await apiHelpers.objectEntry.putObjectEntryPermissions(
+					applicationName,
+					entry.id,
+					[
+						{
+							actionIds: ['DELETE', 'UPDATE', 'VIEW'],
+							roleName: 'CMS Administrator',
+						},
+						{actionIds: ['VIEW'], roleName: 'Guest'},
+						{actionIds: ['VIEW'], roleName: 'User'},
+					]
+				);
+
+				entries.push({applicationName, entry});
+			}
+
+			const entryTitles = entries.map(({entry}) => entry.title);
+
+			const caContext = await browser.newContext();
+
+			const caPage = await caContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: caPage,
+					screenName: cmsAdministrator.alternateName,
+				});
+
+				const caAssetsPage = new AssetsPage(caPage);
+
+				await test.step('The CMS Administrator bulk assigns a category to both entries', async () => {
+					await caAssetsPage.gotoContents();
+
+					await caAssetsPage.selectItems(entryTitles);
+
+					await execBulkAction(caPage, 'Edit Categories');
+
+					await waitForModal({page: caPage});
+
+					await caPage
+						.getByPlaceholder('Add category')
+						.fill(categoryName);
+
+					await caPage
+						.getByRole('option', {name: categoryName})
+						.click();
+
+					await expect(
+						caPage.locator('.label-item', {hasText: categoryName})
+					).toBeAttached({timeout: 5000});
+
+					await caPage.getByRole('button', {name: 'Save'}).click();
+
+					await waitForAlert(
+						caPage,
+						'Info:Categories update action started for 2 assets.',
+						{type: 'info'}
+					);
+				});
+
+				await test.step('The CMS Administrator bulk assigns a tag to both entries', async () => {
+					await caAssetsPage.gotoContents();
+
+					await caAssetsPage.selectItems(entryTitles);
+
+					await execBulkAction(caPage, 'Edit Tags');
+
+					await waitForModal({page: caPage});
+
+					await caPage.getByPlaceholder('Add tag').fill(tagName);
+
+					await caPage
+						.getByRole('option', {exact: true, name: tagName})
+						.click();
+
+					await expect(
+						caPage.locator('.label-item', {hasText: tagName})
+					).toBeAttached({timeout: 5000});
+
+					await caPage.getByRole('button', {name: 'Save'}).click();
+
+					await waitForAlert(
+						caPage,
+						'Info:Tags update action started for 2 assets.',
+						{type: 'info'}
+					);
+				});
+			}
+			finally {
+				await caContext.close();
+			}
+
+			await test.step('Both entries carry the category and the tag', async () => {
+				for (const {applicationName, entry} of entries) {
+					await expect(async () => {
+						const updatedEntry =
+							await apiHelpers.objectEntry.getObjectEntryById(
+								applicationName,
+								String(entry.id)
+							);
+
+						const categoryNames = (
+							updatedEntry.taxonomyCategoryBriefs || []
+						).map((brief) => brief.taxonomyCategoryName);
+
+						expect(categoryNames).toContain(categoryName);
+
+						expect(updatedEntry.keywords || []).toContain(tagName);
+					}).toPass({timeout: 60000});
+				}
+			});
+
+			await test.step('USER finds both entries in site search by category and by tag', async () => {
+				const user =
+					await apiHelpers.headlessAdminUser.postUserAccount();
+
+				userData[user.alternateName] = {
+					name: user.givenName,
+					password: 'test',
+					surname: user.familyName,
+				};
+
+				await clearFirstSignInWalls(apiHelpers, user);
+
+				await apiHelpers.jsonWebServicesUser.addGroupUsers(
+					String(guestSite.id),
+					[user.id]
+				);
+
+				const userContext = await browser.newContext();
+
+				const userPage = await userContext.newPage();
+
+				try {
+					await performLoginViaApi({
+						page: userPage,
+						screenName: user.alternateName,
+					});
+
+					for (const searchTerm of [categoryName, tagName]) {
+						await expect(async () => {
+							await userPage.goto(
+								`/web/guest/search?q=${searchTerm}`,
+								{waitUntil: 'domcontentloaded'}
+							);
+
+							for (const title of entryTitles) {
+								await expect(
+									userPage
+										.getByText(title, {exact: true})
+										.first()
+								).toBeVisible({timeout: 3000});
+							}
+						}).toPass({timeout: 90000});
+					}
+				}
+				finally {
+					await userContext.close();
+				}
+			});
+		}
+		finally {
+			await disconnectSite(
+				apiHelpers,
+				space.externalReferenceCode,
+				guestSite.externalReferenceCode
+			);
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkAssignCategoriesFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkAssignCategoriesFile.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {waitForModal} from '../../../../utils/waitFor';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {
+	addCMSAdministratorUser,
+	disconnectSite,
+	execBulkAction,
+} from './utils/bulkOperations';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'Bulk assigned categories and tags make files discoverable in site search for GUEST',
+	{tag: ['@LPD-95537', '@LPD-95537/TC-14.f']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(600000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const categoryName = `category${getRandomInt()}`;
+		const tagName = `tag${getRandomInt()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const guestSite = await apiHelpers.headlessAdminSite.getSite('L_GUEST');
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			guestSite.externalReferenceCode,
+			{searchable: true}
+		);
+
+		try {
+			const cmsAdministrator = await addCMSAdministratorUser(apiHelpers);
+
+			const cmsSite =
+				await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
+					'cms'
+				);
+
+			const vocabulary =
+				await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary(
+					{
+						assetLibraries: [{id: -1}],
+						assetTypes: [
+							{
+								required: false,
+								subtype: 'AllAssetSubtypes',
+								type: 'AllAssetTypes',
+							},
+						],
+						name: `Vocabulary ${getRandomString()}`,
+						siteId: cmsSite.id,
+						visibilityType: 'PUBLIC',
+					}
+				);
+
+			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+				{
+					name: categoryName,
+					vocabularyId: vocabulary.id,
+				}
+			);
+
+			const tag = await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+				name: tagName,
+				siteId: cmsSite.id,
+			});
+
+			apiHelpers.data.push({
+				id: tag.id,
+				type: 'keyword',
+			});
+
+			const entries = [];
+
+			for (let i = 0; i < 2; i++) {
+				const entry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						file: {
+							fileBase64: imageBase64,
+							name: `${getRandomString()}.jpg`,
+						},
+						objectEntryFolderExternalReferenceCode: 'L_FILES',
+						title: `Image ${getRandomString()}`,
+					},
+					APPLICATION_NAME,
+					spaceName
+				);
+
+				await apiHelpers.objectEntry.putObjectEntryPermissions(
+					APPLICATION_NAME,
+					entry.id,
+					[
+						{
+							actionIds: ['DELETE', 'UPDATE', 'VIEW'],
+							roleName: 'CMS Administrator',
+						},
+						{actionIds: ['VIEW'], roleName: 'Guest'},
+						{actionIds: ['VIEW'], roleName: 'User'},
+					]
+				);
+
+				entries.push(entry);
+			}
+
+			const fileTitles = entries.map((entry) => entry.title);
+
+			const caContext = await browser.newContext();
+
+			const caPage = await caContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: caPage,
+					screenName: cmsAdministrator.alternateName,
+				});
+
+				const caAssetsPage = new AssetsPage(caPage);
+
+				await test.step('The CMS Administrator bulk assigns a category to both files', async () => {
+					await caAssetsPage.gotoFiles();
+
+					await caAssetsPage.selectItems(fileTitles);
+
+					await execBulkAction(caPage, 'Edit Categories');
+
+					await waitForModal({page: caPage});
+
+					await caPage
+						.getByPlaceholder('Add category')
+						.fill(categoryName);
+
+					await caPage
+						.getByRole('option', {name: categoryName})
+						.click();
+
+					await expect(
+						caPage.locator('.label-item', {hasText: categoryName})
+					).toBeAttached({timeout: 5000});
+
+					await caPage.getByRole('button', {name: 'Save'}).click();
+
+					await waitForAlert(
+						caPage,
+						'Info:Categories update action started for 2 assets.',
+						{type: 'info'}
+					);
+				});
+
+				await test.step('The CMS Administrator bulk assigns a tag to both files', async () => {
+					await caAssetsPage.gotoFiles();
+
+					await caAssetsPage.selectItems(fileTitles);
+
+					await execBulkAction(caPage, 'Edit Tags');
+
+					await waitForModal({page: caPage});
+
+					await caPage.getByPlaceholder('Add tag').fill(tagName);
+
+					await caPage
+						.getByRole('option', {exact: true, name: tagName})
+						.click();
+
+					await expect(
+						caPage.locator('.label-item', {hasText: tagName})
+					).toBeAttached({timeout: 5000});
+
+					await caPage.getByRole('button', {name: 'Save'}).click();
+
+					await waitForAlert(
+						caPage,
+						'Info:Tags update action started for 2 assets.',
+						{type: 'info'}
+					);
+				});
+			}
+			finally {
+				await caContext.close();
+			}
+
+			await test.step('Both files carry the category and the tag', async () => {
+				for (const entry of entries) {
+					await expect(async () => {
+						const updatedEntry =
+							await apiHelpers.objectEntry.getObjectEntryById(
+								APPLICATION_NAME,
+								String(entry.id)
+							);
+
+						const categoryNames = (
+							updatedEntry.taxonomyCategoryBriefs || []
+						).map((brief) => brief.taxonomyCategoryName);
+
+						expect(categoryNames).toContain(categoryName);
+
+						expect(updatedEntry.keywords || []).toContain(tagName);
+					}).toPass({timeout: 60000});
+				}
+			});
+
+			await test.step('GUEST finds both files in site search by category and by tag', async () => {
+				const guestContext = await browser.newContext({
+					storageState: {cookies: [], origins: []},
+				});
+
+				const guestPage = await guestContext.newPage();
+
+				try {
+					for (const searchTerm of [categoryName, tagName]) {
+						await expect(async () => {
+							await guestPage.goto(
+								`/web/guest/search?q=${searchTerm}`,
+								{waitUntil: 'domcontentloaded'}
+							);
+
+							for (const title of fileTitles) {
+								await expect(
+									guestPage
+										.getByText(title, {exact: true})
+										.first()
+								).toBeVisible({timeout: 3000});
+							}
+						}).toPass({timeout: 90000});
+					}
+				}
+				finally {
+					await guestContext.close();
+				}
+			});
+		}
+		finally {
+			await disconnectSite(
+				apiHelpers,
+				space.externalReferenceCode,
+				guestSite.externalReferenceCode
+			);
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkDeleteContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkDeleteContent.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {addSpaceUserWithSession, execBulkAction} from './utils/bulkOperations';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'A Content Reviewer bulk deletes Basic Web Content entries and they stop rendering for GUEST',
+	{tag: ['@LPD-95537', '@LPD-95537/TC-14.c', '@LPD-97251']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.fail();
+
+		test.setTimeout(480000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const mappedTitle = `Title ${getRandomString()}`;
+		const mappedBody = `Body ${getRandomString()}`;
+		const secondTitle = `Title ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const contentReviewer = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Content Reviewer'
+		);
+
+		const mappedEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${mappedBody}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: mappedTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: secondTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			mappedEntry.id,
+			[
+				{
+					actionIds: ['DELETE', 'UPDATE', 'VIEW'],
+					roleName: 'Asset Library Content Reviewer',
+				},
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><div><lfr-editable id="content" type="rich-text">Content</lfr-editable></div></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map one entry into a page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: ENTITY,
+						entry: mappedTitle,
+						field: 'Title',
+					},
+				});
+
+				await pageEditorPage.selectEditable(fragmentId, 'content');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: ENTITY,
+						entry: mappedTitle,
+						field: 'Content',
+					},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		const guestContext = await browser.newContext({
+			storageState: {cookies: [], origins: []},
+		});
+
+		const guestPage = await guestContext.newPage();
+
+		try {
+			await test.step('GUEST sees the mapped content before the bulk delete', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(mappedTitle, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					await expect(
+						guestPage.getByText(mappedBody, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			const scrContext = await browser.newContext();
+
+			const scrPage = await scrContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: scrPage,
+					screenName: contentReviewer.alternateName,
+				});
+
+				const scrAssetsPage = new AssetsPage(scrPage);
+
+				await test.step('The Content Reviewer bulk deletes both entries', async () => {
+					await scrAssetsPage.gotoContents();
+
+					await scrAssetsPage.selectItems([mappedTitle, secondTitle]);
+
+					await execBulkAction(scrPage, 'Delete');
+				});
+
+				await test.step('The entries are gone from the content list', async () => {
+					await expect(async () => {
+						await scrAssetsPage.gotoContents();
+
+						for (const title of [mappedTitle, secondTitle]) {
+							await expect(
+								scrPage.getByRole('link', {
+									exact: true,
+									name: title,
+								})
+							).toBeHidden({timeout: 2000});
+						}
+					}).toPass({timeout: 30000});
+				});
+			}
+			finally {
+				await scrContext.close();
+			}
+
+			await test.step('GUEST no longer sees the mapped content', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(mappedTitle, {exact: true})
+					).toBeHidden({timeout: 2000});
+
+					await expect(
+						guestPage.getByText(mappedBody, {exact: true})
+					).toBeHidden({timeout: 2000});
+				}).toPass({timeout: 15000});
+			});
+		}
+		finally {
+			await guestContext.close();
+		}
+
+		await test.step('The entries are in the Recycle Bin', async () => {
+			const recycleBinPage = new RecycleBinPage(page);
+
+			await expect(async () => {
+				await recycleBinPage.goto();
+
+				for (const title of [mappedTitle, secondTitle]) {
+					await expect(
+						page.getByRole('cell', {exact: true, name: title})
+					).toBeVisible({timeout: 2000});
+				}
+			}).toPass({timeout: 30000});
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkDeleteFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkDeleteFile.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {isImageLoaded} from '../../../../utils/isImageLoaded';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {addSpaceUserWithSession, execBulkAction} from './utils/bulkOperations';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const ENTITY = 'Basic Documents (CMS)';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A Space Administrator bulk deletes files and they stop being accessible on the site',
+	{tag: ['@LPD-95537', '@LPD-95537/TC-14.d', '@LPD-97251']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.fail();
+
+		test.setTimeout(480000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const mappedFileTitle = `Image ${getRandomString()}`;
+		const secondFileTitle = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const mappedEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: mappedFileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const secondEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: secondFileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			mappedEntry.id,
+			[
+				{
+					actionIds: ['DELETE', 'UPDATE', 'VIEW'],
+					roleName: 'Asset Library Administrator',
+				},
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			secondEntry.id,
+			[
+				{
+					actionIds: ['DELETE', 'UPDATE', 'VIEW'],
+					roleName: 'Asset Library Administrator',
+				},
+			]
+		);
+
+		const downloadHref = mappedEntry.file.link.href;
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><lfr-editable id="image" type="image"><img alt="" src=""/></lfr-editable></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map one file into a page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: ENTITY,
+						entry: mappedFileTitle,
+						field: 'Title',
+					},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.selectEditable(fragmentId, 'image');
+
+			await page.getByLabel('Source Selection').selectOption('Mapping');
+
+			await pageEditorPage.setMappedItem({
+				entity: ENTITY,
+				entry: mappedFileTitle,
+				field: 'Preview URL',
+			});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		const guestContext = await browser.newContext({
+			storageState: {cookies: [], origins: []},
+		});
+
+		const guestPage = await guestContext.newPage();
+
+		try {
+			await test.step('GUEST sees the mapped file before the bulk delete', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(mappedFileTitle, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					expect(
+						await isImageLoaded(
+							guestPage.locator('img[src*="/documents/"]').first()
+						)
+					).toBe(true);
+				}).toPass({timeout: 30000});
+			});
+
+			const spaContext = await browser.newContext();
+
+			const spaPage = await spaContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: spaPage,
+					screenName: spaceAdministrator.alternateName,
+				});
+
+				const spaAssetsPage = new AssetsPage(spaPage);
+
+				await test.step('The Space Administrator bulk deletes both files', async () => {
+					await spaAssetsPage.gotoFiles();
+
+					await spaAssetsPage.selectItems([
+						mappedFileTitle,
+						secondFileTitle,
+					]);
+
+					await execBulkAction(spaPage, 'Delete');
+				});
+
+				await test.step('The files are gone from the file list', async () => {
+					await expect(async () => {
+						await spaAssetsPage.gotoFiles();
+
+						for (const title of [
+							mappedFileTitle,
+							secondFileTitle,
+						]) {
+							await expect(
+								spaPage.getByRole('button', {
+									name: `${title} Actions`,
+								})
+							).toBeHidden({timeout: 2000});
+						}
+					}).toPass({timeout: 30000});
+				});
+			}
+			finally {
+				await spaContext.close();
+			}
+
+			await test.step('The file is no longer accessible on the site for GUEST', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(mappedFileTitle, {exact: true})
+					).toBeHidden({timeout: 2000});
+
+					await expect(
+						guestPage.locator('img[src*="/documents/"]')
+					).toHaveCount(0, {timeout: 2000});
+				}).toPass({timeout: 15000});
+
+				const downloadStatus = await guestPage.evaluate(
+					async (href) =>
+						(await fetch(href, {redirect: 'manual'})).status,
+					downloadHref
+				);
+
+				expect(downloadStatus).not.toBe(200);
+			});
+		}
+		finally {
+			await guestContext.close();
+		}
+
+		await test.step('Both files are in the Recycle Bin', async () => {
+			const recycleBinPage = new RecycleBinPage(page);
+
+			await expect(async () => {
+				await recycleBinPage.goto();
+
+				for (const title of [mappedFileTitle, secondFileTitle]) {
+					await expect(
+						page.getByRole('cell', {exact: true, name: title})
+					).toBeVisible({timeout: 2000});
+				}
+			}).toPass({timeout: 30000});
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkDeletePermissions.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkDeletePermissions.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {addSpaceUserWithSession} from './utils/bulkOperations';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const FILE_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A Space Member cannot bulk delete content entries or files',
+	{tag: ['@LPD-95537', '@LPD-95537/TC-14.g']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitles = [
+			`Title ${getRandomString()}`,
+			`Title ${getRandomString()}`,
+		];
+		const fileTitles = [
+			`Image ${getRandomString()}`,
+			`Image ${getRandomString()}`,
+		];
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceMember = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Member'
+		);
+
+		for (const title of contentTitles) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					content: `<p>${getRandomString()}</p>`,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title,
+				},
+				CONTENT_APPLICATION_NAME,
+				spaceName
+			);
+		}
+
+		for (const title of fileTitles) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: imageBase64,
+						name: `${getRandomString()}.jpg`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title,
+				},
+				FILE_APPLICATION_NAME,
+				spaceName
+			);
+		}
+
+		const memberContext = await browser.newContext();
+
+		const memberPage = await memberContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: memberPage,
+				screenName: spaceMember.alternateName,
+			});
+
+			const memberAssetsPage = new AssetsPage(memberPage);
+
+			const expectBulkDeleteUnavailable = async (firstTitle: string) => {
+				await expect(
+					memberPage.getByRole('checkbox', {
+						name: `Select ${firstTitle}`,
+					})
+				).toBeChecked({timeout: 5000});
+
+				const menu = memberPage.locator('.dropdown-menu.show');
+
+				await expect(async () => {
+					await memberPage
+						.locator('.management-bar-wrapper')
+						.getByLabel('Actions')
+						.click({timeout: 2000});
+
+					await expect(menu).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 15000});
+
+				await expect(
+					menu.getByRole('menuitem', {exact: true, name: 'Delete'})
+				).toBeHidden({timeout: 2000});
+
+				await memberPage.keyboard.press('Escape');
+			};
+
+			await test.step('Bulk delete is not available in the Contents section', async () => {
+				await memberAssetsPage.gotoContents();
+
+				await memberAssetsPage.selectItems(contentTitles);
+
+				await expectBulkDeleteUnavailable(contentTitles[0]);
+			});
+
+			await test.step('Bulk delete is not available in the Files section', async () => {
+				await memberAssetsPage.gotoFiles();
+
+				await memberAssetsPage.selectItems(fileTitles);
+
+				await expectBulkDeleteUnavailable(fileTitles[0]);
+			});
+		}
+		finally {
+			await memberContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkMoveContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkMoveContent.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {
+	addSpaceUserWithSession,
+	bulkMoveToFolder,
+	openFolder,
+} from './utils/bulkOperations';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+const BASIC_WEB_CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'A Space Administrator bulk moves Basic Web Content and Structured Content entries to another folder',
+	{tag: ['@LPD-95537', '@LPD-95537/TC-14.a']},
+	async ({apiHelpers, browser, structureBuilderPage}) => {
+		test.setTimeout(480000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const originFolderName = `Origin ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const originFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: originFolderName,
+			});
+
+		const destinationFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: destinationFolderName,
+			});
+
+		const objectDefinitionId =
+			await test.step('Build a custom Event structure', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: true,
+					spaces: [spaceName],
+				});
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const structuredContentApplicationName =
+			objectDefinition.restContextPath.replace('/o/', '');
+
+		const entries = [];
+
+		for (const applicationName of [
+			BASIC_WEB_CONTENT_APPLICATION_NAME,
+			BASIC_WEB_CONTENT_APPLICATION_NAME,
+			structuredContentApplicationName,
+			structuredContentApplicationName,
+		]) {
+			const titleField =
+				applicationName === BASIC_WEB_CONTENT_APPLICATION_NAME
+					? 'title'
+					: objectDefinition.titleObjectFieldName;
+
+			entries.push({
+				applicationName,
+				entry: await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode:
+							originFolder.externalReferenceCode,
+						[titleField]: `Title ${getRandomString()}`,
+					},
+					applicationName,
+					spaceName
+				),
+			});
+		}
+
+		const entryTitles = entries.map(({entry}) => entry.title);
+
+		const spaContext = await browser.newContext();
+
+		const spaPage = await spaContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: spaPage,
+				screenName: spaceAdministrator.alternateName,
+			});
+
+			const spaAssetsPage = new AssetsPage(spaPage);
+
+			await test.step('The Space Administrator bulk moves the four entries', async () => {
+				await spaAssetsPage.gotoContents();
+
+				await openFolder(spaPage, originFolderName);
+
+				await spaAssetsPage.selectItems(entryTitles);
+
+				await bulkMoveToFolder(spaPage, {
+					destinationFolder: destinationFolderName,
+					destinationSpace: spaceName,
+				});
+			});
+
+			await test.step('All entries sit in the destination folder', async () => {
+				await expect(async () => {
+					const folderIdsByTitle = [];
+
+					for (const {applicationName, entry} of entries) {
+						const movedEntry =
+							await apiHelpers.objectEntry.getObjectEntryById(
+								applicationName,
+								String(entry.id)
+							);
+
+						folderIdsByTitle.push({
+							folderId: movedEntry.objectEntryFolderId,
+							title: entry.title,
+						});
+					}
+
+					expect(folderIdsByTitle).toEqual(
+						entries.map(({entry}) => ({
+							folderId: destinationFolder.id,
+							title: entry.title,
+						}))
+					);
+				}).toPass({timeout: 60000});
+			});
+
+			await test.step('The entries are gone from the origin folder and listed in the destination', async () => {
+				await spaAssetsPage.gotoContents();
+
+				await openFolder(spaPage, originFolderName);
+
+				for (const title of entryTitles) {
+					await expect(
+						spaPage.getByRole('link', {exact: true, name: title})
+					).toBeHidden({timeout: 5000});
+				}
+
+				await spaAssetsPage.gotoContents();
+
+				await openFolder(spaPage, destinationFolderName);
+
+				for (const title of entryTitles) {
+					await expect(
+						spaPage.getByRole('link', {exact: true, name: title})
+					).toBeVisible({timeout: 5000});
+				}
+			});
+		}
+		finally {
+			await spaContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkMoveFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/bulkMoveFile.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {
+	addSpaceUserWithSession,
+	bulkMoveToFolder,
+	openFolder,
+} from './utils/bulkOperations';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A Space Administrator bulk moves multiple files to another folder',
+	{tag: ['@LPD-95537', '@LPD-95537/TC-14.b']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const originFolderName = `Origin ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const originFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: spaceName,
+				title: originFolderName,
+			});
+
+		const destinationFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: spaceName,
+				title: destinationFolderName,
+			});
+
+		const entries = [];
+
+		for (let i = 0; i < 3; i++) {
+			entries.push(
+				await apiHelpers.objectEntry.postObjectEntry(
+					{
+						file: {
+							fileBase64: imageBase64,
+							name: `${getRandomString()}.jpg`,
+						},
+						objectEntryFolderExternalReferenceCode:
+							originFolder.externalReferenceCode,
+						title: `Image ${getRandomString()}`,
+					},
+					APPLICATION_NAME,
+					spaceName
+				)
+			);
+		}
+
+		const fileTitles = entries.map((entry) => entry.title);
+
+		const spaContext = await browser.newContext();
+
+		const spaPage = await spaContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: spaPage,
+				screenName: spaceAdministrator.alternateName,
+			});
+
+			const spaAssetsPage = new AssetsPage(spaPage);
+
+			await test.step('The Space Administrator bulk moves the three files', async () => {
+				await spaAssetsPage.gotoFiles();
+
+				await openFolder(spaPage, originFolderName);
+
+				await spaAssetsPage.selectItems(fileTitles);
+
+				await bulkMoveToFolder(spaPage, {
+					destinationFolder: destinationFolderName,
+					destinationSpace: spaceName,
+				});
+			});
+
+			await test.step('All files sit in the destination folder', async () => {
+				for (const entry of entries) {
+					await expect(async () => {
+						const movedEntry =
+							await apiHelpers.objectEntry.getObjectEntryById(
+								APPLICATION_NAME,
+								String(entry.id)
+							);
+
+						expect(movedEntry.objectEntryFolderId).toBe(
+							destinationFolder.id
+						);
+					}).toPass({timeout: 30000});
+				}
+			});
+
+			await test.step('The files are gone from the origin folder and listed in the destination', async () => {
+				await spaAssetsPage.gotoFiles();
+
+				await openFolder(spaPage, originFolderName);
+
+				for (const title of fileTitles) {
+					await expect(
+						spaPage.getByRole('button', {name: `${title} Actions`})
+					).toBeHidden({timeout: 5000});
+				}
+
+				await spaAssetsPage.gotoFiles();
+
+				await openFolder(spaPage, destinationFolderName);
+
+				for (const title of fileTitles) {
+					await expect(
+						spaPage.getByRole('button', {name: `${title} Actions`})
+					).toBeVisible({timeout: 5000});
+				}
+			});
+		}
+		finally {
+			await spaContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'bulk-operations.main',
+	testDir: 'tests/e2e-cms-dxp/bulk-operations/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/utils/bulkOperations.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/bulk-operations/main/utils/bulkOperations.ts
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect} from '@playwright/test';
+
+import {DataApiHelpers} from '../../../../../helpers/ApiHelpers';
+import {addSpaceUser} from '../../../../../utils/addSpaceUser';
+import {userData} from '../../../../../utils/performLogin';
+
+export async function execBulkAction(page: Page, action: string) {
+	const menu = page.locator('.dropdown-menu.show');
+
+	const menuItem = menu.getByRole('menuitem', {exact: true, name: action});
+
+	await expect(async () => {
+		if (!(await menu.isVisible())) {
+			await page
+				.getByRole('button', {exact: true, name: 'Actions'})
+				.click({timeout: 2000});
+
+			await expect(menu).toBeVisible({timeout: 2000});
+		}
+
+		await expect(menuItem).toBeVisible({timeout: 5000});
+	}).toPass({timeout: 30000});
+
+	await menuItem.click();
+}
+
+export async function bulkMoveToFolder(
+	page: Page,
+	{
+		destinationFolder,
+		destinationSpace,
+	}: {destinationFolder: string; destinationSpace: string}
+) {
+	const dialog = page.getByRole('dialog', {name: /^Move .+ To$/});
+
+	const folderRadio = dialog.getByRole('radio', {
+		name: `Select ${destinationFolder}`,
+	});
+
+	await expect(async () => {
+		if (!(await dialog.isVisible())) {
+			await execBulkAction(page, 'Move To');
+		}
+
+		await expect(dialog).toBeVisible({timeout: 5000});
+
+		await dialog.getByLabel(destinationSpace).click({timeout: 5000});
+
+		await expect(folderRadio).toBeVisible({timeout: 5000});
+
+		await folderRadio.click();
+
+		await dialog
+			.getByRole('button', {exact: true, name: 'Select'})
+			.click({timeout: 5000});
+
+		await expect(dialog).toBeHidden({timeout: 5000});
+	}).toPass({timeout: 90000});
+}
+
+export async function addCMSAdministratorUser(
+	apiHelpers: DataApiHelpers
+): Promise<TUserAccount> {
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+	userData[user.alternateName] = {
+		name: user.givenName,
+		password: 'test',
+		surname: user.familyName,
+	};
+
+	const rolesPage =
+		await apiHelpers.headlessAdminUser.getRoles('CMS Administrator');
+
+	const cmsAdministratorRole = rolesPage.items.find(
+		(role) => role.name === 'CMS Administrator'
+	);
+
+	if (!cmsAdministratorRole) {
+		throw new Error('CMS Administrator role was not found');
+	}
+
+	await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+		cmsAdministratorRole.id,
+		Number(user.id)
+	);
+
+	await clearFirstSignInWalls(apiHelpers, user);
+
+	return user;
+}
+
+export async function addSpaceUserWithSession(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string,
+	roleName: string
+): Promise<TUserAccount> {
+	const user = await addSpaceUser(
+		apiHelpers,
+		spaceExternalReferenceCode,
+		roleName
+	);
+
+	await clearFirstSignInWalls(apiHelpers, user);
+
+	return user;
+}
+
+export async function clearFirstSignInWalls(
+	apiHelpers: DataApiHelpers,
+	user: TUserAccount
+) {
+	await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+	await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+}
+
+export async function disconnectSite(
+	apiHelpers: DataApiHelpers,
+	assetLibraryExternalReferenceCode: string,
+	connectedSiteExternalReferenceCode: string
+) {
+	await apiHelpers.delete(
+		`${apiHelpers.baseUrl}headless-asset-library/v1.0/asset-libraries/${assetLibraryExternalReferenceCode}/connected-sites/${connectedSiteExternalReferenceCode}`
+	);
+}
+
+export async function openFolder(page: Page, folderName: string) {
+	await page.getByRole('link', {exact: true, name: folderName}).click();
+
+	await page.waitForURL('**/view-folder/**');
+
+	await page.locator('.fds').waitFor();
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95537

## What Is Being Fixed

The CMS end-to-end epic (LPD-85582) had no automated coverage for the Bulk Operations scenarios in LPD-95537: bulk move, bulk delete, and bulk categorization of content and files across roles.

## How It Is Being Fixed

This adds a Playwright suite (bulk-operations.main) with one spec per scenario. A Space Administrator bulk moves Basic Web Content and Structured Content between folders and bulk moves files; a Content Reviewer and a Space Administrator bulk delete content and files; a CMS Administrator bulk assigns categories and tags so entries and files become discoverable in site search for an authenticated user and a guest; and a Space Member is denied bulk operations. Data is provisioned through apiHelpers, the bulk actions are driven through the consolidated Actions dropdown, the destination picker is retried to absorb search-index lag, deletions use a trash-enabled Space and are verified in the Recycle Bin from an administrator context, and rendering is asserted through non-cacheable fragment mapping.

The two bulk delete scenarios are committed as expected failures for LPD-97251: after a bulk delete the entry leaves the content list and lands in the Recycle Bin, but the mapped DXP page keeps rendering it for a guest, because the mapped info item provider resolves the latest approved version and sending an entry to the Recycle Bin does not change its approved status. They are marked test.fail() so they pass now and flip once the bug is fixed.

## PR Check

**pr-check: PASS** — tested on `c687593eed06b99e8dfe5af6ed0ba2f10ade07c1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "c687593eed06b99e8dfe5af6ed0ba2f10ade07c1"} -->

https://claude.ai/code/session_01MjfHA8cbSJn1xbcnTAX15g
