### PR TITLE
LPD-97463 Fix the CMS categorization Playwright tests

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1032,8 +1032,6 @@ test.describe('Categorization Panel', () => {
 
 				const firstTagName = getRandomString();
 
-				tagNames.push(firstTagName);
-
 				await selectTag({page, tagName: firstTagName});
 
 				let tagLabel = page.locator('.label-item', {
@@ -1060,8 +1058,6 @@ test.describe('Categorization Panel', () => {
 
 				const secondTagName = getRandomString();
 
-				tagNames.push(secondTagName);
-
 				tagLabel = page.locator('.label-item', {
 					hasText: secondTagName,
 				});
@@ -1072,6 +1068,8 @@ test.describe('Categorization Panel', () => {
 				await expect(tagLabel).toBeAttached();
 
 				await contentsPage.publishButton.click();
+
+				tagNames.push(secondTagName);
 
 				// Edit the content and check that the categorization is still there
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -889,6 +889,33 @@ test.describe('Schedule Panel', () => {
 });
 
 test.describe('Categorization Panel', () => {
+	const selectAutocompleteOption = async ({
+		option,
+		page,
+		placeholder,
+		value,
+	}: {
+		option: Locator;
+		page: Page;
+		placeholder: string;
+		value: string;
+	}) => {
+		const autocomplete = page.getByPlaceholder(placeholder);
+
+		const selectedLabel = page.locator('.label-item', {hasText: value});
+
+		await expect(async () => {
+			await autocomplete.fill('', {timeout: 3000});
+			await autocomplete.fill(value, {timeout: 3000});
+
+			await option.waitFor({timeout: 3000});
+
+			await option.dispatchEvent('click', undefined, {timeout: 3000});
+
+			await expect(selectedLabel).toBeAttached({timeout: 3000});
+		}).toPass();
+	};
+
 	const selectCategory = async ({
 		categoryName,
 		page,
@@ -896,14 +923,12 @@ test.describe('Categorization Panel', () => {
 		categoryName: string;
 		page: Page;
 	}) => {
-		const categoriesAutocomplete = page.getByPlaceholder('Add category');
-
-		await categoriesAutocomplete.fill(categoryName);
-
-		const option = page.getByRole('option', {name: categoryName});
-
-		await option.waitFor();
-		await option.click();
+		await selectAutocompleteOption({
+			option: page.getByRole('option', {name: categoryName}),
+			page,
+			placeholder: 'Add category',
+			value: categoryName,
+		});
 	};
 
 	const selectTag = async ({
@@ -913,16 +938,14 @@ test.describe('Categorization Panel', () => {
 		page: Page;
 		tagName: string;
 	}) => {
-		const tagsAutocomplete = page.getByPlaceholder('Add tag');
-
-		await tagsAutocomplete.fill(tagName);
-
-		const newTagOption = page.getByRole('option', {
-			name: 'Create New Tag:',
+		await selectAutocompleteOption({
+			option: page.getByRole('option', {
+				name: `Create New Tag: ${tagName}`,
+			}),
+			page,
+			placeholder: 'Add tag',
+			value: tagName,
 		});
-
-		await newTagOption.waitFor();
-		await newTagOption.click();
 	};
 
 	test(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/categorization.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/categorization.spec.ts
@@ -9,8 +9,8 @@ import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
-import performLogin, {
-	performLogout,
+import {
+	performUserSwitchViaApi,
 	userData,
 } from '../../../../utils/performLogin';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
@@ -22,6 +22,7 @@ const test = mergeTests(
 		'LPD-11235': {enabled: false},
 		'LPD-17564': {enabled: true},
 		'LPD-34594': {enabled: true},
+		'LPD-58677': {enabled: true},
 	}),
 	loginTest()
 );
@@ -196,9 +197,7 @@ test(
 			});
 
 			await test.step('Login as a space member and go to Info Panel Categorization tab', async () => {
-				await performLogout(page);
-
-				await performLogin(page, user.alternateName);
+				await performUserSwitchViaApi(page, user.alternateName);
 
 				await assetsPage.gotoAll();
 
@@ -236,9 +235,7 @@ test(
 			});
 		}
 		finally {
-			await performLogout(page);
-
-			await performLogin(page, 'test');
+			await performUserSwitchViaApi(page, 'test');
 
 			if (objectEntry?.id) {
 				await apiHelpers.objectEntry.deleteObjectEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97463

## What Is Being Fixed

Two site-cms-site-initializer Playwright tests were failing in CI. "Add categories and tags to the content" timed out in its cleanup: since LPD-95961 a tag created from the content editor is stored in the space scope instead of the CMS site scope, so the tag the test adds and then cancels never shows up in the Tags admin, and the cleanup retried until the test timed out. "Info Panel Categories tab" failed because the Personas and Funnel Stages sections it exercises only render when the CMP vocabularies exist, and those are provisioned by the CMP site initializer, which never runs in the CMS-only test environment; the test also switched users through the UI sign-in flow, which intermittently left the session as a guest.

## How It Is Being Fixed

The categorization panel test now leaves the cancelled tag to be deleted together with the space and registers the published tag for cleanup only after publishing, which is when its site-scope twin that the Tags admin lists is created. Its selection helpers were also made resilient against two failure modes that only surface on a freshly built bundle: they refill the autocomplete until the suggestions dropdown opens, because a fill that arrives before the component wires its listeners never triggers it, and they dispatch the click and verify that the selected label lands, because the virtualized dropdown re-renders its items too often for an actionability-checked click.

The info panel test enables the LPD-58677 feature flag, whose listener runs the CMP site initializer and seeds the vocabularies the same way a real instance gets them, and switches users through performUserSwitchViaApi instead of the UI flow.

All three commits change Playwright tests only; both specs were verified green with repeated runs against a warmed-up bundle and a freshly built one.

## PR Check

**pr-check: PASS** — tested on `fd143b9c25df2efb31d1543a5bd1bfdc4928c0a0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "fd143b9c25df2efb31d1543a5bd1bfdc4928c0a0"} -->
