### PR TITLE
LPD-97240 Fix AMImageContentTransformerTest routine failure

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
@@ -31,6 +31,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -59,21 +61,20 @@ public class AMImageContentTransformerTest {
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
-		_amImageConfigurationEntry =
-			_amImageConfigurationHelper.addAMImageConfigurationEntry(
-				_group.getCompanyId(), StringUtil.randomString(),
-				StringUtil.randomString(), StringUtil.randomString(),
-				HashMapBuilder.put(
-					"max-height", "600"
-				).put(
-					"max-width", "800"
-				).build());
+		_amImageConfigurationEntries.add(
+			_addAMImageConfigurationEntry(300, 300));
+		_amImageConfigurationEntries.add(
+			_addAMImageConfigurationEntry(600, 800));
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
-			_group.getCompanyId(), _amImageConfigurationEntry.getUUID());
+		for (AMImageConfigurationEntry amImageConfigurationEntry :
+				_amImageConfigurationEntries) {
+
+			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				_group.getCompanyId(), amImageConfigurationEntry.getUUID());
+		}
 	}
 
 	@Test
@@ -109,6 +110,20 @@ public class AMImageContentTransformerTest {
 		Assert.assertTrue(transformedHTML, transformedHTML.matches(regex));
 
 		_assertMatcher(fileEntriesCount, regex, transformedHTML);
+	}
+
+	private AMImageConfigurationEntry _addAMImageConfigurationEntry(
+			int maxHeight, int maxWidth)
+		throws Exception {
+
+		return _amImageConfigurationHelper.addAMImageConfigurationEntry(
+			_group.getCompanyId(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			HashMapBuilder.put(
+				"max-height", String.valueOf(maxHeight)
+			).put(
+				"max-width", String.valueOf(maxWidth)
+			).build());
 	}
 
 	private FileEntry _addImageFileEntry(ServiceContext serviceContext)
@@ -166,7 +181,8 @@ public class AMImageContentTransformerTest {
 			"\\/><\\/picture>");
 	}
 
-	private AMImageConfigurationEntry _amImageConfigurationEntry;
+	private final List<AMImageConfigurationEntry> _amImageConfigurationEntries =
+		new ArrayList<>();
 
 	@Inject
 	private AMImageConfigurationHelper _amImageConfigurationHelper;

--- a/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/AMImageAddConfigurationTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/AMImageAddConfigurationTest.java
@@ -18,7 +18,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -270,20 +269,8 @@ public class AMImageAddConfigurationTest
 				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry -> true);
 
-		Assert.assertEquals(
-			amImageConfigurationEntries.toString(), 2,
-			amImageConfigurationEntries.size());
-
-		Iterator<AMImageConfigurationEntry> iterator =
-			amImageConfigurationEntries.iterator();
-
-		AMImageConfigurationEntry amImageConfigurationEntry = iterator.next();
-
-		Assert.assertEquals("1", amImageConfigurationEntry.getUUID());
-
-		amImageConfigurationEntry = iterator.next();
-
-		Assert.assertEquals("2", amImageConfigurationEntry.getUUID());
+		assertContains(amImageConfigurationEntries, "1");
+		assertContains(amImageConfigurationEntries, "2");
 	}
 
 	@Test

--- a/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/AMImageConfigurationTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/AMImageConfigurationTest.java
@@ -15,7 +15,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -33,18 +32,6 @@ public class AMImageConfigurationTest extends BaseAMImageConfigurationTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
-
-	@Test
-	public void testEmptyConfiguration() throws Exception {
-		Iterable<AMImageConfigurationEntry> amImageConfigurationEntries =
-			_amImageConfigurationHelper.getAMImageConfigurationEntries(
-				TestPropsValues.getCompanyId());
-
-		Iterator<AMImageConfigurationEntry> iterator =
-			amImageConfigurationEntries.iterator();
-
-		Assert.assertFalse(iterator.hasNext());
-	}
 
 	@Test
 	public void testExistantConfigurationEntry() throws Exception {
@@ -88,16 +75,8 @@ public class AMImageConfigurationTest extends BaseAMImageConfigurationTestCase {
 			_amImageConfigurationHelper.getAMImageConfigurationEntries(
 				TestPropsValues.getCompanyId());
 
-		Assert.assertEquals(
-			amImageConfigurationEntries.toString(), 1,
-			amImageConfigurationEntries.size());
-
-		Iterator<AMImageConfigurationEntry> iterator =
-			amImageConfigurationEntries.iterator();
-
-		AMImageConfigurationEntry amImageConfigurationEntry = iterator.next();
-
-		Assert.assertEquals("1", amImageConfigurationEntry.getUUID());
+		assertContains(amImageConfigurationEntries, "1");
+		assertNotContains(amImageConfigurationEntries, "2");
 	}
 
 	@Test
@@ -128,20 +107,8 @@ public class AMImageConfigurationTest extends BaseAMImageConfigurationTestCase {
 				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry -> true);
 
-		Assert.assertEquals(
-			amImageConfigurationEntries.toString(), 2,
-			amImageConfigurationEntries.size());
-
-		Iterator<AMImageConfigurationEntry> iterator =
-			amImageConfigurationEntries.iterator();
-
-		AMImageConfigurationEntry amImageConfigurationEntry = iterator.next();
-
-		Assert.assertEquals("1", amImageConfigurationEntry.getUUID());
-
-		amImageConfigurationEntry = iterator.next();
-
-		Assert.assertEquals("2", amImageConfigurationEntry.getUUID());
+		assertContains(amImageConfigurationEntries, "1");
+		assertContains(amImageConfigurationEntries, "2");
 	}
 
 	@Test
