### PR TITLE
LPD-96227 Keep widgets on the live site pointing at the live asset library

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -315,16 +315,11 @@ public class DLExportImportPortletPreferencesProcessorTest {
 
 		GroupTestUtil.enableLocalStaging(depotLiveGroup);
 
-		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
-
-		FileEntry stagingFileEntry = _dlAppLocalService.getFileEntry(
-			depotStagingGroup.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			liveFileEntry.getTitle());
+		Map<String, String> livePortletPreferencesValues =
+			_getPortletPreferencesValues(liveFileEntry);
 
 		_testExportImportFolderInAssetLibraryWithStagingInProcess(
-			_getPortletPreferencesValues(liveFileEntry),
-			_getPortletPreferencesValues(stagingFileEntry));
+			livePortletPreferencesValues, livePortletPreferencesValues);
 	}
 
 	@Test
@@ -374,15 +369,11 @@ public class DLExportImportPortletPreferencesProcessorTest {
 
 		GroupTestUtil.enableLocalStaging(depotLiveGroup);
 
-		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
-
-		Folder stagingFolder = _dlAppLocalService.getFolder(
-			depotStagingGroup.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, liveFolder.getName());
+		Map<String, String> livePortletPreferencesValues =
+			_getPortletPreferencesValues(liveFolder);
 
 		_testExportImportFolderInAssetLibraryWithStagingInProcess(
-			_getPortletPreferencesValues(liveFolder),
-			_getPortletPreferencesValues(stagingFolder));
+			livePortletPreferencesValues, livePortletPreferencesValues);
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
@@ -163,10 +163,11 @@ public class DLPortletInstanceSettingsHelper {
 		try {
 			ThemeDisplay themeDisplay = _dlRequestHelper.getThemeDisplay();
 
-			Group selectedGroup =
+			Group selectedGroup = _getSelectedGroup(
 				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
 					selectedGroupExternalReferenceCode,
-					themeDisplay.getCompanyId());
+					themeDisplay.getCompanyId()),
+				themeDisplay);
 
 			String selectedRepositoryExternalReferenceCode =
 				dlPortletInstanceSettings.
@@ -254,9 +255,22 @@ public class DLPortletInstanceSettingsHelper {
 			return themeDisplay.getScopeGroup();
 		}
 
-		return GroupLocalServiceUtil.getGroupByExternalReferenceCode(
-			dlPortletInstanceSettings.getSelectedGroupExternalReferenceCode(),
-			themeDisplay.getCompanyId());
+		return _getSelectedGroup(
+			GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+				dlPortletInstanceSettings.
+					getSelectedGroupExternalReferenceCode(),
+				themeDisplay.getCompanyId()),
+			themeDisplay);
+	}
+
+	private Group _getSelectedGroup(Group group, ThemeDisplay themeDisplay) {
+		Group scopeGroup = themeDisplay.getScopeGroup();
+
+		if (group.isStagingGroup() && !scopeGroup.isStagingGroup()) {
+			return group.getLiveGroup();
+		}
+
+		return group;
 	}
 
 	private void _populateDisplayViews() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -20,13 +20,11 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandler;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
-import com.liferay.exportimport.kernel.staging.StagingURLHelperUtil;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.base.BaseExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
-import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.lang.ThreadContextClassLoaderUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
@@ -38,23 +36,16 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.Repository;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.security.auth.HttpPrincipal;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
-import com.liferay.portal.service.http.GroupServiceHttp;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
 import jakarta.portlet.PortletPreferences;
@@ -75,7 +66,7 @@ import org.osgi.service.component.annotations.Reference;
 	service = ExportImportPortletPreferencesProcessor.class
 )
 public class DLExportImportPortletPreferencesProcessor
