### PR TITLE
LPD-97499 Fix flaky Recycle Bin permanent-delete test

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -11,7 +11,8 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
 import {checkAccessibility} from '../../../utils/checkAccessibility';
 import getRandomString from '../../../utils/getRandomString';
-import performLoginViaApi, {
+import {
+	performLoginViaApi,
 	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';
@@ -34,7 +35,7 @@ test.beforeAll(async ({browser}) => {
 
 	const recycleBinPage = new RecycleBinPage(newPage);
 
-	await performLoginViaApi(newPage, 'test');
+	await performLoginViaApi({page: newPage, screenName: 'test'});
 
 	await recycleBinPage.goto();
 
@@ -278,7 +279,12 @@ test(
 				{first: true}
 			);
 
-			await expect(page.getByText('No Assets Yet')).toBeVisible();
+			await expect(
+				page.getByRole('cell', {name: contentName1})
+			).toBeHidden();
+			await expect(
+				page.getByRole('cell', {name: contentName2})
+			).toBeHidden();
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97499

## What Is Being Fixed

The Playwright test "Can delete permanently multiple contents from Recycle Bin" failed in CI but passed locally. It asserted that the whole Recycle Bin showed the empty state after permanently deleting its two contents, but the CMS Recycle Bin is shared across the site groups and accumulates trashed items left by other specs running in the same bundle, so the empty state never appeared in CI. Locally the bin held only the test's own items, so it passed. The test setup also flaked on repeated runs.

## How It Is Being Fixed

The final assertion now checks that the two deleted contents are gone from the list, mirroring the item-level check the empty-bin sibling test already uses, instead of requiring the entire shared bin to be empty. The setup was also importing the default export by mistake, which is the UI form helper rather than the API helper, so its click was occasionally swallowed on repeats; it now imports and calls the named API helper with its object signature.

## PR Check

**pr-check: PASS** — tested on `eadd6404b0f39951c0198fd14f03638e9dda4993`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "eadd6404b0f39951c0198fd14f03638e9dda4993"} -->
