### PR TITLE
LPD-97241 Enable LPD-86291 for the system category deletion test

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -523,6 +523,7 @@ public class AssetCategoryLocalServiceTest {
 			assetCategory, assetCategoryTitle);
 	}
 
+	@FeatureFlag("LPD-86291")
 	@Test
 	public void testDeleteCategories() throws Exception {
 		AssetCategory assetCategory = _addSystemCategory();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97241

## What Is Being Fixed

The integration test `AssetCategoryLocalServiceTest.testDeleteCategories` failed with an `AssertionError`. The test creates a system category and asserts that deleting it throws `SystemCategoryException.MustNotDelete`. That protection is gated behind the `LPD-86291` feature flag in `AssetCategoryLocalServiceImpl.deleteCategory`, which is disabled by default. The test was added under LPD-96310 without the `@FeatureFlag("LPD-86291")` annotation, so the flag was off, the delete succeeded silently, and the expected exception never fired.

## How It Is Being Fixed

Add `@FeatureFlag("LPD-86291")` to `testDeleteCategories`, matching the sibling system-category tests (`testDeleteCategory`, `testMoveCategory`, `testUpdateCategory`) that already carry the annotation to assert the same flag-gated protections.

## Why Are There No Tests?

The change is a test-only fix that repairs the existing `testDeleteCategories` integration test; it adds no production code, so no new test coverage applies.

## PR Check

**pr-check: PASS** — tested on `b2e47e192ba85fb75a58a0cb418db4851bf21294`

| Validation | Result |
| --- | --- |
| Integration Test Compile | PASS |
| Per-Module Compile | PASS |
| Source Format | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b2e47e192ba85fb75a58a0cb418db4851bf21294"} -->
