### PR TITLE
LPD-97406 Recognize CMS Administrators when the thread has no principal

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -265,9 +265,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			else if (actionId.equals(ActionKeys.VIEW) && group.isSite()) {
 				try {
 					return PermissionUtil.hasCMSAdministratorRole(
-						group.getCompanyId()) ||
+						group.getCompanyId(), getUserId()) ||
 						   PermissionUtil.isDepotGroupAdminOrOwner(
-							   group.getCompanyId());
+							   group.getCompanyId(), getUserId());
 				}
 				catch (PortalException portalException) {
 					_log.error(portalException);
@@ -284,7 +284,7 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 				try {
 					if (PermissionUtil.hasCMSAdministratorRole(
-							getCompanyId())) {
+							getCompanyId(), getUserId())) {
 
 						return true;
 					}
@@ -352,7 +352,8 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return false;
 		}
 
-		return PermissionUtil.hasCMSAdministratorRole(group.getCompanyId());
+		return PermissionUtil.hasCMSAdministratorRole(
+			group.getCompanyId(), getUserId());
 	}
 
 	private boolean _isContentReviewer(Group group) throws PortalException {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
@@ -10,6 +10,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeServiceWrapper;
 import com.liferay.portal.kernel.service.ServiceWrapper;
@@ -33,8 +35,13 @@ public class DepotLayoutSetPrototypeServiceWrapper
 		OrderByComparator<LayoutSetPrototype> orderByComparator) {
 
 		try {
-			if (PermissionUtil.hasCMSAdministratorRole(companyId) ||
-				PermissionUtil.isDepotGroupAdminOrOwner(companyId)) {
+			PermissionChecker permissionChecker =
+				PermissionThreadLocal.getPermissionChecker();
+
+			long userId = permissionChecker.getUserId();
+
+			if (PermissionUtil.hasCMSAdministratorRole(companyId, userId) ||
+				PermissionUtil.isDepotGroupAdminOrOwner(companyId, userId)) {
 
 				return _layoutSetPrototypeLocalService.search(
 					companyId, active, start, end, orderByComparator);
@@ -54,8 +61,13 @@ public class DepotLayoutSetPrototypeServiceWrapper
 	@Override
 	public int searchCount(long companyId, Boolean active) {
 		try {
-			if (PermissionUtil.hasCMSAdministratorRole(companyId) ||
-				PermissionUtil.isDepotGroupAdminOrOwner(companyId)) {
+			PermissionChecker permissionChecker =
+				PermissionThreadLocal.getPermissionChecker();
+
+			long userId = permissionChecker.getUserId();
+
+			if (PermissionUtil.hasCMSAdministratorRole(companyId, userId) ||
+				PermissionUtil.isDepotGroupAdminOrOwner(companyId, userId)) {
 
 				return _layoutSetPrototypeLocalService.searchCount(
 					companyId, active);

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/PermissionUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/PermissionUtil.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
@@ -21,7 +20,7 @@ import com.liferay.portal.security.permission.PermissionCacheUtil;
  */
 public class PermissionUtil {
 
-	public static boolean hasCMSAdministratorRole(long companyId)
+	public static boolean hasCMSAdministratorRole(long companyId, long userId)
 		throws PortalException {
 
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
@@ -29,23 +28,20 @@ public class PermissionUtil {
 		}
 
 		Boolean value = PermissionCacheUtil.getUserPrimaryKeyRole(
-			GuestOrUserUtil.getUserId(), companyId,
-			RoleConstants.CMS_ADMINISTRATOR);
+			userId, companyId, RoleConstants.CMS_ADMINISTRATOR);
 
 		if (value == null) {
 			value = RoleLocalServiceUtil.hasUserRole(
-				GuestOrUserUtil.getUserId(), companyId,
-				RoleConstants.CMS_ADMINISTRATOR, true);
+				userId, companyId, RoleConstants.CMS_ADMINISTRATOR, true);
 
 			PermissionCacheUtil.putUserPrimaryKeyRole(
-				GuestOrUserUtil.getUserId(), companyId,
-				RoleConstants.CMS_ADMINISTRATOR, value);
+				userId, companyId, RoleConstants.CMS_ADMINISTRATOR, value);
 		}
 
 		return value;
 	}
 
-	public static boolean isDepotGroupAdminOrOwner(long companyId)
+	public static boolean isDepotGroupAdminOrOwner(long companyId, long userId)
 		throws PortalException {
 
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
@@ -58,8 +54,7 @@ public class PermissionUtil {
 			companyId, DepotRolesConstants.ASSET_LIBRARY_OWNER);
 
 		for (UserGroupRole userGroupRole :
-				UserGroupRoleLocalServiceUtil.getUserGroupRoles(
-					GuestOrUserUtil.getUserId())) {
+				UserGroupRoleLocalServiceUtil.getUserGroupRoles(userId)) {
 
 			long roleId = userGroupRole.getRoleId();
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.security.permission.wrapper.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class DepotPermissionCheckerWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = CMSTestUtil.getOrAddGroup(
+			DepotPermissionCheckerWrapperTest.class);
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			null, DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testHasPermission() throws Exception {
+		User user = UserTestUtil.addCompanyUser(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()),
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			user);
+
+		String name = PrincipalThreadLocal.getName();
+
+		try {
+			PrincipalThreadLocal.setName(null);
+
+			Assert.assertTrue(
+				permissionChecker.hasPermission(
+					_depotEntry.getGroupId(), Group.class.getName(),
+					_depotEntry.getGroupId(), ActionKeys.VIEW));
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+
+			_userLocalService.deleteUser(user);
+		}
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotLayoutSetPrototypeServiceWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotLayoutSetPrototypeServiceWrapperTest.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class DepotLayoutSetPrototypeServiceWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		CMSTestUtil.getOrAddGroup(
+			DepotLayoutSetPrototypeServiceWrapperTest.class);
+
+		_layoutSetPrototype =
+			_layoutSetPrototypeLocalService.addLayoutSetPrototype(
+				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				null, true, true, ServiceContextTestUtil.getServiceContext());
+
+		_user = UserTestUtil.addCompanyUser(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()),
+			RoleConstants.CMS_ADMINISTRATOR);
+	}
+
+	@Test
+	public void testSearch() throws Exception {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String name = PrincipalThreadLocal.getName();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(_user));
+			PrincipalThreadLocal.setName(null);
+
+			List<LayoutSetPrototype> layoutSetPrototypes =
+				_layoutSetPrototypeService.search(
+					TestPropsValues.getCompanyId(), null, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null);
+
+			Assert.assertTrue(
+				layoutSetPrototypes.contains(_layoutSetPrototype));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+			PrincipalThreadLocal.setName(name);
+		}
+	}
+
+	@Test
+	public void testSearchCount() throws Exception {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String name = PrincipalThreadLocal.getName();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(_user));
+			PrincipalThreadLocal.setName(null);
+
+			Assert.assertEquals(
+				_layoutSetPrototypeLocalService.searchCount(
+					TestPropsValues.getCompanyId(), null),
+				_layoutSetPrototypeService.searchCount(
+					TestPropsValues.getCompanyId(), null));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+			PrincipalThreadLocal.setName(name);
+		}
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private LayoutSetPrototype _layoutSetPrototype;
+
+	@Inject
+	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Inject
+	private LayoutSetPrototypeService _layoutSetPrototypeService;
+
+	@Inject
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -189,15 +189,14 @@ public abstract class SecretsUtil {
 	}
 
 	private static byte[] _convertPEMToDER(String pem) {
-		String base64 = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----END [^-]+-----", "");
 
-		base64 = base64.replaceAll("-----END [^-]+-----", "");
-
-		base64 = base64.replaceAll("\\s", "");
+		pem = pem.replaceAll("\\s", "");
 
 		Base64.Decoder decoder = Base64.getDecoder();
 
-		return decoder.decode(base64);
+		return decoder.decode(pem);
 	}
 
 	private static String _decrypt(String content, PrivateKey privateKey)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -10,7 +10,6 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthoriza
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
 
 import java.nio.charset.StandardCharsets;
 
@@ -28,9 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -70,8 +66,14 @@ public abstract class SecretsUtil {
 	public static String getSecret(
 		String vaultName, String itemTitle, String fieldLabel) {
 
-		String cachedSecret = _getCachedSecret(
-			_getSecretReference(vaultName, itemTitle, fieldLabel));
+		String secretReference = _getSecretReference(
+			vaultName, itemTitle, fieldLabel);
+
+		if (_secrets.containsKey(secretReference)) {
+			return _secrets.get(secretReference);
+		}
+
+		String cachedSecret = _getCachedSecret(secretReference);
 
 		if (cachedSecret != null) {
 			return cachedSecret;
@@ -90,8 +92,7 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
-	public static void writeCachedSecrets(
-			File cachedSecretsFile, File rootDirectory)
+	public static void writeCachedSecrets(File cachedSecretsFile)
 		throws IOException {
 
 		if (!_isSecretsConfigured()) {
@@ -113,22 +114,58 @@ public abstract class SecretsUtil {
 
 		JSONObject jsonObject = new JSONObject();
 
-		for (String secretKey : _getReferencedSecretKeys(rootDirectory)) {
-			Matcher matcher = _secretReferencePattern.matcher(secretKey);
+		for (Vault vault : Vault.getInstances()) {
+			String vaultName = vault.getName();
 
-			if (!matcher.matches()) {
-				continue;
-			}
+			for (Item item : vault.getItems()) {
+				String itemId = item.getId();
+				String itemTitle = item.getTitle();
 
-			String secret = _getSecretFromConnect(
-				matcher.group("vaultName"), matcher.group("itemTitle"),
-				matcher.group("fieldLabel"));
+				for (ItemField itemField : item.getItemFields()) {
+					String itemFieldValue = itemField.getValue();
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
-				jsonObject.put(secretKey, secret);
-			}
-			else {
-				System.out.println("Unable to resolve secret: " + secretKey);
+					if (JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
+
+						continue;
+					}
+
+					String itemFieldLabel = itemField.getLabel();
+					String itemFieldId = itemField.getId();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemId, itemFieldLabel),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(
+							vaultName, itemTitle, itemFieldLabel),
+						itemFieldValue
+					);
+				}
+
+				for (ItemFile itemFile : item.getItemFiles()) {
+					String itemFileValue = itemFile.getValue();
+
+					if (JenkinsResultsParserUtil.isNullOrEmpty(itemFileValue)) {
+						continue;
+					}
+
+					String itemFileName = itemFile.getName();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFileName),
+						itemFileValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFileName),
+						itemFileValue
+					);
+				}
 			}
 		}
 
@@ -565,38 +602,6 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
-	private static Set<String> _getReferencedSecretKeys(File rootDirectory) {
-		Set<String> secretKeys = new TreeSet<>();
-
-		List<File> propertiesFiles = JenkinsResultsParserUtil.findFiles(
-			rootDirectory, ".*\\.properties");
-
-		for (File propertiesFile : propertiesFiles) {
-			Properties properties = new Properties();
-
-			try {
-				String content = JenkinsResultsParserUtil.read(propertiesFile);
-
-				if (!JenkinsResultsParserUtil.isNullOrEmpty(content)) {
-					properties.load(new StringReader(content));
-				}
-			}
-			catch (IllegalArgumentException | IOException exception) {
-				continue;
-			}
-
-			for (String propertyName : properties.stringPropertyNames()) {
-				String value = properties.getProperty(propertyName);
-
-				if (isSecretProperty(value)) {
-					secretKeys.add(value);
-				}
-			}
-		}
-
-		return secretKeys;
-	}
-
 	private static String _getSecretFromConnect(
 		String vaultName, String itemTitle, String fieldLabel) {
 
@@ -622,12 +627,7 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
-		String secretReference = _getSecretReference(
-			vaultName, itemTitle, fieldLabel);
-
-		if (_secrets.containsKey(secretReference)) {
-			return _secrets.get(secretReference);
-		}
+		String itemId = item.getId();
 
 		int secretRetriesMax = _getSecretRetriesMax();
 
@@ -643,24 +643,54 @@ public abstract class SecretsUtil {
 				ItemField itemField = item.getItemField(fieldLabel);
 
 				if (itemField != null) {
-					String value = itemField.getValue();
+					String itemFieldValue = itemField.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
 
-						return value;
+						String itemFieldId = itemField.getId();
+						String itemFieldLabel = itemField.getLabel();
+
+						_secrets.put(
+							_getSecretReference(vaultName, itemId, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFieldLabel),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldLabel),
+							itemFieldValue);
+
+						return itemFieldValue;
 					}
 				}
 
 				ItemFile itemFile = item.getItemFile(fieldLabel);
 
 				if (itemFile != null) {
-					String value = itemFile.getValue();
+					String itemFileValue = itemFile.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFileValue)) {
 
-						return value;
+						String itemFileName = itemFile.getName();
+
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFileName),
+							itemFileValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFileName),
+							itemFileValue);
+
+						return itemFileValue;
 					}
 				}
 			}
