### PR TITLE
LPD-97367 Handle the catalog type in the asset library REST test

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -474,7 +474,10 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 		int depotEntryType = DepotConstants.TYPE_ASSET_LIBRARY;
 
-		if (assetLibrary.getType() == AssetLibrary.Type.DESIGN_LIBRARY) {
+		if (assetLibrary.getType() == AssetLibrary.Type.CATALOG) {
+			depotEntryType = DepotConstants.TYPE_CATALOG;
+		}
+		else if (assetLibrary.getType() == AssetLibrary.Type.DESIGN_LIBRARY) {
 			depotEntryType = DepotConstants.TYPE_DESIGN_LIBRARY;
 		}
 		else if (assetLibrary.getType() == AssetLibrary.Type.PROJECT) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97367

## Failing Test

`com.liferay.headless.asset.library.resource.v1_0.test.AssetLibraryResourceTest`

`modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java`

```
2 Failed tests     testPatchAssetLibrary      testPostAssetLibrary
```

## Root Cause

Commit `4bf2fab9ab595` ("LPD-96681 New depot type") added a fifth value, `CATALOG`, to the `AssetLibrary.Type` enum without updating this test. `_randomAssetLibrary` assigns a type with `RandomTestUtil.randomEnum`, so about one in five generated libraries is now a `Catalog`, and `_assertGroupDepotEntryType` had no branch for it.

## Fix

The assertion helper expected the default `TYPE_ASSET_LIBRARY` (`0`) for any unrecognized type, while a real catalog group stores `TYPE_CATALOG` (`4`), so every `Catalog` library tripped the assertion and made `testPostAssetLibrary` and `testPatchAssetLibrary` fail intermittently (~90% of builds, occasionally green). Adding the `CATALOG` branch makes the expected value match the persisted one.

- `modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java`

## Why Are There No Tests?

This change fixes an existing integration test; the modification is the test coverage itself, so no additional test is added.

## PR Check

**pr-check: PASS** — tested on `b9463c7f9b95a4ad5daf85b73b3f040f7c741ca2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b9463c7f9b95a4ad5daf85b73b3f040f7c741ca2"} -->
