### PR TITLE
LPD-95539 Add Recycle Bin E2E Playwright tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -76,6 +76,7 @@ import {config as documentLibraryWebConfig} from './tests/document-library-web/m
 import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-mapping-form-web/main/config';
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
+import {config as e2eCmsDxpRecycleBinConfig} from './tests/e2e-cms-dxp/recycle-bin/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
 import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
@@ -321,6 +322,7 @@ export default defineConfig({
 		dynamicDataMappingFormWebConfig,
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
+		e2eCmsDxpRecycleBinConfig,
 		e2eCmsDxpSharingConfig,
 		e2eCmsDxpTranslationsConfig,
 		e2eCmsDxpWorkflowConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'recycle-bin.main',
+	testDir: 'tests/e2e-cms-dxp/recycle-bin/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/permanentDelete.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/permanentDelete.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {applyRecycleBinFilter} from './utils/recycleBin';
+
+const test = mergeTests(dataApiHelpersTest, loginTest());
+
+const CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const FILE_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A CMS Administrator permanently deletes selected items and they can no longer be restored',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.d']},
+	async ({apiHelpers, page}) => {
+		test.setTimeout(180000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle1 = `Content ${getRandomString()}`;
+		const contentTitle2 = `Content ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		for (const title of [contentTitle1, contentTitle2]) {
+			const entry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					content: `<p>${getRandomString()}</p>`,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title,
+				},
+				CONTENT_APPLICATION_NAME,
+				spaceName
+			);
+
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				CONTENT_APPLICATION_NAME,
+				String(entry.id)
+			);
+		}
+
+		const recycleBinPage = new RecycleBinPage(page);
+
+		await test.step('Select the trashed items and permanently delete them', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.locator('tbody tr', {hasText: contentTitle1})
+			).toBeVisible({timeout: 10000});
+
+			await recycleBinPage.selectItems([contentTitle1, contentTitle2]);
+
+			await recycleBinPage.tableActions.click();
+
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Delete'})
+				.click();
+
+			await expect(
+				page.getByText('You are about to permanently delete 2 items.')
+			).toBeVisible({timeout: 10000});
+
+			await recycleBinPage.modalDeleteEntriesButton.click();
+
+			await expect(
+				page.locator('.alert', {hasText: 'successfully deleted'})
+			).toBeVisible({timeout: 15000});
+		});
+
+		await test.step('The items are no longer listed and cannot be restored', async () => {
+			await expect(async () => {
+				await recycleBinPage.goto();
+
+				await expect(
+					page.locator('tbody tr', {hasText: contentTitle1})
+				).toHaveCount(0, {timeout: 2000});
+
+				await expect(
+					page.locator('tbody tr', {hasText: contentTitle2})
+				).toHaveCount(0, {timeout: 2000});
+			}).toPass({timeout: 30000});
+		});
+	}
+);
+
+test(
+	'The Recycle Bin can be filtered by content type',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.d', '@LPD-97359']},
+	async ({apiHelpers, page}) => {
+		test.setTimeout(180000);
+
+		test.fail(
+			true,
+			'LPD-97359: the Recycle Bin type filter returns no results for trashed content, so filtering by "Basic Web Content" hides items that are of that type.'
+		);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			CONTENT_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.deleteObjectEntry(
+			CONTENT_APPLICATION_NAME,
+			String(contentEntry.id)
+		);
+
+		const fileEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			FILE_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.deleteObjectEntry(
+			FILE_APPLICATION_NAME,
+			String(fileEntry.id)
+		);
+
+		const recycleBinPage = new RecycleBinPage(page);
+
+		await recycleBinPage.goto();
+
+		await applyRecycleBinFilter(page, 'Type', 'Basic Web Content');
+
+		await expect(
+			page.locator('tbody tr', {hasText: contentTitle})
+		).toBeVisible({timeout: 10000});
+
+		await expect(page.locator('tbody tr', {hasText: fileTitle})).toBeHidden(
+			{timeout: 5000}
+		);
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/recycleBinAccess.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/recycleBinAccess.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {
+	addSpaceUserWithSession,
+	expectRestoreUnavailable,
+} from './utils/recycleBin';
+
+const test = mergeTests(dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+async function createTrashedContent(
+	apiHelpers: DataApiHelpers,
+	spaceName: string
+) {
+	const title = `Content ${getRandomString()}`;
+
+	const entry = await apiHelpers.objectEntry.postObjectEntry(
+		{
+			content: `<p>${getRandomString()}</p>`,
+			objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			title,
+		},
+		APPLICATION_NAME,
+		spaceName
+	);
+
+	await apiHelpers.objectEntry.deleteObjectEntry(
+		APPLICATION_NAME,
+		String(entry.id)
+	);
+
+	return title;
+}
+
+test(
+	'A CMS Administrator sees Recycle Bin items from all Spaces',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.e']},
+	async ({apiHelpers, page}) => {
+		test.setTimeout(120000);
+
+		const spaceName1 = `Space ${getRandomString()}`;
+		const spaceName2 = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName1,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName2,
+			type: 'Space',
+		});
+
+		const title1 = await createTrashedContent(apiHelpers, spaceName1);
+		const title2 = await createTrashedContent(apiHelpers, spaceName2);
+
+		const recycleBinPage = new RecycleBinPage(page);
+
+		await recycleBinPage.goto();
+
+		await expect(async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.locator('tbody tr', {hasText: title1})
+			).toBeVisible({timeout: 2000});
+
+			await expect(
+				page.locator('tbody tr', {hasText: title2})
+			).toBeVisible({timeout: 2000});
+		}).toPass({timeout: 30000});
+	}
+);
+
+test(
+	'A Space Administrator sees only their own Space in the Recycle Bin',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.e']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(120000);
+
+		const spaceName1 = `Space ${getRandomString()}`;
+		const spaceName2 = `Space ${getRandomString()}`;
+
+		const space1 = await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+			{
+				name: spaceName1,
+				type: 'Space',
+			}
+		);
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName2,
+			type: 'Space',
+		});
+
+		const title1 = await createTrashedContent(apiHelpers, spaceName1);
+		const title2 = await createTrashedContent(apiHelpers, spaceName2);
+
+		const spaceAdministrator = await addSpaceUserWithSession(
+			apiHelpers,
+			space1.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		const spaContext = await browser.newContext();
+
+		const spaPage = await spaContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: spaPage,
+				screenName: spaceAdministrator.alternateName,
+			});
+
+			const recycleBinPage = new RecycleBinPage(spaPage);
+
+			await recycleBinPage.goto();
+
+			await expect(
+				spaPage.locator('tbody tr', {hasText: title1})
+			).toBeVisible({timeout: 10000});
+
+			await expect(
+				spaPage.locator('tbody tr', {hasText: title2})
+			).toBeHidden({timeout: 5000});
+		}
+		finally {
+			await spaContext.close();
+		}
+	}
+);
+
+test(
+	'A Space Member cannot restore items from the Recycle Bin',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.e', '@LPD-95539/TC-16.a']},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(120000);
+
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const title = await createTrashedContent(apiHelpers, spaceName);
+
+		const spaceMember = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Member'
+		);
+
+		const memberContext = await browser.newContext();
+
+		const memberPage = await memberContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: memberPage,
+				screenName: spaceMember.alternateName,
+			});
+
+			const recycleBinPage = new RecycleBinPage(memberPage);
+
+			await recycleBinPage.goto();
+
+			await expect(
+				memberPage.locator('tbody tr', {hasText: title})
+			).toBeVisible({timeout: 10000});
+
+			await expectRestoreUnavailable(memberPage, title);
+		}
+		finally {
+			await memberContext.close();
+		}
+	}
+);
+
+test(
+	'A Space Content Reviewer cannot restore items from the Recycle Bin',
+	{
+		tag: [
+			'@LPD-95539',
+			'@LPD-95539/TC-16.f',
+			'@LPD-95539/TC-16.a',
+			'@LPD-96455',
+		],
+	},
+	async ({apiHelpers, browser}) => {
+		test.setTimeout(120000);
+
+		test.fail(
+			true,
+			"LPD-96455 (Won't Fix): the product allows a Space Content Reviewer to restore from the Recycle Bin, so the restore action is available."
+		);
+
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const title = await createTrashedContent(apiHelpers, spaceName);
+
+		const contentReviewer = await addSpaceUserWithSession(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Content Reviewer'
+		);
+
+		const reviewerContext = await browser.newContext();
+
+		const reviewerPage = await reviewerContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: reviewerPage,
+				screenName: contentReviewer.alternateName,
+			});
+
+			const recycleBinPage = new RecycleBinPage(reviewerPage);
+
+			await recycleBinPage.goto();
+
+			await expect(
+				reviewerPage.locator('tbody tr', {hasText: title})
+			).toBeVisible({timeout: 10000});
+
+			await expectRestoreUnavailable(reviewerPage, title);
+		}
+		finally {
+			await reviewerContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/restoreContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/restoreContent.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {deleteEntryToRecycleBin, restoreEntry} from './utils/recycleBin';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'A CMS Administrator restores a deleted Basic Web Content from the Recycle Bin and it renders again for GUEST',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.a']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const title = `Title ${getRandomString()}`;
+		const body = `Body ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${body}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><div><lfr-editable id="content" type="rich-text">Content</lfr-editable></div></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the entry into a page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {entity: ENTITY, entry: title, field: 'Title'},
+				});
+
+				await pageEditorPage.selectEditable(fragmentId, 'content');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {entity: ENTITY, entry: title, field: 'Content'},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		const guestContext = await browser.newContext({
+			storageState: {cookies: [], origins: []},
+		});
+
+		const guestPage = await guestContext.newPage();
+
+		try {
+			await test.step('GUEST sees the published content', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(body, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			const contentsPage = new ContentsPage(page);
+			const recycleBinPage = new RecycleBinPage(page);
+
+			await test.step('The CMS Administrator deletes the content into the Recycle Bin', async () => {
+				await contentsPage.goto();
+
+				await deleteEntryToRecycleBin(page, title);
+			});
+
+			await test.step('GUEST no longer sees the deleted content', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(body, {exact: true})
+					).toBeHidden({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			await test.step('The CMS Administrator restores the content from the Recycle Bin', async () => {
+				await recycleBinPage.goto();
+
+				await restoreEntry(page, title);
+			});
+
+			await test.step('The content reappears in the Space', async () => {
+				await expect(async () => {
+					await contentsPage.goto();
+
+					await expect(
+						page.getByRole('row', {name: title})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			await test.step('GUEST sees the restored content again on the DXP page', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(body, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+		}
+		finally {
+			await guestContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/restoreFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/restoreFile.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {isImageLoaded} from '../../../../utils/isImageLoaded';
+import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPage';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {deleteEntryToRecycleBin, restoreEntry} from './utils/recycleBin';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const ENTITY = 'Basic Documents (CMS)';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A CMS Administrator restores a deleted file from the Recycle Bin and it renders again for GUEST',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.c']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const title = `Image ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><lfr-editable id="image" type="image"><img alt="" src=""/></lfr-editable></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the file Title and Preview URL into a page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {entity: ENTITY, entry: title, field: 'Title'},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.selectEditable(fragmentId, 'image');
+
+			await page.getByLabel('Source Selection').selectOption('Mapping');
+
+			await pageEditorPage.setMappedItem({
+				entity: ENTITY,
+				entry: title,
+				field: 'Preview URL',
+			});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		const guestContext = await browser.newContext({
+			storageState: {cookies: [], origins: []},
+		});
+
+		const guestPage = await guestContext.newPage();
+
+		try {
+			await test.step('GUEST sees the published file image', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					expect(
+						await isImageLoaded(
+							guestPage.locator('img[src*="/documents/"]').first()
+						)
+					).toBe(true);
+				}).toPass({timeout: 30000});
+			});
+
+			const assetsPage = new AssetsPage(page);
+			const recycleBinPage = new RecycleBinPage(page);
+
+			await test.step('The CMS Administrator deletes the file into the Recycle Bin', async () => {
+				await assetsPage.gotoFiles();
+
+				await assetsPage.changeVisualizationMode('Table');
+
+				await deleteEntryToRecycleBin(page, title);
+			});
+
+			await test.step('The CMS Administrator restores the file from the Recycle Bin', async () => {
+				await recycleBinPage.goto();
+
+				await restoreEntry(page, title);
+			});
+
+			await test.step('GUEST sees the restored file image again on the DXP page', async () => {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					expect(
+						await isImageLoaded(
+							guestPage.locator('img[src*="/documents/"]').first()
+						)
+					).toBe(true);
+				}).toPass({timeout: 30000});
+			});
+		}
+		finally {
+			await guestContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/restoreStructuredContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/restoreStructuredContent.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi, userData} from '../../../../utils/performLogin';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {RecycleBinPage} from '../../../site-cms-site-initializer/main/pages/RecycleBinPage';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {deleteEntryToRecycleBin, restoreEntry} from './utils/recycleBin';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	structureBuilderPagesTest
+);
+
+test(
+	'A CMS Administrator restores a deleted Structured Content from the Recycle Bin and it renders again for USER',
+	{tag: ['@LPD-95539', '@LPD-95539/TC-16.b']},
+	async ({
+		apiHelpers,
+		browser,
+		page,
+		pageEditorPage,
+		site,
+		structureBuilderPage,
+	}) => {
+		test.setTimeout(360000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const titleValue = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a custom structure with a Body field', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({
+					label: 'Body',
+				});
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const entityLabel = `${objectDefinition.pluralLabel.en_US} (CMS)`;
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) =>
+				objectField.label && objectField.label.en_US === 'Body'
+		);
+
+		if (!bodyField) {
+			throw new Error('Body field not found in object definition');
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[bodyField.name]: bodyValue,
+				[objectDefinition.titleObjectFieldName]: titleValue,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			entry.id,
+			[
+				{actionIds: ['VIEW'], roleName: 'Guest'},
+				{actionIds: ['VIEW'], roleName: 'User'},
+			]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><p><lfr-editable id="body" type="text">Body</lfr-editable></p></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the Title and Body into the page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: entityLabel,
+						entry: titleValue,
+						field: 'Title',
+					},
+				});
+
+				await pageEditorPage.selectEditable(fragmentId, 'body');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: entityLabel,
+						entry: titleValue,
+						field: 'Body',
+					},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+		await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+		await apiHelpers.jsonWebServicesUser.addGroupUsers(String(site.id), [
+			user.id,
+		]);
+
+		const userContext = await browser.newContext();
+
+		const userPage = await userContext.newPage();
+
+		try {
+			await performLoginViaApi({
+				page: userPage,
+				screenName: user.alternateName,
+			});
+
+			await test.step('USER sees the published content', async () => {
+				await expect(async () => {
+					await userPage.goto(viewUrl);
+
+					await expect(
+						userPage.getByText(bodyValue, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+
+			const contentsPage = new ContentsPage(page);
+			const recycleBinPage = new RecycleBinPage(page);
+
+			await test.step('The CMS Administrator deletes the content into the Recycle Bin', async () => {
+				await contentsPage.goto();
+
+				await deleteEntryToRecycleBin(page, titleValue);
+			});
+
+			await test.step('The CMS Administrator restores the content from the Recycle Bin', async () => {
+				await recycleBinPage.goto();
+
+				await restoreEntry(page, titleValue);
+			});
+
+			await test.step('USER sees the restored content again on the DXP page', async () => {
+				await expect(async () => {
+					await userPage.goto(viewUrl);
+
+					await expect(
+						userPage.getByText(bodyValue, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			});
+		}
+		finally {
+			await userContext.close();
+		}
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/utils/recycleBin.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/recycle-bin/main/utils/recycleBin.ts
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect} from '@playwright/test';
+
+import {DataApiHelpers} from '../../../../../helpers/ApiHelpers';
+import {addSpaceUser} from '../../../../../utils/addSpaceUser';
+
+export async function addSpaceUserWithSession(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string,
+	roleName: string
+): Promise<TUserAccount> {
+	const user = await addSpaceUser(
+		apiHelpers,
+		spaceExternalReferenceCode,
+		roleName
+	);
+
+	await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+	await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+	return user;
+}
+
+function rowActionsButton(page: Page, rowText: string) {
+	return page
+		.locator('tbody tr', {hasText: rowText})
+		.first()
+		.getByRole('button', {name: `${rowText} Actions`});
+}
+
+async function clickRowAction(page: Page, rowText: string, action: string) {
+	const menuItem = page.getByRole('menuitem', {exact: true, name: action});
+
+	await expect(async () => {
+		if (!(await menuItem.isVisible())) {
+			await rowActionsButton(page, rowText).click({timeout: 5000});
+
+			await expect(menuItem).toBeVisible({timeout: 5000});
+		}
+	}).toPass({timeout: 30000});
+
+	await menuItem.click();
+}
+
+export async function applyRecycleBinFilter(
+	page: Page,
+	category: string,
+	optionLabel: string
+) {
+	await page.locator('button.filters-dropdown-button').click();
+
+	const menu = page.locator('.dropdown-menu.show');
+
+	await menu.getByRole('menuitem', {exact: true, name: category}).click();
+
+	await menu.getByText(optionLabel, {exact: true}).click();
+
+	await menu.getByRole('button', {name: /Show Results|Add Filter/}).click();
+}
+
+export async function deleteEntryToRecycleBin(page: Page, title: string) {
+	await clickRowAction(page, title, 'Delete');
+
+	const modalDeleteButton = page
+		.locator('.modal.show')
+		.getByRole('button', {name: 'Delete Entry'});
+
+	await expect(modalDeleteButton).toBeVisible({timeout: 10000});
+
+	await modalDeleteButton.click();
+
+	await expect(page.locator('.alert', {hasText: 'was moved'})).toBeVisible({
+		timeout: 15000,
+	});
+}
+
+export async function restoreEntry(page: Page, title: string) {
+	await clickRowAction(page, title, 'Restore');
+
+	await expect(page.locator('.alert', {hasText: 'was restored'})).toBeVisible(
+		{timeout: 15000}
+	);
+}
+
+export async function expectRestoreUnavailable(page: Page, title: string) {
+	const actionsButton = rowActionsButton(page, title);
+
+	if (!(await actionsButton.isVisible().catch(() => false))) {
+		return;
+	}
+
+	await actionsButton.click({timeout: 5000});
+
+	await expect(page.locator('.dropdown-menu.show')).toBeVisible({
+		timeout: 5000,
+	});
+
+	await expect(
+		page.getByRole('menuitem', {exact: true, name: 'Restore'})
+	).toBeHidden({timeout: 5000});
+
+	await page.keyboard.press('Escape');
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95539

## What Is Being Fixed

The CMS "Recycle Bin" use cases (LPD-95539, TC-16) had no end-to-end coverage. Nothing verified that a deleted Basic Web Content, Structured Content, or file entry can be restored from the Recycle Bin and rendered again on a DXP page, that selected items can be permanently deleted so they can no longer be restored, or that the Recycle Bin honors the role-based scope across Spaces.

## How It Is Being Fixed

Adds a new `recycle-bin.main` Playwright project. Content and files are created through the headless API, deleted into the Recycle Bin (mapped content triggers the "in use" confirmation, which the helper handles), then restored or permanently deleted through the Recycle Bin UI. Rendering uses a non-cacheable mapping fragment so a restore surfaces without re-publishing.

TC-16.a/b/c restore a deleted entry and confirm it renders again for GUEST (a, c) or USER (b). TC-16.d selects trashed items and permanently deletes them, then confirms they no longer appear and cannot be restored. TC-16.e covers the role scope: a CMS Administrator sees every Space's items, a Space Administrator sees only their own, and a Space Member sees items but has no restore action.

Two checks are kept faithful to the ticket and marked as expected failures so they flip to real failures if the behavior changes: the Space Content Reviewer restore check tracks LPD-96455 (the product allows it, resolved Won't Fix), and the type-filter check tracks LPD-97359, a newly filed bug where the Recycle Bin type filter returns no results for trashed content.

## PR Check

**pr-check: PASS** — tested on `2a78ffb3d570aa5c14f9baf84e2d5cebcaa9ff17`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "2a78ffb3d570aa5c14f9baf84e2d5cebcaa9ff17"} -->
