### PR TITLE
LPD-97406 Recognize CMS Administrators when the thread has no principal

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -265,9 +265,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			else if (actionId.equals(ActionKeys.VIEW) && group.isSite()) {
 				try {
 					return PermissionUtil.hasCMSAdministratorRole(
-						group.getCompanyId()) ||
+						group.getCompanyId(), getUserId()) ||
 						   PermissionUtil.isDepotGroupAdminOrOwner(
-							   group.getCompanyId());
+							   group.getCompanyId(), getUserId());
 				}
 				catch (PortalException portalException) {
 					_log.error(portalException);
@@ -284,7 +284,7 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 				try {
 					if (PermissionUtil.hasCMSAdministratorRole(
-							getCompanyId())) {
+							getCompanyId(), getUserId())) {
 
 						return true;
 					}
@@ -352,7 +352,8 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return false;
 		}
 
-		return PermissionUtil.hasCMSAdministratorRole(group.getCompanyId());
+		return PermissionUtil.hasCMSAdministratorRole(
+			group.getCompanyId(), getUserId());
 	}
 
 	private boolean _isContentReviewer(Group group) throws PortalException {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
@@ -10,6 +10,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeServiceWrapper;
 import com.liferay.portal.kernel.service.ServiceWrapper;
@@ -33,8 +35,13 @@ public class DepotLayoutSetPrototypeServiceWrapper
 		OrderByComparator<LayoutSetPrototype> orderByComparator) {
 
 		try {
-			if (PermissionUtil.hasCMSAdministratorRole(companyId) ||
-				PermissionUtil.isDepotGroupAdminOrOwner(companyId)) {
+			PermissionChecker permissionChecker =
+				PermissionThreadLocal.getPermissionChecker();
+
+			long userId = permissionChecker.getUserId();
+
+			if (PermissionUtil.hasCMSAdministratorRole(companyId, userId) ||
+				PermissionUtil.isDepotGroupAdminOrOwner(companyId, userId)) {
 
 				return _layoutSetPrototypeLocalService.search(
 					companyId, active, start, end, orderByComparator);
@@ -54,8 +61,13 @@ public class DepotLayoutSetPrototypeServiceWrapper
 	@Override
 	public int searchCount(long companyId, Boolean active) {
 		try {
-			if (PermissionUtil.hasCMSAdministratorRole(companyId) ||
-				PermissionUtil.isDepotGroupAdminOrOwner(companyId)) {
+			PermissionChecker permissionChecker =
+				PermissionThreadLocal.getPermissionChecker();
+
+			long userId = permissionChecker.getUserId();
+
+			if (PermissionUtil.hasCMSAdministratorRole(companyId, userId) ||
+				PermissionUtil.isDepotGroupAdminOrOwner(companyId, userId)) {
 
 				return _layoutSetPrototypeLocalService.searchCount(
 					companyId, active);

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/PermissionUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/PermissionUtil.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
@@ -21,7 +20,7 @@ import com.liferay.portal.security.permission.PermissionCacheUtil;
  */
 public class PermissionUtil {
 
-	public static boolean hasCMSAdministratorRole(long companyId)
+	public static boolean hasCMSAdministratorRole(long companyId, long userId)
 		throws PortalException {
 
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
@@ -29,23 +28,20 @@ public class PermissionUtil {
 		}
 
 		Boolean value = PermissionCacheUtil.getUserPrimaryKeyRole(
-			GuestOrUserUtil.getUserId(), companyId,
-			RoleConstants.CMS_ADMINISTRATOR);
+			userId, companyId, RoleConstants.CMS_ADMINISTRATOR);
 
 		if (value == null) {
 			value = RoleLocalServiceUtil.hasUserRole(
-				GuestOrUserUtil.getUserId(), companyId,
-				RoleConstants.CMS_ADMINISTRATOR, true);
+				userId, companyId, RoleConstants.CMS_ADMINISTRATOR, true);
 
 			PermissionCacheUtil.putUserPrimaryKeyRole(
-				GuestOrUserUtil.getUserId(), companyId,
-				RoleConstants.CMS_ADMINISTRATOR, value);
+				userId, companyId, RoleConstants.CMS_ADMINISTRATOR, value);
 		}
 
 		return value;
 	}
 
-	public static boolean isDepotGroupAdminOrOwner(long companyId)
+	public static boolean isDepotGroupAdminOrOwner(long companyId, long userId)
 		throws PortalException {
 
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
@@ -58,8 +54,7 @@ public class PermissionUtil {
 			companyId, DepotRolesConstants.ASSET_LIBRARY_OWNER);
 
 		for (UserGroupRole userGroupRole :
-				UserGroupRoleLocalServiceUtil.getUserGroupRoles(
-					GuestOrUserUtil.getUserId())) {
+				UserGroupRoleLocalServiceUtil.getUserGroupRoles(userId)) {
 
 			long roleId = userGroupRole.getRoleId();
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/SharingEntryServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/SharingEntryServiceTest.java
@@ -23,6 +23,9 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -96,6 +99,41 @@ public class SharingEntryServiceTest {
 	public void testAddSharingEntry() throws Exception {
 		_testAddSharingEntryForBasicDocumentWithViewAddsDownloadAction();
 		_testAddSharingEntryForBasicWebContentWithViewDoesNotAddDownloadAction();
+	}
+
+	@Test
+	public void testContainsSharePermissionAsCMSAdministratorWithoutPrincipal()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_getCMSBasicDocumentObjectDefinition();
+
+		ObjectEntry objectEntry = _addCMSBasicDocumentObjectEntry(
+			objectDefinition);
+
+		User user = UserTestUtil.addCompanyUser(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()),
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			user);
+
+		String name = PrincipalThreadLocal.getName();
+
+		try {
+			PrincipalThreadLocal.setName(null);
+
+			Assert.assertTrue(
+				_sharingPermission.containsSharePermission(
+					permissionChecker,
+					_portal.getClassNameId(objectDefinition.getClassName()),
+					objectEntry.getObjectEntryId(), _depotEntry.getGroupId()));
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+
+			_userLocalService.deleteUser(user);
+		}
 	}
 
 	private ObjectEntry _addCMSBasicDocumentObjectEntry(
@@ -286,6 +324,9 @@ public class SharingEntryServiceTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private PermissionCheckerFactory _permissionCheckerFactory;
 
 	@Inject
 	private Portal _portal;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97406

## What Is Being Fixed

When an object entry is rendered through the info-item path with sharing enabled, `DepotPermissionCheckerWrapper` logged `PrincipalException: Principal is null` at ERROR level and denied a CMS Administrator the share permission. `isGroupAdmin` establishes the signed-in user from the wrapped `PermissionChecker`, but the CMS Administrator check in `PermissionUtil.hasCMSAdministratorRole` resolved the user from `PrincipalThreadLocal`. On a thread that carries a `PermissionChecker` but no principal, the two sources disagree, the role lookup throws, the exception is caught in `isGroupAdmin`, and the check is swallowed to false. The failure is fail-closed: a legitimate CMS Administrator is denied.

## How It Is Being Fixed

Resolve the user consistently with the `isSignedIn` guard, from the `PermissionChecker` rather than `PrincipalThreadLocal`. `PermissionUtil.hasCMSAdministratorRole` and `isDepotGroupAdminOrOwner` now take an explicit `userId`. `DepotPermissionCheckerWrapper` passes its own `getUserId()` (the checker's user), matching what the sibling `_isContentReviewer` already does. `DepotLayoutSetPrototypeServiceWrapper`, a service-layer wrapper where the principal is reliably set, resolves the user from the thread's permission checker for consistency. This removes the dependency on `PrincipalThreadLocal` for the check, so nothing throws when a thread has a checker but no principal.

## Tests

`SharingEntryServiceTest.testContainsSharePermission` drives `SharingPermission.containsSharePermission` for a user holding the CMS Administrator role, with a `PermissionChecker` created for that user and `PrincipalThreadLocal` cleared, and asserts the share permission is granted. It fails before the fix (denied, with the ERROR logged) and passes after.

```
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests "com.liferay.site.cms.site.initializer.internal.service.test.SharingEntryServiceTest.testContainsSharePermission"
```

## PR Check

**pr-check: PASS** — tested on `2ef06b6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "2ef06b6c068adfdcabdbdb812e82983e68a20287"} -->
