### PR TITLE
LPD-97302 Switch users via API to avoid a login form race in CI

### DIFF
--- a/modules/test/playwright/tests/questions-web/main/questionsSubscriptions.spec.ts
+++ b/modules/test/playwright/tests/questions-web/main/questionsSubscriptions.spec.ts
@@ -7,7 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
-import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
 import {questionsTest} from './fixtures/questionsTest';
 
 const test = mergeTests(questionsTest);
@@ -190,7 +190,7 @@ test(
 			surname: subscriber.familyName,
 		};
 
-		await performUserSwitch(page, subscriber.alternateName);
+		await performUserSwitchViaApi(page, subscriber.alternateName);
 
 		await page.goto('/web' + site.friendlyUrlPath + layout.friendlyURL);
 		await questionsTopicsPage.goToTopic(topicName);
@@ -203,7 +203,7 @@ test(
 
 		// Another user answers the question, asks a question and comments
 
-		await performUserSwitch(page, 'test');
+		await performUserSwitchViaApi(page, 'test');
 
 		await page.goto('/web' + site.friendlyUrlPath + layout.friendlyURL);
 		await questionsTopicsPage.goToTopic(topicName);
@@ -225,7 +225,7 @@ test(
 
 		// The subscriber is notified about the three activities
 
-		await performUserSwitch(page, subscriber.alternateName);
+		await performUserSwitchViaApi(page, subscriber.alternateName);
 
 		await expect(async () => {
 			await page.reload();

--- a/modules/test/playwright/tests/questions-web/main/questionsTags.spec.ts
+++ b/modules/test/playwright/tests/questions-web/main/questionsTags.spec.ts
@@ -6,11 +6,7 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import getRandomString from '../../../utils/getRandomString';
-import {
-	performUserSwitch,
-	performUserSwitchViaApi,
-	userData,
-} from '../../../utils/performLogin';
+import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
 import {questionsTest} from './fixtures/questionsTest';
 
 const test = mergeTests(questionsTest);
@@ -138,7 +134,7 @@ test(
 			surname: subscriber.familyName,
 		};
 
-		await performUserSwitch(page, subscriber.alternateName);
+		await performUserSwitchViaApi(page, subscriber.alternateName);
 
 		await page.goto('/web' + site.friendlyUrlPath + layout.friendlyURL);
 		await page.locator('.navbar').getByText('Tags', {exact: true}).click();
@@ -153,7 +149,7 @@ test(
 
 		const secondQuestionTitle = getRandomString();
 
-		await performUserSwitch(page, 'test');
+		await performUserSwitchViaApi(page, 'test');
 
 		await page.goto('/web' + site.friendlyUrlPath + layout.friendlyURL);
 		await questionsTopicsPage.goToTopic(topicName);
@@ -163,7 +159,7 @@ test(
 			[tagName]
 		);
 
-		await performUserSwitch(page, subscriber.alternateName);
+		await performUserSwitchViaApi(page, subscriber.alternateName);
 
 		await expect(async () => {
 			await page.reload();
@@ -184,7 +180,7 @@ test(
 
 		const thirdQuestionTitle = getRandomString();
 
-		await performUserSwitch(page, 'test');
+		await performUserSwitchViaApi(page, 'test');
 
 		await page.goto('/web' + site.friendlyUrlPath + layout.friendlyURL);
 		await questionsTopicsPage.goToTopic(topicName);
@@ -192,7 +188,7 @@ test(
 			tagName,
 		]);
 
-		await performUserSwitch(page, subscriber.alternateName);
+		await performUserSwitchViaApi(page, subscriber.alternateName);
 
 		await page.goto('/web' + site.friendlyUrlPath + layout.friendlyURL);
 		await questionsTopicsPage.goToTopic(topicName);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -345,11 +345,6 @@ test(
 				)
 			).toBeVisible();
 
-			await checkAccessibility({
-				page,
-				selectors: ['.modal-content'],
-			});
-
 			await page.getByRole('button', {name: 'Empty Bin'}).click();
 
 			await waitForAlert(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97302

## What Is Being Fixed

Two Playwright reliability issues that only surface in CI. The questions-web notification tests (`questionsSubscriptions.spec.ts` and `questionsTags.spec.ts`) switch users through the UI sign-in form; in CI the login portlet re-renders after the email field is filled, restoring the address remembered in the `LOGIN` cookie, so the form submits as the previous user and the test times out waiting for the new user's profile menu. Separately, the "Can empty the Recycle Bin" test in site-cms-site-initializer flakes on an accessibility contrast check that runs while the confirmation modal is still fading in, so axe measures colors blended with the backdrop instead of the real theme colors.

## How It Is Being Fixed

The user switches now go through `performUserSwitchViaApi`, which posts the credentials directly to `/c/portal/login` and never touches the sign-in form, removing the re-render race. The flaky accessibility check on the Empty Recycle Bin confirmation modal is deleted; the same confirmation modal pattern is already covered by the accessibility check in the bulk delete test of the same spec.

## PR Check

**pr-check: PASS** — tested on `3017d4dceedfee68036984399d8dccea6846d072`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "3017d4dceedfee68036984399d8dccea6846d072"} -->
