### PR TITLE
LPD-95541 Add headless API access tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -76,6 +76,7 @@ import {config as documentLibraryWebConfig} from './tests/document-library-web/m
 import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-mapping-form-web/main/config';
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
+import {config as e2eCmsDxpHeadlessAPIConfig} from './tests/e2e-cms-dxp/headless-api/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
 import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
@@ -321,6 +322,7 @@ export default defineConfig({
 		dynamicDataMappingFormWebConfig,
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
+		e2eCmsDxpHeadlessAPIConfig,
 		e2eCmsDxpSharingConfig,
 		e2eCmsDxpTranslationsConfig,
 		e2eCmsDxpWorkflowConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/basicWebContentAccess.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/basicWebContentAccess.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {getAsGuest} from './getAsGuest';
+
+const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'An anonymous client can read a published Basic Web Content through the headless API',
+	{tag: ['@LPD-95541', '@LPD-95541/TC-18.a']},
+	async ({apiHelpers, browser, site}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+		const friendlyUrlPath = `slug-${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${bodyValue}</p>`,
+				friendlyUrlPath,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		const {body, status} = await getAsGuest(
+			browser,
+			`/o/${APPLICATION_NAME}/${entry.id}`
+		);
+
+		expect(status).toBe(200);
+		expect(body?.title).toBe(contentTitle);
+		expect(String(body?.content)).toContain(bodyValue);
+		expect(body?.friendlyUrlPath).toBe(friendlyUrlPath);
+	}
+);
+
+test(
+	'An anonymous client cannot read an unpublished Basic Web Content through the headless API',
+	{tag: ['@LPD-95541', '@LPD-95541/TC-18.d']},
+	async ({apiHelpers, browser, site}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>Body ${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				status: {code: 2, label: 'draft'},
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const {body, status} = await getAsGuest(
+			browser,
+			`/o/${APPLICATION_NAME}/${entry.id}`
+		);
+
+		expect([401, 403, 404]).toContain(status);
+		expect(body?.title).not.toBe(contentTitle);
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'headless-api.main',
+	testDir: 'tests/e2e-cms-dxp/headless-api/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/fileAccess.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/fileAccess.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {getAsGuest} from './getAsGuest';
+
+const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'An anonymous client can read a published file and download it through the headless API',
+	{tag: ['@LPD-95541', '@LPD-95541/TC-18.c']},
+	async ({apiHelpers, browser, site}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+		const fileName = `sample_${getRandomString()}.jpg`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {fileBase64: imageBase64, name: fileName},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['DOWNLOAD_FILE', 'VIEW'], roleName: 'Guest'}]
+		);
+
+		const {body, status} = await getAsGuest(
+			browser,
+			`/o/${APPLICATION_NAME}/${entry.id}`
+		);
+
+		expect(status).toBe(200);
+		expect(body?.title).toBe(fileTitle);
+
+		const file = body?.file as {
+			extension?: string;
+			link?: {href?: string};
+			mimeType?: string;
+			name?: string;
+		};
+
+		expect(file?.name).toBe(fileName);
+		expect(file?.extension).toBe('jpg');
+		expect(file?.mimeType).toBe('image/jpeg');
+		expect(file?.link?.href).toBeTruthy();
+
+		const downloadStatus = await getAsGuest(
+			browser,
+			String(file?.link?.href)
+		);
+
+		expect(downloadStatus.status).toBe(200);
+	}
+);
+
+test(
+	'An anonymous client cannot read an unpublished file through the headless API',
+	{tag: ['@LPD-95541', '@LPD-95541/TC-18.e']},
+	async ({apiHelpers, browser, site}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `sample_${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				status: {code: 2, label: 'draft'},
+				title: fileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const {body, status} = await getAsGuest(
+			browser,
+			`/o/${APPLICATION_NAME}/${entry.id}`
+		);
+
+		expect([401, 403, 404]).toContain(status);
+		expect(body?.title).not.toBe(fileTitle);
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/getAsGuest.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/getAsGuest.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser} from '@playwright/test';
+
+// Sends a GET request as an anonymous client (no credentials). The request runs
+// inside a fresh browser context with an empty storage state, from the portal
+// origin so relative paths resolve. redirect: 'manual' keeps an authentication
+// redirect from being silently followed into a 200.
+
+export async function getAsGuest(
+	browser: Browser,
+	path: string
+): Promise<{body: Record<string, unknown> | null; status: number}> {
+	const context = await browser.newContext({
+		storageState: {cookies: [], origins: []},
+	});
+
+	try {
+		const page = await context.newPage();
+
+		await page.goto('/');
+
+		return await page.evaluate(async (url) => {
+			const response = await fetch(url, {redirect: 'manual'});
+
+			const contentType = response.headers.get('content-type') || '';
+
+			// Only parse a JSON body; a file download or an error page is not
+			// JSON, and the caller relies on the status alone in that case.
+
+			const body = contentType.includes('application/json')
+				? await response.json()
+				: null;
+
+			return {body, status: response.status};
+		}, path);
+	}
+	finally {
+		await context.close();
+	}
+}

--- a/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/structuredContentAccess.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/structuredContentAccess.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {getAsGuest} from './getAsGuest';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	isolatedSiteTest,
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'An anonymous client can read a published Structured Content entry with all field values through the headless API',
+	{tag: ['@LPD-95541', '@LPD-95541/TC-18.b']},
+	async ({apiHelpers, browser, site, structureBuilderPage}) => {
+		test.setTimeout(240000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Article ${getRandomString()}`;
+		const structureName = `Article${getRandomInt()}`;
+		const titleValue = `Title ${getRandomString()}`;
+		const bodyValue = `Body ${getRandomString()}`;
+		const fileName = `sample_${getRandomString()}.jpg`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a custom structure with Rich Text and Upload fields', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Rich Text');
+				await structureBuilderPage.selectFields([{label: 'Rich Text'}]);
+				await structureBuilderPage.changeFieldSettings({label: 'Body'});
+
+				await structureBuilderPage.addField('Upload');
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) => objectField.label?.en_US === 'Body'
+		);
+
+		const uploadField = objectDefinition.objectFields.find(
+			(objectField) => objectField.label?.en_US === 'Upload'
+		);
+
+		if (!bodyField || !uploadField) {
+			throw new Error(
+				'Body or Upload field not found in object definition'
+			);
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[bodyField.name]: `<p>${bodyValue}</p>`,
+				[uploadField.name]: {
+					fileBase64: imageBase64,
+					name: fileName,
+				},
+				[objectDefinition.titleObjectFieldName]: titleValue,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		const {body, status} = await getAsGuest(
+			browser,
+			`/o/${applicationName}/${entry.id}`
+		);
+
+		expect(status).toBe(200);
+		expect(body?.title).toBe(titleValue);
+		expect(String(body?.[bodyField.name])).toContain(bodyValue);
+
+		const uploadValue = body?.[uploadField.name] as {
+			fileURL?: string;
+			name?: string;
+		};
+
+		expect(uploadValue?.name).toBe(fileName);
+		expect(uploadValue?.fileURL).toBeTruthy();
+
+		const downloadStatus = await getAsGuest(
+			browser,
+			String(uploadValue?.fileURL)
+		);
+
+		expect(downloadStatus.status).toBe(200);
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/headless-api/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95541

## What Is Being Fixed

The CMS end-to-end epic (LPD-85582) lacked automated coverage for the Headless API Access scenarios (TC-18): confirming an anonymous client can read published CMS content and files through the REST API and receive accurate field values, and confirming that unpublished entries are not exposed to unauthenticated requests.

## How It Is Being Fixed

Adds a new headless-api.main project under tests/e2e-cms-dxp. Because CMS content are object entries, the specs exercise the object API (/o/cms/basic-web-contents, /o/cms/basic-documents, and the custom structure endpoint) rather than headless-delivery, granting a Guest VIEW so published entries are anonymously readable. basicWebContentAccess covers a published Basic Web Content returning its title, content body, and friendly URL (TC-18.a) and an unpublished entry returning 401, 403, or 404 (TC-18.d). structuredContentAccess covers a published custom structure with Rich Text and Upload fields returning every field value and the uploaded file URL (TC-18.b). fileAccess covers a published file returning its metadata and a working download URL (TC-18.c) and an unpublished file not being exposed (TC-18.e). A small getAsGuest helper sends the anonymous request from an empty-storage context, and uploads reuse the shared sample image fixture.

## PR Check

**pr-check: PASS** — tested on `26296cabf87d42554549dcde8d134fefa8cd2e59`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "26296cabf87d42554549dcde8d134fefa8cd2e59"} -->
