### PR TITLE
LPD-95538 Add versioning and content history E2E Playwright tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -78,6 +78,7 @@ import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
 import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
+import {config as e2eCmsDxpVersioningConfig} from './tests/e2e-cms-dxp/versioning/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
 import {config as expandoWebConfig} from './tests/expando-web/main/config';
 import {config as exportImportServiceConfig} from './tests/export-import-service/main/config';
@@ -323,6 +324,7 @@ export default defineConfig({
 		e2eCmsDxpContentPageConfig,
 		e2eCmsDxpSharingConfig,
 		e2eCmsDxpTranslationsConfig,
+		e2eCmsDxpVersioningConfig,
 		e2eCmsDxpWorkflowConfig,
 		expandoWebConfig,
 		exportImportServiceConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'versioning.main',
+	testDir: 'tests/e2e-cms-dxp/versioning/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/deleteStructuredContentVersion.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/deleteStructuredContentVersion.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {deleteVersion, openVersionHistory} from './utils/versioning';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({'LPD-17564': {enabled: true}}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+test(
+	'A CMS Administrator permanently deletes a specific Structured Content version',
+	{tag: ['@LPD-95538', '@LPD-95538/TC-15.d']},
+	async ({apiHelpers, page, structureBuilderPage}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const title = `Title ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const objectDefinitionId =
+			await test.step('Build a custom structure with a localizable Body field', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({
+					label: 'Body',
+					localizable: true,
+				});
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) =>
+				objectField.label && objectField.label.en_US === 'Body'
+		);
+
+		if (!bodyField) {
+			throw new Error('Body field not found in object definition');
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[bodyField.name]: `Body ${getRandomString()}`,
+				[objectDefinition.titleObjectFieldName]: title,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		await test.step('Edit the entry twice to generate versions 2 and 3', async () => {
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{
+					[`${bodyField.name}_i18n`]: {
+						en_US: `Body ${getRandomString()}`,
+					},
+				},
+				applicationName,
+				entry.id
+			);
+
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{
+					[`${bodyField.name}_i18n`]: {
+						en_US: `Body ${getRandomString()}`,
+					},
+				},
+				applicationName,
+				entry.id
+			);
+		});
+
+		const assetsPage = new AssetsPage(page);
+
+		await test.step('The version history lists all three versions', async () => {
+			await assetsPage.gotoContents();
+
+			await openVersionHistory(page, title);
+
+			await expect(page.locator('tbody tr')).toHaveCount(3, {
+				timeout: 10000,
+			});
+
+			for (const versionNumber of ['1', '2', '3']) {
+				await expect(
+					page.getByRole('cell', {exact: true, name: versionNumber})
+				).toHaveCount(1, {timeout: 5000});
+			}
+		});
+
+		await test.step('The CMS Administrator permanently deletes version 2', async () => {
+			await deleteVersion(page, '2');
+		});
+
+		await test.step('The deleted version no longer appears and cannot be restored', async () => {
+			await expect(page.locator('tbody tr')).toHaveCount(2, {
+				timeout: 10000,
+			});
+
+			await expect(
+				page.getByRole('cell', {exact: true, name: '2'})
+			).toHaveCount(0, {timeout: 5000});
+
+			await expect(
+				page.getByRole('cell', {exact: true, name: '1'})
+			).toHaveCount(1, {timeout: 5000});
+
+			await expect(
+				page.getByRole('cell', {exact: true, name: '3'})
+			).toHaveCount(1, {timeout: 5000});
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/restoreBasicWebContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/restoreBasicWebContent.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {openVersionHistory, restoreVersion} from './utils/versioning';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'A CMS Administrator restores a previous Basic Web Content version and it renders for GUEST',
+	{tag: ['@LPD-95538', '@LPD-95538/TC-15.a']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+
+		const titleV1 = `Title ${getRandomString()}`;
+		const bodyV1 = `Body ${getRandomString()}`;
+		const titleV3 = `Title ${getRandomString()}`;
+		const bodyV3 = `Body ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${bodyV1}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: titleV1,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><div><lfr-editable id="content" type="rich-text">Content</lfr-editable></div></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the entry into a page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {entity: ENTITY, entry: titleV1, field: 'Title'},
+				});
+
+				await pageEditorPage.selectEditable(fragmentId, 'content');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {entity: ENTITY, entry: titleV1, field: 'Content'},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('Edit the entry twice to generate versions 2 and 3', async () => {
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{
+					content_i18n: {en_US: `<p>Body ${getRandomString()}</p>`},
+					title_i18n: {en_US: `Title ${getRandomString()}`},
+				},
+				APPLICATION_NAME,
+				entry.id
+			);
+
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{
+					content_i18n: {en_US: `<p>${bodyV3}</p>`},
+					title_i18n: {en_US: titleV3},
+				},
+				APPLICATION_NAME,
+				entry.id
+			);
+		});
+
+		const guestContext = await browser.newContext({
+			storageState: {cookies: [], origins: []},
+		});
+
+		const guestPage = await guestContext.newPage();
+
+		try {
+			await test.step('GUEST sees the current version content', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(titleV3, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					await expect(
+						guestPage.getByText(bodyV3, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			const assetsPage = new AssetsPage(page);
+
+			await test.step('The version history lists all versions with timestamps', async () => {
+				await assetsPage.gotoContents();
+
+				await openVersionHistory(page, titleV3);
+
+				const rows = page.locator('tbody tr');
+
+				await expect(rows).toHaveCount(3, {timeout: 10000});
+
+				for (const versionNumber of ['1', '2', '3']) {
+					await expect(
+						page.getByRole('cell', {
+							exact: true,
+							name: versionNumber,
+						})
+					).toHaveCount(1, {timeout: 5000});
+				}
+
+				await expect(page.getByText(/, \d{4},/)).toHaveCount(3, {
+					timeout: 5000,
+				});
+			});
+
+			await test.step('The CMS Administrator restores version 1', async () => {
+				await restoreVersion(page, titleV1);
+			});
+
+			await test.step('GUEST sees the restored version 1 content', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(titleV1, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					await expect(
+						guestPage.getByText(bodyV1, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+
+				await expect(
+					guestPage.getByText(titleV3, {exact: true})
+				).toBeHidden({timeout: 2000});
+			});
+		}
+		finally {
+			await guestContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/restoreFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/restoreFile.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {isImageLoaded} from '../../../../utils/isImageLoaded';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {openVersionHistory, restoreVersion} from './utils/versioning';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const ENTITY = 'Basic Documents (CMS)';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A CMS Administrator restores a previous file metadata version and it is reflected in the CMS and on the DXP page',
+	{tag: ['@LPD-95538', '@LPD-95538/TC-15.c']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const titleV1 = `Image ${getRandomString()}`;
+		const titleV3 = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: titleV1,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><lfr-editable id="image" type="image"><img alt="" src=""/></lfr-editable></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the file Title and Preview URL into a page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {entity: ENTITY, entry: titleV1, field: 'Title'},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.selectEditable(fragmentId, 'image');
+
+			await page.getByLabel('Source Selection').selectOption('Mapping');
+
+			await pageEditorPage.setMappedItem({
+				entity: ENTITY,
+				entry: titleV1,
+				field: 'Preview URL',
+			});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('Update the file metadata twice to generate versions 2 and 3', async () => {
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{title_i18n: {en_US: `Image ${getRandomString()}`}},
+				APPLICATION_NAME,
+				entry.id
+			);
+
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{title_i18n: {en_US: titleV3}},
+				APPLICATION_NAME,
+				entry.id
+			);
+		});
+
+		const guestContext = await browser.newContext({
+			storageState: {cookies: [], origins: []},
+		});
+
+		const guestPage = await guestContext.newPage();
+
+		try {
+			await test.step('GUEST sees the current metadata title and the image', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(titleV3, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					expect(
+						await isImageLoaded(
+							guestPage.locator('img[src*="/documents/"]').first()
+						)
+					).toBe(true);
+				}).toPass({timeout: 30000});
+			});
+
+			const assetsPage = new AssetsPage(page);
+
+			await test.step('The CMS Administrator restores version 1 of the metadata', async () => {
+				await assetsPage.gotoFiles();
+
+				await assetsPage.changeVisualizationMode('Table');
+
+				await openVersionHistory(page, titleV3);
+
+				await restoreVersion(page, titleV1);
+			});
+
+			await test.step('The CMS detail view reflects the restored title', async () => {
+				await expect(async () => {
+					await assetsPage.gotoFiles();
+
+					await assetsPage.changeVisualizationMode('Table');
+
+					await expect(
+						page.getByText(titleV1, {exact: true}).first()
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			await test.step('The DXP page shows the restored title and the image still renders', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(titleV1, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					expect(
+						await isImageLoaded(
+							guestPage.locator('img[src*="/documents/"]').first()
+						)
+					).toBe(true);
+				}).toPass({timeout: 30000});
+			});
+		}
+		finally {
+			await guestContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/restoreStructuredContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/restoreStructuredContent.spec.ts
@@ -1,0 +1,247 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi, userData} from '../../../../utils/performLogin';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {openVersionHistory, restoreVersionByNumber} from './utils/versioning';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	structureBuilderPagesTest
+);
+
+test(
+	'A CMS Administrator restores a previous Structured Content version and its localizable field renders for USER',
+	{tag: ['@LPD-95538', '@LPD-95538/TC-15.b']},
+	async ({
+		apiHelpers,
+		browser,
+		page,
+		pageEditorPage,
+		site,
+		structureBuilderPage,
+	}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const titleValue = `Title ${getRandomString()}`;
+		const bodyV1 = `Body ${getRandomString()}`;
+		const bodyV3 = `Body ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a structure with a localizable Body field', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({
+					label: 'Body',
+					localizable: true,
+				});
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const entityLabel = `${objectDefinition.pluralLabel.en_US} (CMS)`;
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) =>
+				objectField.label && objectField.label.en_US === 'Body'
+		);
+
+		if (!bodyField) {
+			throw new Error('Body field not found in object definition');
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[bodyField.name]: bodyV1,
+				[objectDefinition.titleObjectFieldName]: titleValue,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			entry.id,
+			[
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><p><lfr-editable id="body" type="text">Body</lfr-editable></p></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the Title and localizable Body into the page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: entityLabel,
+						entry: titleValue,
+						field: 'Title',
+					},
+				});
+
+				await pageEditorPage.selectEditable(fragmentId, 'body');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: entityLabel,
+						entry: titleValue,
+						field: 'Body',
+					},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('Edit the entry twice to generate versions 2 and 3', async () => {
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{
+					[`${bodyField.name}_i18n`]: {
+						en_US: `Body ${getRandomString()}`,
+					},
+				},
+				applicationName,
+				entry.id
+			);
+
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{[`${bodyField.name}_i18n`]: {en_US: bodyV3}},
+				applicationName,
+				entry.id
+			);
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+		await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+		await apiHelpers.jsonWebServicesUser.addGroupUsers(String(site.id), [
+			user.id,
+		]);
+
+		const userContext = await browser.newContext();
+
+		const userPage = await userContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: userPage,
+				screenName: user.alternateName,
+			});
+
+			await test.step('USER sees the current localizable Body value', async () => {
+				await expect(async () => {
+					await userPage.goto(viewUrl);
+
+					await expect(
+						userPage.getByText(titleValue, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					await expect(
+						userPage.getByText(bodyV3, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			const assetsPage = new AssetsPage(page);
+
+			await test.step('The CMS Administrator restores version 1', async () => {
+				await assetsPage.gotoContents();
+
+				await openVersionHistory(page, titleValue);
+
+				await expect(page.locator('tbody tr')).toHaveCount(3, {
+					timeout: 10000,
+				});
+
+				await restoreVersionByNumber(page, '1');
+			});
+
+			await test.step('USER sees the restored version 1 localizable Body value', async () => {
+				await expect(async () => {
+					await userPage.goto(viewUrl);
+
+					await expect(
+						userPage.getByText(bodyV1, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+
+				await expect(
+					userPage.getByText(bodyV3, {exact: true})
+				).toBeHidden({timeout: 2000});
+			});
+		}
+		finally {
+			await userContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/utils/versioning.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/versioning/main/utils/versioning.ts
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect} from '@playwright/test';
+
+async function clickRowAction(page: Page, rowText: string, action: string) {
+	const actionsButton = page
+		.locator('tbody tr', {hasText: rowText})
+		.first()
+		.getByRole('button', {name: `${rowText} Actions`});
+
+	const menuItem = page.getByRole('menuitem', {exact: true, name: action});
+
+	await expect(async () => {
+		if (!(await menuItem.isVisible())) {
+			await actionsButton.click({timeout: 5000});
+
+			await expect(menuItem).toBeVisible({timeout: 5000});
+		}
+	}).toPass({timeout: 30000});
+
+	await menuItem.click();
+}
+
+async function clickVersionRowAction(
+	page: Page,
+	versionNumber: string,
+	action: string
+) {
+	const row = page.locator('tbody tr', {
+		has: page.getByRole('cell', {exact: true, name: versionNumber}),
+	});
+
+	const actionsButton = row.getByRole('button', {name: /Actions$/});
+
+	const menuItem = page.getByRole('menuitem', {exact: true, name: action});
+
+	await expect(async () => {
+		if (!(await menuItem.isVisible())) {
+			await actionsButton.click({timeout: 5000});
+
+			await expect(menuItem).toBeVisible({timeout: 5000});
+		}
+	}).toPass({timeout: 30000});
+
+	await menuItem.click();
+}
+
+export async function deleteVersion(page: Page, versionNumber: string) {
+	const rows = page.locator('tbody tr');
+
+	const rowCount = await rows.count();
+
+	await clickVersionRowAction(page, versionNumber, 'Delete');
+
+	const modal = page.locator('.modal.show');
+
+	await expect(modal).toBeVisible({timeout: 10000});
+
+	await modal.getByRole('button', {exact: true, name: 'Delete'}).click();
+
+	await expect(rows).toHaveCount(rowCount - 1, {timeout: 15000});
+}
+
+export async function restoreVersionByNumber(
+	page: Page,
+	versionNumber: string
+) {
+	const rows = page.locator('tbody tr');
+
+	const rowCount = await rows.count();
+
+	await clickVersionRowAction(page, versionNumber, 'Restore Version');
+
+	await expect(rows).toHaveCount(rowCount + 1, {timeout: 15000});
+}
+
+export async function openVersionHistory(page: Page, headTitle: string) {
+	await clickRowAction(page, headTitle, 'View History');
+
+	await expect(
+		page.getByRole('heading', {name: `"${headTitle}" History`})
+	).toBeVisible({timeout: 15000});
+}
+
+export async function restoreVersion(page: Page, versionTitle: string) {
+	const rows = page.locator('tbody tr');
+
+	const rowCount = await rows.count();
+
+	await clickRowAction(page, versionTitle, 'Restore Version');
+
+	await expect(rows).toHaveCount(rowCount + 1, {timeout: 15000});
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95538

## What Is Being Fixed

The CMS "Versioning & Content History" use cases (LPD-95538, TC-15) had no automated coverage. Nothing verified end to end that a previous content version can be restored and rendered on a DXP page, that restored file metadata is reflected in the CMS detail view and on the page where the file is displayed, or that a specific version can be permanently deleted from the history.

## How It Is Being Fixed

Adds a new `versioning.main` Playwright project with four end-to-end specs. Each spec generates multiple versions of a CMS entry through the headless API, then drives the Version History page and its per-version Restore and Delete actions as a CMS Administrator, matching the role-based restore permission model.

TC-15.a restores a Basic Web Content version and verifies it renders for an anonymous visitor. TC-15.b restores a Structured Content version and verifies its localizable field renders for a signed-in user. TC-15.c restores file metadata and verifies it in the CMS detail view and on the mapped page. TC-15.d permanently deletes a specific version and verifies it no longer appears in the history and cannot be restored. Rendering uses a non-cacheable mapping fragment so a restore surfaces without re-publishing the page.

## PR Check

**pr-check: PASS** — tested on `89792f90e4a7365d214eac4b91ccc0a7340070a9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "89792f90e4a7365d214eac4b91ccc0a7340070a9"} -->