-	implements ExportImportPortletPreferencesProcessor {
+	extends BaseExportImportPortletPreferencesProcessor {
 
 	@Override
 	public List<Capability> getExportCapabilities() {
@@ -523,6 +514,29 @@ public class DLExportImportPortletPreferencesProcessor
 		return portletPreferences;
 	}
 
+	@Override
+	protected String getExportPortletPreferencesValue(
+			PortletDataContext portletDataContext, Portlet portlet,
+			String className, long primaryKeyLong)
+		throws Exception {
+
+		// Unused: this processor does not use the base primary key drivers.
+
+		return null;
+	}
+
+	@Override
+	protected Long getImportPortletPreferencesNewValue(
+			PortletDataContext portletDataContext, Class<?> clazz,
+			long companyGroupId, Map<Long, Long> primaryKeys,
+			String portletPreferencesOldValue)
+		throws Exception {
+
+		// Unused: this processor does not use the base primary key drivers.
+
+		return null;
+	}
+
 	private JSONObject _fetchStagingPreferencesMappingJSONObject(
 			PortletDataContext portletDataContext)
 		throws PortletDataException {
@@ -626,104 +640,6 @@ public class DLExportImportPortletPreferencesProcessor
 		return group.getExternalReferenceCode();
 	}
 
-	private String _getMirrorGroupExternalReferenceCode(
-		PortletDataContext portletDataContext,
-		String groupExternalReferenceCode) {
-
-		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
-			groupExternalReferenceCode, portletDataContext.getCompanyId());
-
-		if (group == null) {
-			return groupExternalReferenceCode;
-		}
-
-		Group stagingGroup = group.getStagingGroup();
-
-		if (stagingGroup != null) {
-			return stagingGroup.getExternalReferenceCode();
-		}
-
-		if (ExportImportThreadLocal.isStagingInProcess() &&
-			group.isStagedRemotely()) {
-
-			UnicodeProperties typeSettingsUnicodeProperties =
-				group.getTypeSettingsProperties();
-
-			String remoteGroupExternalReferenceCode =
-				typeSettingsUnicodeProperties.get(
-					"remoteGroupExternalReferenceCode");
-
-			if (Validator.isNull(remoteGroupExternalReferenceCode)) {
-				remoteGroupExternalReferenceCode =
-					_getRemoteGroupExternalReferenceCode(
-						typeSettingsUnicodeProperties);
-			}
-
-			if (Validator.isNotNull(remoteGroupExternalReferenceCode)) {
-				groupExternalReferenceCode = remoteGroupExternalReferenceCode;
-			}
-		}
-
-		Group liveGroup = _groupLocalService.fetchGroup(group.getLiveGroupId());
-
-		if (liveGroup == null) {
-			return groupExternalReferenceCode;
-		}
-
-		return liveGroup.getExternalReferenceCode();
-	}
-
-	private String _getRemoteGroupExternalReferenceCode(
-		UnicodeProperties typeSettingsUnicodeProperties) {
-
-		String remoteAddress = GetterUtil.getString(
-			typeSettingsUnicodeProperties.get("remoteAddress"));
-		long remoteGroupId = GetterUtil.getLong(
-			typeSettingsUnicodeProperties.get("remoteGroupId"));
-
-		if (Validator.isNull(remoteAddress) || (remoteGroupId <= 0)) {
-			return null;
-		}
-
-		int remotePort = GetterUtil.getInteger(
-			typeSettingsUnicodeProperties.get("remotePort"));
-		String remotePathContext = GetterUtil.getString(
-			typeSettingsUnicodeProperties.get("remotePathContext"));
-		boolean secureConnection = GetterUtil.getBoolean(
-			typeSettingsUnicodeProperties.get("secureConnection"));
-
-		String remoteURL = StagingURLHelperUtil.buildRemoteURL(
-			remoteAddress, remotePort, remotePathContext, secureConnection);
-
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		User user = permissionChecker.getUser();
-
-		try {
-			HttpPrincipal httpPrincipal = new HttpPrincipal(
-				remoteURL, user.getLogin(), user.getPassword(),
-				user.isPasswordEncrypted());
-
-			try (SafeCloseable safeCloseable =
-					ThreadContextClassLoaderUtil.swap(
-						PortalClassLoaderUtil.getClassLoader())) {
-
-				Group group = GroupServiceHttp.getGroup(
-					httpPrincipal, remoteGroupId);
-
-				return group.getExternalReferenceCode();
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
-
-		return null;
-	}
-
 	private String _getRepositoryExternalReferenceCode(Folder folder) {
 		Repository repository = _repositoryLocalService.fetchRepository(
 			folder.getRepositoryId());
@@ -751,7 +667,7 @@ public class DLExportImportPortletPreferencesProcessor
 					rootFolderExternalReferenceCode
 				).put(
 					_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE,
-					_getMirrorGroupExternalReferenceCode(
+					getGroupExportPortletPreferencesExternalReferenceCode(
 						portletDataContext, selectedGroupExternalReferenceCode)
 				).put(
 					_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,

--- a/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelperTest.java
+++ b/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelperTest.java
@@ -1,0 +1,322 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.display.context.helper;
+
+import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.document.library.web.internal.constants.DLWebKeys;
+import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Mikel Lorza
+ */
+public class DLPortletInstanceSettingsHelperTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSelectedRepositoryIdWhenScopeGroupIsNotStaging()
+		throws Exception {
+
+		Group liveGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			liveGroup.getGroupId()
+		).thenReturn(
+			_LIVE_GROUP_ID
+		);
+
+		Group stagingGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			stagingGroup.getLiveGroup()
+		).thenReturn(
+			liveGroup
+		);
+
+		Mockito.when(
+			stagingGroup.isStagingGroup()
+		).thenReturn(
+			true
+		);
+
+		Group scopeGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			scopeGroup.isStagingGroup()
+		).thenReturn(
+			false
+		);
+
+		try (MockedStatic<GroupLocalServiceUtil>
+				groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					GroupLocalServiceUtil.class);
+			MockedStatic<RepositoryLocalServiceUtil>
+				repositoryLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					RepositoryLocalServiceUtil.class)) {
+
+			Mockito.when(
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+					_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE, _COMPANY_ID)
+			).thenReturn(
+				stagingGroup
+			);
+
+			Repository repository = Mockito.mock(Repository.class);
+
+			Mockito.when(
+				repository.getRepositoryId()
+			).thenReturn(
+				_LIVE_REPOSITORY_ID
+			);
+
+			Mockito.when(
+				RepositoryLocalServiceUtil.getRepositoryByExternalReferenceCode(
+					_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+					_LIVE_GROUP_ID)
+			).thenReturn(
+				repository
+			);
+
+			DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+				_createDLPortletInstanceSettingsHelper(scopeGroup);
+
+			Assert.assertEquals(
+				_LIVE_REPOSITORY_ID,
+				dlPortletInstanceSettingsHelper.getSelectedRepositoryId());
+		}
+	}
+
+	@Test
+	public void testGetSelectedRepositoryIdWhenScopeGroupIsStaging()
+		throws Exception {
+
+		Group stagingGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			stagingGroup.getGroupId()
+		).thenReturn(
+			_STAGING_GROUP_ID
+		);
+
+		Mockito.when(
+			stagingGroup.isStagingGroup()
+		).thenReturn(
+			true
+		);
+
+		Group scopeGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			scopeGroup.isStagingGroup()
+		).thenReturn(
+			true
+		);
+
+		try (MockedStatic<GroupLocalServiceUtil>
+				groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					GroupLocalServiceUtil.class);
+			MockedStatic<RepositoryLocalServiceUtil>
+				repositoryLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					RepositoryLocalServiceUtil.class)) {
+
+			Mockito.when(
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+					_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE, _COMPANY_ID)
+			).thenReturn(
+				stagingGroup
+			);
+
+			Repository repository = Mockito.mock(Repository.class);
+
+			Mockito.when(
+				repository.getRepositoryId()
+			).thenReturn(
+				_STAGING_REPOSITORY_ID
+			);
+
+			Mockito.when(
+				RepositoryLocalServiceUtil.getRepositoryByExternalReferenceCode(
+					_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+					_STAGING_GROUP_ID)
+			).thenReturn(
+				repository
+			);
+
+			DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+				_createDLPortletInstanceSettingsHelper(scopeGroup);
+
+			Assert.assertEquals(
+				_STAGING_REPOSITORY_ID,
+				dlPortletInstanceSettingsHelper.getSelectedRepositoryId());
+		}
+	}
+
+	@Test
+	public void testGetSelectedRepositoryIdWhenSelectedGroupIsNotStaging()
+		throws Exception {
+
+		Group liveGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			liveGroup.getGroupId()
+		).thenReturn(
+			_LIVE_GROUP_ID
+		);
+
+		Mockito.when(
+			liveGroup.isStagingGroup()
+		).thenReturn(
+			false
+		);
+
+		Group scopeGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			scopeGroup.isStagingGroup()
+		).thenReturn(
+			false
+		);
+
+		try (MockedStatic<GroupLocalServiceUtil>
+				groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					GroupLocalServiceUtil.class);
+			MockedStatic<RepositoryLocalServiceUtil>
+				repositoryLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					RepositoryLocalServiceUtil.class)) {
+
+			Mockito.when(
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+					_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE, _COMPANY_ID)
+			).thenReturn(
+				liveGroup
+			);
+
+			Repository repository = Mockito.mock(Repository.class);
+
+			Mockito.when(
+				repository.getRepositoryId()
+			).thenReturn(
+				_LIVE_REPOSITORY_ID
+			);
+
+			Mockito.when(
+				RepositoryLocalServiceUtil.getRepositoryByExternalReferenceCode(
+					_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+					_LIVE_GROUP_ID)
+			).thenReturn(
+				repository
+			);
+
+			DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+				_createDLPortletInstanceSettingsHelper(scopeGroup);
+
+			Assert.assertEquals(
+				_LIVE_REPOSITORY_ID,
+				dlPortletInstanceSettingsHelper.getSelectedRepositoryId());
+		}
+	}
+
+	private DLPortletInstanceSettingsHelper
+		_createDLPortletInstanceSettingsHelper(Group scopeGroup) {
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getCompanyId()
+		).thenReturn(
+			_COMPANY_ID
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			scopeGroup
+		);
+
+		DLPortletInstanceSettings dlPortletInstanceSettings =
+			_mockDLPortletInstanceSettings();
+
+		Mockito.when(
+			dlPortletInstanceSettings.getSelectedGroupExternalReferenceCode()
+		).thenReturn(
+			_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.when(
+			dlPortletInstanceSettings.
+				getSelectedRepositoryExternalReferenceCode()
+		).thenReturn(
+			_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			DLWebKeys.DOCUMENT_LIBRARY_PORTLET_INSTANCE_SETTINGS,
+			dlPortletInstanceSettings);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return new DLPortletInstanceSettingsHelper(
+			new DLRequestHelper(mockHttpServletRequest));
+	}
+
+	private DLPortletInstanceSettings _mockDLPortletInstanceSettings() {
+		try (MockedStatic<DLUtil> dlUtilMockedStatic = Mockito.mockStatic(
+				DLUtil.class)) {
+
+			dlUtilMockedStatic.when(
+				DLUtil::getAllMediaGalleryMimeTypes
+			).thenReturn(
+				Collections.emptySet()
+			);
+
+			return Mockito.mock(DLPortletInstanceSettings.class);
+		}
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final long _LIVE_GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final long _LIVE_REPOSITORY_ID = RandomTestUtil.randomLong();
+
+	private static final String _SELECTED_GROUP_EXTERNAL_REFERENCE_CODE =
+		RandomTestUtil.randomString();
+
+	private static final String _SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE =
+		RandomTestUtil.randomString();
+
+	private static final long _STAGING_GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final long _STAGING_REPOSITORY_ID =
+		RandomTestUtil.randomLong();
+
+}


