### PR TITLE
LPD-95540 Add cross-Space content sharing tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -75,6 +75,7 @@ import {config as dispatchWebConfig} from './tests/dispatch-web/main/config';
 import {config as documentLibraryWebConfig} from './tests/document-library-web/main/config';
 import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-mapping-form-web/main/config';
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
+import {config as e2eCmsDxpCrossSpaceSharingConfig} from './tests/e2e-cms-dxp/cross-space-sharing/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
 import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
@@ -321,6 +322,7 @@ export default defineConfig({
 		dynamicDataMappingFormWebConfig,
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
+		e2eCmsDxpCrossSpaceSharingConfig,
 		e2eCmsDxpSharingConfig,
 		e2eCmsDxpTranslationsConfig,
 		e2eCmsDxpWorkflowConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'cross-space-sharing.main',
+	testDir: 'tests/e2e-cms-dxp/cross-space-sharing/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/crossSpaceContentMapping.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/crossSpaceContentMapping.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import {addSpaceUser} from '../../../../utils/addSpaceUser';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'A Basic Web Content moved from one Space to another can be published and mapped on the DXP site connected to the destination Space',
+	{tag: ['@LPD-95540', '@LPD-95540/TC-17.a']},
+	async ({apiHelpers, assetsPage, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(240000);
+
+		const sourceSpaceName = `Space A ${getRandomString()}`;
+		const destinationSpaceName = `Space B ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+
+		const destinationSpace =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				type: 'Space',
+			});
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: sourceSpaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			destinationSpace.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const destinationFolder =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${bodyValue}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			sourceSpaceName
+		);
+
+		const spaceAdmin = await addSpaceUser(
+			apiHelpers,
+			destinationSpace.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		await test.step('Move the content from the source Space to the destination Space', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: contentTitle,
+			});
+
+			await waitForAlert(
+				page,
+				`Success:${contentTitle} was successfully moved to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The content is no longer in the source Space and is present in the destination Space', async () => {
+			const sourceResponse =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					APPLICATION_NAME,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			expect(
+				sourceResponse.items.filter(
+					(item: {title: string}) => item.title === contentTitle
+				)
+			).toHaveLength(0);
+
+			const destinationResponse =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					APPLICATION_NAME,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			expect(
+				destinationResponse.items.filter(
+					(item: {title: string}) => item.title === contentTitle
+				)
+			).toHaveLength(1);
+		});
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1><div><lfr-editable id="content" type="rich-text">Content</lfr-editable></div></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the moved content into the page fragment and publish', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: ENTITY,
+						entry: contentTitle,
+						field: 'Title',
+					},
+				});
+
+				await pageEditorPage.selectEditable(fragmentId, 'content');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: ENTITY,
+						entry: contentTitle,
+						field: 'Content',
+					},
+				});
+			}).toPass({timeout: 30000});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('GUEST sees the moved content rendered on the connected DXP site', async () => {
+			const guestContext = await browser.newContext({
+				storageState: {cookies: [], origins: []},
+			});
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(contentTitle, {exact: true})
+					).toBeVisible({timeout: 2000});
+
+					await expect(
+						guestPage.getByText(bodyValue, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 30000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+
+		await test.step('SPA of the destination Space sees the moved content in the destination Space', async () => {
+			await performUserSwitchViaApi(page, spaceAdmin.alternateName);
+
+			await assetsPage.gotoFolder(
+				String(destinationFolder.id),
+				destinationFolderName
+			);
+
+			await expect(assetsPage.getItem(contentTitle)).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/moveRestriction.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/moveRestriction.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {addSpaceUser} from '../../../../utils/addSpaceUser';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'A Space Member cannot move content or files to another Space',
+	{tag: ['@LPD-95540', '@LPD-95540/TC-17.c']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: 'R0lGODlhAQABAAAAACw=',
+					name: `file_${getRandomString()}.png`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			'cms/basic-documents',
+			spaceName
+		);
+
+		const spaceMember = await addSpaceUser(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Member'
+		);
+
+		await performUserSwitchViaApi(page, spaceMember.alternateName);
+
+		await test.step('The Move action is not available on the content', async () => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.expectItemActionHidden('Move', contentTitle);
+		});
+
+		await test.step('The Move action is not available on the file', async () => {
+			await assetsPage.gotoSpaceFiles(spaceName);
+
+			await assetsPage.expectItemActionHidden('Move', fileTitle);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/cross-space-sharing/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
@@ -178,6 +178,10 @@ export class AssetsPage {
 		await this.dataSetFragmentPage.expectBulkItemActionHidden({action});
 	}
 
+	async expectItemActionHidden(action: string, filter: string) {
+		await this.dataSetFragmentPage.expectItemActionHidden({action, filter});
+	}
+
 	async bulkCopyTo(args: CopyOrMoveDestinationArgs) {
 		await this.page
 			.getByRole('button', {exact: true, name: 'Copy To'})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95540

## What Is Being Fixed

The CMS end-to-end epic (LPD-85582) lacked automated coverage for the Cross-Space Content Sharing scenarios (TC-17): moving CMS content between Spaces and confirming the moved content can be published and mapped onto the DXP site connected to the destination Space, and confirming that a non-managing Space role cannot move content or files across Spaces.

## How It Is Being Fixed

Adds a new cross-space-sharing.main project under tests/e2e-cms-dxp. crossSpaceContentMapping.spec.ts (TC-17.a) moves a Basic Web Content from one Space to another, confirms it is gone from the source Space and present in the destination Space, has the destination Space administrator confirm it, and then publishes and maps it onto the DXP site connected to the destination Space through a non-cacheable fragment. moveRestriction.spec.ts (TC-17.c) confirms that a Space Member sees no Move action on content or files, which is the role that lacks it by design.

The file move scenario (TC-17.b) is already covered end to end by copyMove.spec.ts, so it is not duplicated. The move mechanic reuses the existing AssetsPage helper, and a small expectItemActionHidden wrapper is added to AssetsPage to assert an absent row action.

## PR Check

**pr-check: PASS** — tested on `c276658182d8dff69b1c696125f55fd9f2a1400b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "c276658182d8dff69b1c696125f55fd9f2a1400b"} -->