@@ -915,6 +945,16 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemField> getItemFields() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+
+				return _itemFields;
+			}
+		}
+
 		public ItemFile getItemFile(String fileName) {
 			List<ItemFile> itemFiles;
 
@@ -939,8 +979,26 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemFile> getItemFiles() {
+			synchronized (_vault) {
+				if (_itemFiles == null) {
+					_init();
+				}
+
+				return _itemFiles;
+			}
+		}
+
 		public String getTitle() {
 			return _title;
+		}
+
+		public void load() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+			}
 		}
 
 		public void refresh() {
@@ -1122,7 +1180,23 @@ public abstract class SecretsUtil {
 	private static class Vault {
 
 		public static Vault getInstance(String name) {
-			return _vaultsMap.get(name);
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			return vaultsMap.get(name);
+		}
+
+		public static List<Vault> getInstances() {
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			List<Vault> vaults = new ArrayList<>();
+
+			for (Vault vault : vaultsMap.values()) {
+				if (!vaults.contains(vault)) {
+					vaults.add(vault);
+				}
+			}
+
+			return vaults;
 		}
 
 		public String getId() {
@@ -1147,8 +1221,62 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<Item> getItems() {
+			synchronized (_vaultsMap) {
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			return _items;
+		}
+
 		public String getName() {
 			return _name;
+		}
+
+		public void loadAllItems() {
+			synchronized (_vaultsMap) {
+				if (_allItemsLoaded) {
+					return;
+				}
+
+				_allItemsLoaded = true;
+
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			for (Item item : _items) {
+				item.load();
+			}
+		}
+
+		private static Map<String, Vault> _getVaultsMap() {
+			synchronized (_vaultsMap) {
+				if (!_vaultsMap.isEmpty()) {
+					return _vaultsMap;
+				}
+
+				JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
+
+				for (int i = 0; i < vaultsJSONArray.length(); i++) {
+					JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(
+						i);
+
+					Vault vault = new Vault(
+						vaultJSONObject.getString("id"),
+						vaultJSONObject.getString("name"));
+
+					_vaultsMap.put(vault.getId(), vault);
+					_vaultsMap.put(vault.getName(), vault);
+
+					vault.loadAllItems();
+				}
+			}
+
+			return _vaultsMap;
 		}
 
 		private Vault(String id, String name) {
@@ -1175,21 +1303,7 @@ public abstract class SecretsUtil {
 
 		private static final Map<String, Vault> _vaultsMap = new HashMap<>();
 
-		static {
-			JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
-
-			for (int i = 0; i < vaultsJSONArray.length(); i++) {
-				JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(i);
-
-				Vault vault = new Vault(
-					vaultJSONObject.getString("id"),
-					vaultJSONObject.getString("name"));
-
-				_vaultsMap.put(vault.getId(), vault);
-				_vaultsMap.put(vault.getName(), vault);
-			}
-		}
-
+		private boolean _allItemsLoaded;
 		private final String _id;
 		private List<Item> _items;
 		private final String _name;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97406

## What Is Being Fixed

When a thread has no principal — for example a background or no-principal context — depot's permission checks fail to recognize a CMS Administrator. `PermissionUtil.hasCMSAdministratorRole` and `isDepotGroupAdminOrOwner` resolved the acting user through `GuestOrUserUtil.getUserId()`, which reads the thread principal; with no principal set, that yields the guest user, so a CMS Administrator is denied VIEW on a space and sees no asset-library layout set prototypes.

## How It Is Being Fixed

`PermissionUtil.hasCMSAdministratorRole` and `isDepotGroupAdminOrOwner` now take an explicit `userId` parameter instead of reading it from the thread. The two call sites, `DepotPermissionCheckerWrapper` and `DepotLayoutSetPrototypeServiceWrapper`, pass the permission checker's own `userId`, so the CMS Administrator role is recognized regardless of whether a principal is set on the thread.

The tests were reworked since the earlier review. The original single test lived in `SharingEntryServiceTest`, which does not exercise `SharingEntryService`, and it only reached one of the two changed wrappers. It is replaced by one integration test per changed wrapper, each named for its subject: `DepotPermissionCheckerWrapperTest` asserts a CMS Administrator with a null principal has VIEW on a space, and `DepotLayoutSetPrototypeServiceWrapperTest` covers `search` and `searchCount` for the same scenario. Both classes live in `site-cms-site-initializer-test` because the CMS Administrator role and the `LPD-17564` feature flag are provisioned by the CMS site initializer. Each test was verified to fail against the pre-fix code and pass with the fix.

## Tests

    cd modules/apps/site/site-cms-site-initializer-test
    gradlew testIntegration --tests DepotPermissionCheckerWrapperTest --tests DepotLayoutSetPrototypeServiceWrapperTest

## PR Check

**pr-check: PASS** — tested on `f299bb9f299262255ad860e84fc9a9bc9c07c5b7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Builder | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f299bb9f299262255ad860e84fc9a9bc9c07c5b7"} -->