### PR DESCRIPTION
## What

Widgets backed by the Document Library display (Media Gallery, Documents and Media, ...) that point at an **asset library (depot) with staging** showed the **staging** content on the **live** site after a staging→live publish.

## Root cause

The widget stores the asset library reference in its portlet preferences by group external reference code. Because the item selector lists an asset library by its **live** group, the preference holds the depot's **live** ERC.

`DLExportImportPortletPreferencesProcessor` was the **only** portlet-preferences processor doing a **symmetric** live↔staging remapping of that ERC (its private `_getMirrorGroupExternalReferenceCode`): a live ERC was rewritten to its staging counterpart on publish, so the live layout ended up pointing at the depot **staging** group. Every other widget that stores a group ERC (Asset Publisher, Asset Categories Navigation, Category Facet) already uses the shared, asymmetric `BaseExportImportPortletPreferencesProcessor.getGroupExportPortletPreferencesExternalReferenceCode`, which only remaps staging→live and leaves a live ERC untouched. DL was the outlier — and since this one processor backs all DL display variants, fixing it here covers all of them (the reported Media Gallery is only one example).

## Fix (two layers)

1. **Export/import (source of truth):** `DLExportImportPortletPreferencesProcessor` now extends `BaseExportImportPortletPreferencesProcessor` and reuses the shared asymmetric helper, deleting its own symmetric flip (and the duplicated remote-group helper). New publishes preserve a live asset library reference.