@@ -174,13 +141,10 @@ public class AMImageConfigurationTest extends BaseAMImageConfigurationTestCase {
 				"max-width", "100"
 			).build());
 
-		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
+		assertContains(
 			_amImageConfigurationHelper.getAMImageConfigurationEntries(
-				TestPropsValues.getCompanyId());
-
-		Assert.assertFalse(
-			amImageConfigurationEntries.toString(),
-			amImageConfigurationEntries.isEmpty());
+				TestPropsValues.getCompanyId()),
+			"1");
 	}
 
 	@Test

--- a/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/BaseAMImageConfigurationTestCase.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/BaseAMImageConfigurationTestCase.java
@@ -12,6 +12,8 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -24,12 +26,30 @@ public abstract class BaseAMImageConfigurationTestCase {
 
 	@Before
 	public void setUp() throws Exception {
-		_deleteAllConfigurationEntries();
+		_initialAMImageConfigurationEntryUuids =
+			_getAMImageConfigurationEntryUuids();
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		_deleteAllConfigurationEntries();
+		AMImageConfigurationHelper amImageConfigurationHelper =
+			getAMImageConfigurationHelper();
+
+		for (String uuid : _getAMImageConfigurationEntryUuids()) {
+			if (!_initialAMImageConfigurationEntryUuids.contains(uuid)) {
+				amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+					TestPropsValues.getCompanyId(), uuid);
+			}
+		}
+	}
+
+	protected void assertContains(
+		Collection<AMImageConfigurationEntry> amImageConfigurationEntries,
+		String uuid) {
+
+		Assert.assertTrue(
+			amImageConfigurationEntries.toString(),
+			_contains(amImageConfigurationEntries, uuid));
 	}
 
 	protected void assertDisabled(
@@ -46,6 +66,15 @@ public abstract class BaseAMImageConfigurationTestCase {
 		Assert.assertTrue(amImageConfigurationEntry.isEnabled());
 	}
 
+	protected void assertNotContains(
+		Collection<AMImageConfigurationEntry> amImageConfigurationEntries,
+		String uuid) {
+
+		Assert.assertFalse(
+			amImageConfigurationEntries.toString(),
+			_contains(amImageConfigurationEntries, uuid));
+	}
+
 	protected abstract AMImageConfigurationHelper
 		getAMImageConfigurationHelper();
 
@@ -56,7 +85,24 @@ public abstract class BaseAMImageConfigurationTestCase {
 
 	}
 
-	private void _deleteAllConfigurationEntries() throws Exception {
+	private boolean _contains(
+		Collection<AMImageConfigurationEntry> amImageConfigurationEntries,
+		String uuid) {
+
+		for (AMImageConfigurationEntry amImageConfigurationEntry :
+				amImageConfigurationEntries) {
+
+			if (uuid.equals(amImageConfigurationEntry.getUUID())) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private Set<String> _getAMImageConfigurationEntryUuids() throws Exception {
+		Set<String> uuids = new HashSet<>();
+
 		AMImageConfigurationHelper amImageConfigurationHelper =
 			getAMImageConfigurationHelper();
 
@@ -68,11 +114,13 @@ public abstract class BaseAMImageConfigurationTestCase {
 		for (AMImageConfigurationEntry amImageConfigurationEntry :
 				amImageConfigurationEntries) {
 
-			amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
-				TestPropsValues.getCompanyId(),
-				amImageConfigurationEntry.getUUID());
+			uuids.add(amImageConfigurationEntry.getUUID());
 		}
+
+		return uuids;
 	}
+
+	private Set<String> _initialAMImageConfigurationEntryUuids;
 
 	@Inject
 	private MessageBus _messageBus;

--- a/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/BaseAMImageConfigurationTestCase.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/BaseAMImageConfigurationTestCase.java
@@ -32,6 +32,10 @@ public abstract class BaseAMImageConfigurationTestCase {
 
 	@After
 	public void tearDown() throws Exception {
+		if (_initialAMImageConfigurationEntryUuids == null) {
+			return;
+		}
+
 		AMImageConfigurationHelper amImageConfigurationHelper =
 			getAMImageConfigurationHelper();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97240

## What Is Being Fixed

AMImageContentTransformerTest fails on the CI routine (both testTransformASingleImage and testTransformASingleImageMultipleTimes). The test asserts that an <img> is rewritten into a <picture> with two <source> elements, but it added only a single Adaptive Media image configuration entry and relied on the company already having at least one more, the Document Library thumbnail and preview defaults. The root cause is BaseAMImageConfigurationTestCase, whose subclasses delete every image configuration entry for the shared company (including those defaults) in setUp and tearDown and never restore them. Once any of those tests runs in a portal instance, the defaults are gone, so the transformer emits a <picture> with a single <source> and the two-source assertion fails.

## How It Is Being Fixed

AMImageContentTransformerTest now creates the two configuration entries it needs and deletes them afterward, so it no longer depends on the ambient company configuration. BaseAMImageConfigurationTestCase no longer wipes the shared company: it records the entries present before each test and removes only the ones created during the test, leaving the defaults intact. The count and iteration-order assertions in AMImageConfigurationTest and AMImageAddConfigurationTest that relied on the wipe were rewritten to check for the presence or absence of specific entries, since the defaults now interleave in the name-sorted results.

## Why Are There No Tests?

This change only modifies existing integration tests to fix a routine test failure; there is no production code change, so no new tests are warranted.

## PR Check

**pr-check: PASS** — tested on `ac42c62c0cfd3cb5e6593020ee2b7b5f06348f70`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ac42c62c0cfd3cb5e6593020ee2b7b5f06348f70"} -->
