### PR TITLE
LPD-97272 Send Asset Publisher subscription emails for collections

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/nofications/test/AssetPublisherUserNotificationTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/nofications/test/AssetPublisherUserNotificationTest.java
@@ -6,7 +6,12 @@
 package com.liferay.asset.publisher.nofications.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.InfoCollectionProvider;
+import com.liferay.info.pagination.InfoPage;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
@@ -44,7 +49,10 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,8 +61,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
 /**
  * @author Eudaldo Alonso
+ * @author Mikel Lorza
  */
 @RunWith(Arquillian.class)
 public class AssetPublisherUserNotificationTest {
@@ -118,6 +132,47 @@ public class AssetPublisherUserNotificationTest {
 	}
 
 	@Test
+	public void testUserNotificationForInfoCollectionProvider()
+		throws Exception {
+
+		AssetEntry assetEntry = _getAssetEntry();
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			AssetPublisherUserNotificationTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ServiceRegistration<InfoCollectionProvider<?>> serviceRegistration =
+			bundleContext.registerService(
+				(Class<InfoCollectionProvider<?>>)
+					(Class<?>)InfoCollectionProvider.class,
+				new TestInfoCollectionProvider(
+					Collections.singletonList(assetEntry)),
+				null);
+
+		try {
+			_updateInfoCollectionProviderPortletPreferences(
+				TestInfoCollectionProvider.class.getName());
+
+			UnsafeRunnable<Exception> unsafeRunnable =
+				_schedulerJobConfiguration.getJobExecutorUnsafeRunnable();
+
+			unsafeRunnable.run();
+
+			_assertAssetPublisherNotifications(
+				_getExpectedMailBody(
+					assetEntry.getTitle(_user.getLocale()),
+					_portal.getPortletTitle(
+						AssetPublisherPortletKeys.ASSET_PUBLISHER,
+						_user.getLanguageId()),
+					_group.getDescriptiveName(_user.getLocale())));
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Test
 	public void testUserNotificationWithDifferentUserLocale() throws Exception {
 		_user = _userLocalService.updateLanguageId(
 			_user.getUserId(), LanguageUtil.getLanguageId(LocaleUtil.SPAIN));
@@ -163,6 +218,16 @@ public class AssetPublisherUserNotificationTest {
 		Assert.assertEquals(expectedMailBody, mailMessage.getBody());
 	}
 
+	private AssetEntry _getAssetEntry() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		return _assetEntryLocalService.getEntry(
+			JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey());
+	}
+
 	private String _getExpectedMailBody(
 		String assetEntries, String portletTitle, String siteName) {
 
@@ -189,6 +254,20 @@ public class AssetPublisherUserNotificationTest {
 			portletPreferences.getPortletPreferencesId());
 	}
 
+	private void _updateInfoCollectionProviderPortletPreferences(
+			String infoListProviderKey)
+		throws Exception {
+
+		jakarta.portlet.PortletPreferences jxPortletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		jxPortletPreferences.setValue(
+			"infoListProviderKey", infoListProviderKey);
+		jxPortletPreferences.setValue("selectionStyle", "asset-list");
+
+		jxPortletPreferences.store();
+	}
+
 	private void _updatePortletPreferences() throws Exception {
 		jakarta.portlet.PortletPreferences jxPortletPreferences =
 			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
@@ -205,6 +284,9 @@ public class AssetPublisherUserNotificationTest {
 
 	private static final String _EMAIL_ASSET_ENTRY_ADDED_BODY =
 		"[$PORTLET_TITLE$]: [$SITE_NAME$]: [$ASSET_ENTRIES$]";
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
@@ -237,5 +319,28 @@ public class AssetPublisherUserNotificationTest {
 
 	@Inject
 	private UserLocalService _userLocalService;
+
+	private static class TestInfoCollectionProvider
+		implements InfoCollectionProvider<AssetEntry> {
+
+		public TestInfoCollectionProvider(List<AssetEntry> assetEntries) {
+			_assetEntries = assetEntries;
+		}
+
+		@Override
+		public InfoPage<AssetEntry> getCollectionInfoPage(
+			CollectionQuery collectionQuery) {
+
+			return InfoPage.of(_assetEntries);
+		}
+
+		@Override
+		public String getLabel(Locale locale) {
+			return StringPool.BLANK;
+		}
+
+		private final List<AssetEntry> _assetEntries;
+
+	}
 
 }

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/scheduler/helper/test/AssetEntriesCheckerHelperTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/scheduler/helper/test/AssetEntriesCheckerHelperTest.java
@@ -33,8 +33,10 @@ import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -190,8 +192,10 @@ public class AssetEntriesCheckerHelperTest {
 					LayoutTestUtil.getPortletPreferences(_layout, _portletId),
 					_layout));
 
-			Assert.assertNotNull(
-				testInfoCollectionProvider.getPermissionChecker());
+			PermissionChecker permissionChecker =
+				testInfoCollectionProvider.getPermissionChecker();
+
+			Assert.assertTrue(permissionChecker.isCompanyAdmin());
 
 			ServiceContext serviceContext =
 				testInfoCollectionProvider.getServiceContext();
@@ -389,8 +393,12 @@ public class AssetEntriesCheckerHelperTest {
 			_assetEntriesCheckerHelper, "_infoItemServiceRegistry",
 			_infoItemServiceRegistry);
 		ReflectionTestUtil.setFieldValue(
+			_assetEntriesCheckerHelper, "_roleLocalService", _roleLocalService);
+		ReflectionTestUtil.setFieldValue(
 			_assetEntriesCheckerHelper, "_segmentsConfigurationProvider",
 			_segmentsConfigurationProvider);
+		ReflectionTestUtil.setFieldValue(
+			_assetEntriesCheckerHelper, "_userLocalService", _userLocalService);
 	}
 
 	private Object _assetEntriesCheckerHelper;
@@ -433,7 +441,13 @@ public class AssetEntriesCheckerHelperTest {
 	private String _portletId;
 
 	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
 	private SegmentsConfigurationProvider _segmentsConfigurationProvider;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 	private static class TestInfoCollectionProvider
 		implements InfoCollectionProvider<AssetEntry> {

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/scheduler/helper/test/AssetEntriesCheckerHelperTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/scheduler/helper/test/AssetEntriesCheckerHelperTest.java
@@ -19,6 +19,10 @@ import com.liferay.asset.publisher.util.AssetPublisherHelper;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.InfoCollectionProvider;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.pagination.InfoPage;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
@@ -26,8 +30,11 @@ import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -50,6 +57,7 @@ import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import org.junit.Assert;
@@ -60,7 +68,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author István András Dézsi
@@ -143,6 +153,56 @@ public class AssetEntriesCheckerHelperTest {
 					new Class<?>[] {PortletPreferences.class, Layout.class},
 					LayoutTestUtil.getPortletPreferences(_layout, _portletId),
 					_layout));
+		}
+	}
+
+	@Test
+	public void testGetAssetEntriesFromInfoCollectionProviderSelectionAssetPublisher()
+		throws Exception {
+
+		AssetEntry assetEntry1 = _addAssetEntry();
+		AssetEntry assetEntry2 = _addAssetEntry();
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			AssetEntriesCheckerHelperTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		TestInfoCollectionProvider testInfoCollectionProvider =
+			new TestInfoCollectionProvider(
+				Arrays.asList(assetEntry1, assetEntry2));
+
+		ServiceRegistration<InfoCollectionProvider<?>> serviceRegistration =
+			bundleContext.registerService(
+				(Class<InfoCollectionProvider<?>>)
+					(Class<?>)InfoCollectionProvider.class,
+				testInfoCollectionProvider, null);
+
+		try {
+			_setInfoCollectionProviderSelectionStylePreference(
+				TestInfoCollectionProvider.class.getName());
+
+			_assertAssetEntries(
+				Arrays.asList(assetEntry1, assetEntry2),
+				ReflectionTestUtil.invoke(
+					_assetEntriesCheckerHelper, "_getAssetEntries",
+					new Class<?>[] {PortletPreferences.class, Layout.class},
+					LayoutTestUtil.getPortletPreferences(_layout, _portletId),
+					_layout));
+
+			Assert.assertNotNull(
+				testInfoCollectionProvider.getPermissionChecker());
+
+			ServiceContext serviceContext =
+				testInfoCollectionProvider.getServiceContext();
+
+			Assert.assertEquals(
+				_layout.getCompanyId(), serviceContext.getCompanyId());
+			Assert.assertEquals(
+				_layout.getGroupId(), serviceContext.getScopeGroupId());
+		}
+		finally {
+			serviceRegistration.unregister();
 		}
 	}
 
@@ -245,6 +305,19 @@ public class AssetEntriesCheckerHelperTest {
 		portletPreferences.store();
 	}
 
+	private void _setInfoCollectionProviderSelectionStylePreference(
+			String infoListProviderKey)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		portletPreferences.setValue("infoListProviderKey", infoListProviderKey);
+		portletPreferences.setValue("selectionStyle", "asset-list");
+
+		portletPreferences.store();
+	}
+
 	private void _setPortletManualSelectionStylePreference(
 			AssetEntry... assetEntries)
 		throws Exception {
@@ -313,6 +386,9 @@ public class AssetEntriesCheckerHelperTest {
 			_assetEntriesCheckerHelper, "_groupLocalService",
 			_groupLocalService);
 		ReflectionTestUtil.setFieldValue(
+			_assetEntriesCheckerHelper, "_infoItemServiceRegistry",
+			_infoItemServiceRegistry);
+		ReflectionTestUtil.setFieldValue(
 			_assetEntriesCheckerHelper, "_segmentsConfigurationProvider",
 			_segmentsConfigurationProvider);
 	}
@@ -350,10 +426,49 @@ public class AssetEntriesCheckerHelperTest {
 	@Inject
 	private GroupLocalService _groupLocalService;
 
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
 	private Layout _layout;
 	private String _portletId;
 
 	@Inject
 	private SegmentsConfigurationProvider _segmentsConfigurationProvider;
+
+	private static class TestInfoCollectionProvider
+		implements InfoCollectionProvider<AssetEntry> {
+
+		public TestInfoCollectionProvider(List<AssetEntry> assetEntries) {
+			_assetEntries = assetEntries;
+		}
+
+		@Override
+		public InfoPage<AssetEntry> getCollectionInfoPage(
+			CollectionQuery collectionQuery) {
+
+			_permissionChecker = PermissionThreadLocal.getPermissionChecker();
+			_serviceContext = ServiceContextThreadLocal.getServiceContext();
+
+			return InfoPage.of(_assetEntries);
+		}
+
+		@Override
+		public String getLabel(Locale locale) {
+			return StringPool.BLANK;
+		}
+
+		public PermissionChecker getPermissionChecker() {
+			return _permissionChecker;
+		}
+
+		public ServiceContext getServiceContext() {
+			return _serviceContext;
+		}
+
+		private final List<AssetEntry> _assetEntries;
+		private PermissionChecker _permissionChecker;
+		private ServiceContext _serviceContext;
+
+	}
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
@@ -20,7 +20,12 @@ import com.liferay.asset.publisher.web.internal.constants.AssetPublisherSelectio
 import com.liferay.asset.publisher.web.internal.helper.AssetPublisherWebHelper;
 import com.liferay.asset.publisher.web.internal.util.AssetPublisherUtil;
 import com.liferay.asset.util.AssetHelper;
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.InfoCollectionProvider;
+import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.layout.util.LayoutServiceContextHelperUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
@@ -257,10 +262,14 @@ public class AssetEntriesCheckerHelper {
 
 		if (Objects.equals(
 				selectionStyle,
-				AssetPublisherSelectionStyleConstants.TYPE_ASSET_LIST)) {
+				AssetPublisherSelectionStyleConstants.TYPE_ASSET_LIST) ||
+			Objects.equals(
+				selectionStyle,
+				AssetPublisherSelectionStyleConstants.
+					TYPE_ASSET_LIST_PROVIDER)) {
 
 			return _getAssetListEntrySelectedAssetEntries(
-				layout.getCompanyId(), layout.getGroupId(), portletPreferences);
+				layout, portletPreferences);
 		}
 		else if (Objects.equals(
 					selectionStyle,
@@ -274,24 +283,29 @@ public class AssetEntriesCheckerHelper {
 	}
 
 	private List<AssetEntry> _getAssetListEntrySelectedAssetEntries(
-		long companyId, long groupId, PortletPreferences portletPreferences) {
+		Layout layout, PortletPreferences portletPreferences) {
 
 		List<AssetEntry> assetEntries = new ArrayList<>();
 
-		try {
+		try (AutoCloseable autoCloseable =
+				LayoutServiceContextHelperUtil.getServiceContextAutoCloseable(
+					layout)) {
+
 			AssetListEntry assetListEntry =
 				AssetPublisherUtil.getAssetListEntry(
-					false, companyId, groupId, portletPreferences);
+					false, layout.getCompanyId(), layout.getGroupId(),
+					portletPreferences);
 
 			if (assetListEntry == null) {
-				return Collections.emptyList();
+				return _getInfoCollectionProviderSelectedAssetEntries(
+					layout, portletPreferences);
 			}
 
 			long[] segmentsEntryIds = {SegmentsEntryConstants.ID_DEFAULT};
 
 			try {
 				if (_segmentsConfigurationProvider.isSegmentationEnabled(
-						groupId)) {
+						layout.getGroupId())) {
 
 					segmentsEntryIds = ArrayUtil.toLongArray(
 						TransformUtil.transform(
@@ -389,6 +403,48 @@ public class AssetEntriesCheckerHelper {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	private List<AssetEntry> _getInfoCollectionProviderSelectedAssetEntries(
+			Layout layout, PortletPreferences portletPreferences)
+		throws PortalException {
+
+		String infoListProviderKey = GetterUtil.getString(
+			portletPreferences.getValue("infoListProviderKey", null));
+
+		if (Validator.isNull(infoListProviderKey)) {
+			return Collections.emptyList();
+		}
+
+		InfoCollectionProvider<AssetEntry> infoCollectionProvider =
+			_infoItemServiceRegistry.getInfoItemService(
+				InfoCollectionProvider.class, infoListProviderKey);
+
+		if (infoCollectionProvider == null) {
+			return Collections.emptyList();
+		}
+
+		AssetPublisherWebConfiguration assetPublisherWebConfiguration =
+			_configurationProvider.getCompanyConfiguration(
+				AssetPublisherWebConfiguration.class, layout.getCompanyId());
+
+		int end = assetPublisherWebConfiguration.dynamicSubscriptionLimit();
+
+		int start = 0;
+
+		if (end == 0) {
+			end = QueryUtil.ALL_POS;
+			start = QueryUtil.ALL_POS;
+		}
+
+		CollectionQuery collectionQuery = new CollectionQuery();
+
+		collectionQuery.setPagination(Pagination.of(end, start));
+
+		InfoPage<AssetEntry> infoPage =
+			infoCollectionProvider.getCollectionInfoPage(collectionQuery);
+
+		return (List<AssetEntry>)infoPage.getPageItems();
 	}
 
 	private List<AssetEntry> _getManuallySelectedAssetEntries(
@@ -613,6 +669,9 @@ public class AssetEntriesCheckerHelper {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
@@ -39,6 +39,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
@@ -53,6 +55,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
@@ -289,7 +292,7 @@ public class AssetEntriesCheckerHelper {
 
 		try (AutoCloseable autoCloseable =
 				LayoutServiceContextHelperUtil.getServiceContextAutoCloseable(
-					layout)) {
+					layout, _getUser(layout.getCompanyId()))) {
 
 			AssetListEntry assetListEntry =
 				AssetPublisherUtil.getAssetListEntry(
@@ -578,6 +581,24 @@ public class AssetEntriesCheckerHelper {
 		return subscriptionSender;
 	}
 
+	private User _getUser(long companyId) throws PortalException {
+		Role role = _roleLocalService.fetchRole(
+			companyId, RoleConstants.ADMINISTRATOR);
+
+		if (role == null) {
+			return _userLocalService.getGuestUser(companyId);
+		}
+
+		List<User> adminUsers = _userLocalService.getRoleUsers(
+			role.getRoleId(), 0, 1);
+
+		if (adminUsers.isEmpty()) {
+			return _userLocalService.getGuestUser(companyId);
+		}
+
+		return adminUsers.get(0);
+	}
+
 	private void _notifySubscribers(
 		Layout layout, String layoutURL, List<Subscription> subscriptions,
 		String portletId, PortletPreferences portletPreferences,
@@ -688,6 +709,9 @@ public class AssetEntriesCheckerHelper {
 	@Reference
 	private PortletPreferenceValueLocalService
 		_portletPreferenceValueLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private SegmentsConfigurationProvider _segmentsConfigurationProvider;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97272

## What Is Being Fixed

An Asset Publisher widget configured with a Collection (a saved Asset List entry) or a Collection Provider never sent "asset added" subscription notification emails; only the Dynamic and Manual selection styles worked.

The check-entries scheduled job resolves each widget's assets on a background thread that has no request context — no `ServiceContext` and no `PermissionChecker`. Two things broke there. A saved Collection whose resolution runs a permission-filtered persistence query (for example a dynamic collection scoped to an asset library with Document file entry types) threw `IllegalStateException: Permission checker is null` inside `filterFindByGroupId`. And a Collection Provider — which reads the company id, scope group id, and a `ThemeDisplay` from the thread-local `ServiceContext` — was never consulted at all. Both failures were caught and logged at debug, so the resolved asset list came back empty, the `assetEntries.isEmpty()` guard returned early, and no subscriber was ever notified.

## How It Is Being Fixed

The scheduler now resolves the asset-list selection style — which covers both saved Collections and Collection Providers, mirroring `AssetPublisherDisplayContext.isSelectionStyleAssetList()` — inside a real, portal-built request context obtained from `LayoutServiceContextHelper`. This is the same helper that headless REST resources, fragment installers, and model listeners already use for headless layout work, so it supplies a genuine `ThemeDisplay`/`ServiceContext`/`PermissionChecker` rather than a hand-faked partial one. When no saved Asset List entry resolves, it falls back to the Collection Provider via the `infoListProviderKey` preference, exactly as the runtime display does.

Resolution runs as a company administrator rather than the guest user. Asset list and Collection Provider resolution always filters by the resolving user, unlike Manual and Dynamic selection which resolve broadly and rely on the per-subscriber filter; resolving as guest would return strictly less than the other selection styles. A company administrator aligns the behavior across all selection styles, and the existing per-subscriber permission filter in `_notifySubscribers` still guarantees each subscriber only receives assets they can view.

Verified end to end against a live portal (the notification reached the mail server) and covered by an integration test that reproduces the real preference shape and asserts the resolution runs with a company-admin `PermissionChecker` and a populated `ServiceContext`.

## PR Check

**pr-check: PASS** — tested on `72f593ceb8c2f35f3f9f8a5af06f14948d6c1583`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "72f593ceb8c2f35f3f9f8a5af06f14948d6c1583"} -->