2. **Render (defense for already-published data):** `DLPortletInstanceSettingsHelper` resolves the stored group to its live counterpart when rendering outside a staging scope, so pages **already published** with a flipped staging ERC are corrected on the next render.

## Why render-time and not a data upgrade

Layer 1 stops new bad data at the source; the only remaining concern is existing (already-published) data. We correct that at render rather than with a data upgrade because:

- **Migration risk on real customer databases.** In LPD-91035 a data upgrade was reverted precisely because the upgrade process failed on a real customer database. Render-time correction touches nothing at rest, so it cannot break a customer's upgrade.
- **Self-healing and immediate.** It applies on deploy, with no upgrade step, no downtime, and is fully reversible.
- **Consistency with the sibling ticket.** LPD-96103 (the pages/fragments variant of the same problem) also resolves to the live group at render time when not on staging, rather than migrating data.

All readers of these preferences live in `document-library-web`, so a render-time guard fully covers them.

## Tests

- `DLExportImportPortletPreferencesProcessorTest` (integration): the staging-in-process asset library cases now assert that a live reference is preserved; the staging→live cases are unchanged.
- `DLPortletInstanceSettingsHelperTest` (unit, new): asserts the render-time resolution — live group when the scope is not staging, staging group left untouched when it is.

## Verification

Manually reproduced and verified both layers on a running bundle (already-published widget auto-corrects on refresh; a freshly published widget stays on the live library). Automated tests green.

**pr-check: PASS** — tested on `a4c0071f02d80d30104d248baf6494c8b74772eb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a4c0071f02d80d30104d248baf6494c8b74772eb"} -->
