### PR TITLE
LPD-95542 Add restricted CMS content consumption tests

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -76,6 +76,7 @@ import {config as documentLibraryWebConfig} from './tests/document-library-web/m
 import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-mapping-form-web/main/config';
 import {config as e2eCmsDxpContentPageConfig} from './tests/e2e-cms-dxp/content-page/main/config';
 import {config as e2eCmsDxpDisplayPageTemplateConfig} from './tests/e2e-cms-dxp/display-page-template/main/config';
+import {config as e2eCmsDxpRestrictedAccessConfig} from './tests/e2e-cms-dxp/restricted-access/main/config';
 import {config as e2eCmsDxpSharingConfig} from './tests/e2e-cms-dxp/sharing/main/config';
 import {config as e2eCmsDxpTranslationsConfig} from './tests/e2e-cms-dxp/translations/main/config';
 import {config as e2eCmsDxpWorkflowConfig} from './tests/e2e-cms-dxp/workflow/main/config';
@@ -321,6 +322,7 @@ export default defineConfig({
 		dynamicDataMappingFormWebConfig,
 		e2eCmsDxpDisplayPageTemplateConfig,
 		e2eCmsDxpContentPageConfig,
+		e2eCmsDxpRestrictedAccessConfig,
 		e2eCmsDxpSharingConfig,
 		e2eCmsDxpTranslationsConfig,
 		e2eCmsDxpWorkflowConfig,

--- a/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'restricted-access.main',
+	testDir: 'tests/e2e-cms-dxp/restricted-access/main',
+};

--- a/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/restrictedBasicWebContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/restrictedBasicWebContent.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {displayPageTemplatesPagesTest} from '../../../../fixtures/displayPageTemplatesPagesTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {fragmentsPagesTest} from '../../../../fixtures/fragmentPagesTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi, userData} from '../../../../utils/performLogin';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	displayPageTemplatesPagesTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	fragmentsPagesTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+test(
+	'A restricted Basic Web Content is denied to GUEST and to a non-member, and renders for a member at its DPT URL',
+	{tag: ['@LPD-95542', '@LPD-95542/TC-19.g', '@LPD-95542/TC-19.j']},
+	async ({
+		apiHelpers,
+		browser,
+		displayPageTemplatesPage,
+		pageEditorPage,
+		site,
+	}) => {
+		test.setTimeout(240000);
+
+		const dptName = `DPT ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const friendlyUrlPath = `restricted-${getRandomString()}`.toLowerCase();
+
+		await test.step('Create and activate a Basic Web Content DPT', async () => {
+			await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+			await displayPageTemplatesPage.createTemplate({
+				contentType: 'Basic Web Content',
+				name: dptName,
+			});
+
+			await displayPageTemplatesPage.editTemplate(dptName);
+
+			await pageEditorPage.addFragment('Basic Components', 'Heading');
+
+			const headingId = await pageEditorPage.getFragmentId('Heading');
+
+			await pageEditorPage.selectEditable(headingId, 'element-text');
+
+			await pageEditorPage.changeConfiguration({
+				fieldLabel: 'Field',
+				tab: 'Mapping',
+				value: 'Title',
+			});
+
+			await pageEditorPage.publishPage();
+
+			await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+			await displayPageTemplatesPage.markAsDefault(dptName);
+		});
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>Body ${getRandomString()}</p>`,
+				friendlyUrlPath,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const role = await apiHelpers.headlessAdminUser.postRole({
+			name: `cms_viewer_${getRandomString()}`,
+			roleType: 'regular',
+		});
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: role.name}]
+		);
+
+		const displayUrl = `/web${site.friendlyUrlPath}/cmsbasicwebcontent/asset-library-${space.id}/${friendlyUrlPath}`;
+
+		await test.step('GUEST is denied and the content body is not exposed', async () => {
+			const guestContext = await browser.newContext({
+				storageState: {cookies: [], origins: []},
+			});
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await guestPage.goto(displayUrl);
+
+				await guestPage.waitForLoadState('networkidle');
+
+				await expect(
+					guestPage.getByText(contentTitle, {exact: true})
+				).toBeHidden();
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+
+		await test.step('A member USER sees the restricted content rendered', async () => {
+			const member = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[member.alternateName] = {
+				name: member.givenName,
+				password: 'test',
+				surname: member.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(member.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(member.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(
+				String(site.id),
+				[member.id]
+			);
+
+			await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+				role.id,
+				Number(member.id)
+			);
+
+			const memberContext = await browser.newContext();
+
+			const memberPage = await memberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: memberPage,
+					screenName: member.alternateName,
+				});
+
+				await expect(async () => {
+					await memberPage.goto(displayUrl);
+
+					await expect(
+						memberPage.getByText(contentTitle, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 10000});
+			}
+			finally {
+				await memberContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/restrictedFile.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/restrictedFile.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {displayPageTemplatesPagesTest} from '../../../../fixtures/displayPageTemplatesPagesTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {fragmentsPagesTest} from '../../../../fixtures/fragmentPagesTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi, userData} from '../../../../utils/performLogin';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	displayPageTemplatesPagesTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	fragmentsPagesTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+const SEPARATOR = 'cmsbasicdocument';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+async function fetchStatus(page, href: string) {
+	return page.evaluate(
+		async (url) => (await fetch(url, {redirect: 'manual'})).status,
+		href
+	);
+}
+
+test(
+	'A restricted CMS file is denied to GUEST at its DPT URL and its binary is not served, while a member can download it',
+	{tag: ['@LPD-95542', '@LPD-95542/TC-19.i']},
+	async ({
+		apiHelpers,
+		browser,
+		displayPageTemplatesPage,
+		pageEditorPage,
+		site,
+	}) => {
+		test.setTimeout(240000);
+
+		const dptName = `DPT ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+		const friendlyUrlPath = `restricted-${getRandomString()}`.toLowerCase();
+
+		await test.step('Create and activate a Basic Document DPT (Title + Preview URL)', async () => {
+			await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+			await displayPageTemplatesPage.createTemplate({
+				contentType: 'Basic Document',
+				name: dptName,
+			});
+
+			await displayPageTemplatesPage.editTemplate(dptName);
+
+			await pageEditorPage.addFragment('Basic Components', 'Heading');
+
+			const headingId = await pageEditorPage.getFragmentId('Heading');
+
+			await pageEditorPage.selectEditable(headingId, 'element-text');
+
+			await pageEditorPage.changeConfiguration({
+				fieldLabel: 'Field',
+				tab: 'Mapping',
+				value: 'Title',
+			});
+
+			await pageEditorPage.addFragment('Basic Components', 'Image');
+
+			const imageId = await pageEditorPage.getFragmentId('Image');
+
+			await pageEditorPage.selectEditable(imageId, 'image-square');
+
+			await pageEditorPage.changeConfiguration({
+				fieldLabel: 'Source Selection',
+				tab: 'Image Source',
+				value: 'Mapping',
+			});
+
+			await pageEditorPage.changeConfiguration({
+				fieldLabel: 'Field',
+				tab: 'Image Source',
+				value: 'Preview URL',
+			});
+
+			await pageEditorPage.publishPage();
+
+			await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+			await displayPageTemplatesPage.markAsDefault(dptName);
+		});
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {fileBase64: imageBase64, name: `${friendlyUrlPath}.jpg`},
+				friendlyUrlPath,
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const downloadHref = entry.file.link.href;
+
+		const role = await apiHelpers.headlessAdminUser.postRole({
+			name: `cms_viewer_${getRandomString()}`,
+			roleType: 'regular',
+		});
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['DOWNLOAD_FILE', 'VIEW'], roleName: role.name}]
+		);
+
+		const displayUrl = `/web${site.friendlyUrlPath}/${SEPARATOR}/asset-library-${space.id}/${friendlyUrlPath}`;
+
+		await test.step('A member USER sees the file page and can download the binary', async () => {
+			const member = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[member.alternateName] = {
+				name: member.givenName,
+				password: 'test',
+				surname: member.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(member.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(member.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(
+				String(site.id),
+				[member.id]
+			);
+
+			await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+				role.id,
+				Number(member.id)
+			);
+
+			const memberContext = await browser.newContext();
+
+			const memberPage = await memberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: memberPage,
+					screenName: member.alternateName,
+				});
+
+				await expect(async () => {
+					await memberPage.goto(displayUrl);
+
+					await expect(
+						memberPage.getByText(fileTitle, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 10000});
+
+				expect(await fetchStatus(memberPage, downloadHref)).toBe(200);
+			}
+			finally {
+				await memberContext.close();
+			}
+		});
+
+		await test.step('GUEST is denied at the DPT URL and the binary is not served', async () => {
+			const guestContext = await browser.newContext({
+				storageState: {cookies: [], origins: []},
+			});
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await guestPage.goto(displayUrl);
+
+				await guestPage.waitForLoadState('networkidle');
+
+				await expect(
+					guestPage.getByText(fileTitle, {exact: true})
+				).toBeHidden();
+
+				expect(await fetchStatus(guestPage, downloadHref)).not.toBe(
+					200
+				);
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/restrictedStructuredContent.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/restrictedStructuredContent.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {displayPageTemplatesPagesTest} from '../../../../fixtures/displayPageTemplatesPagesTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {fragmentsPagesTest} from '../../../../fixtures/fragmentPagesTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi, userData} from '../../../../utils/performLogin';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	displayPageTemplatesPagesTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	fragmentsPagesTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	structureBuilderPagesTest
+);
+
+async function createSiteMember(apiHelpers, siteId: string) {
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+	userData[user.alternateName] = {
+		name: user.givenName,
+		password: 'test',
+		surname: user.familyName,
+	};
+
+	await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+	await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+	await apiHelpers.jsonWebServicesUser.addGroupUsers(siteId, [user.id]);
+
+	return user;
+}
+
+test(
+	'A restricted Structured Content is denied to GUEST and to a non-member USER, and renders for a member at its DPT URL',
+	{tag: ['@LPD-95542', '@LPD-95542/TC-19.h', '@LPD-95542/TC-19.k']},
+	async ({
+		apiHelpers,
+		browser,
+		displayPageTemplatesPage,
+		pageEditorPage,
+		site,
+		structureBuilderPage,
+	}) => {
+		test.setTimeout(300000);
+
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Event ${getRandomString()}`;
+		const structureName = `Event${getRandomInt()}`;
+		const dptName = `DPT ${getRandomString()}`;
+		const titleValue = `Title ${getRandomString()}`;
+		const friendlyUrlPath = `restricted-${getRandomString()}`.toLowerCase();
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a custom structure', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({label: 'Body'});
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		await test.step('Create and activate a DPT for the structure', async () => {
+			await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+			await displayPageTemplatesPage.createTemplate({
+				contentType: structureLabel,
+				name: dptName,
+			});
+
+			await displayPageTemplatesPage.editTemplate(dptName);
+
+			await pageEditorPage.addFragment('Basic Components', 'Heading');
+
+			const headingId = await pageEditorPage.getFragmentId('Heading');
+
+			await pageEditorPage.selectEditable(headingId, 'element-text');
+
+			await pageEditorPage.changeConfiguration({
+				fieldLabel: 'Field',
+				tab: 'Mapping',
+				value: 'Title',
+			});
+
+			await pageEditorPage.publishPage();
+
+			await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+			await displayPageTemplatesPage.markAsDefault(dptName);
+		});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const bodyField = objectDefinition.objectFields.find(
+			(objectField) => objectField.label?.en_US === 'Body'
+		);
+
+		if (!bodyField) {
+			throw new Error('Body field not found in object definition');
+		}
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[bodyField.name]: `Body ${getRandomString()}`,
+				[objectDefinition.titleObjectFieldName]: titleValue,
+				friendlyUrlPath,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			},
+			applicationName,
+			spaceName
+		);
+
+		const role = await apiHelpers.headlessAdminUser.postRole({
+			name: `cms_viewer_${getRandomString()}`,
+			roleType: 'regular',
+		});
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: role.name}]
+		);
+
+		const displayUrl = `/web${site.friendlyUrlPath}/${objectDefinition.friendlyURLSeparator}/asset-library-${space.id}/${friendlyUrlPath}`;
+
+		await test.step('A member USER sees the restricted structured content', async () => {
+			const member = await createSiteMember(apiHelpers, String(site.id));
+
+			await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+				role.id,
+				Number(member.id)
+			);
+
+			const memberContext = await browser.newContext();
+
+			const memberPage = await memberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: memberPage,
+					screenName: member.alternateName,
+				});
+
+				await expect(async () => {
+					await memberPage.goto(displayUrl);
+
+					await expect(
+						memberPage.getByText(titleValue, {exact: true})
+					).toBeVisible({timeout: 2000});
+				}).toPass({timeout: 10000});
+			}
+			finally {
+				await memberContext.close();
+			}
+		});
+
+		await test.step('GUEST is denied and the content is not exposed', async () => {
+			const guestContext = await browser.newContext({
+				storageState: {cookies: [], origins: []},
+			});
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await guestPage.goto(displayUrl);
+
+				await guestPage.waitForLoadState('networkidle');
+
+				await expect(
+					guestPage.getByText(titleValue, {exact: true})
+				).toBeHidden();
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+
+		await test.step('A non-member USER is denied even when logged in', async () => {
+			const nonMember = await createSiteMember(
+				apiHelpers,
+				String(site.id)
+			);
+
+			const nonMemberContext = await browser.newContext();
+
+			const nonMemberPage = await nonMemberContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: nonMemberPage,
+					screenName: nonMember.alternateName,
+				});
+
+				await nonMemberPage.goto(displayUrl);
+
+				await nonMemberPage.waitForLoadState('networkidle');
+
+				await expect(
+					nonMemberPage.getByText(titleValue, {exact: true})
+				).toBeHidden();
+			}
+			finally {
+				await nonMemberContext.close();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/test.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/restricted-access/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95542

## What Is Being Fixed

The CMS end-to-end epic (LPD-85582) lacked automated coverage for the permission-gated slice of the Content & File Consumption scenarios (TC-19): restricted CMS content and files must be denied at their Display Page Template URL to unauthenticated and unauthorized users, while remaining accessible to authorized members. The rest of TC-19 (DPT rendering, fragment mapping, multilingual, search, scheduling, collection browsing) is already covered by sibling epic suites, so this PR focuses on the denial thread not covered elsewhere.

## How It Is Being Fixed

Adds a new restricted-access.main project under tests/e2e-cms-dxp with three specs. Each builds a Display Page Template, a restricted Basic Web Content, Structured Content, or file entry, and a custom regular role, then grants VIEW (and DOWNLOAD_FILE for files) to that role only, adding a member user to it. restrictedBasicWebContent covers a GUEST being denied the content body and a member rendering it (TC-19.g, TC-19.j). restrictedStructuredContent covers a GUEST and a non-member signed-in user being denied while a member renders it (TC-19.h, TC-19.k). restrictedFile covers a GUEST being denied at the DPT URL with the file binary not served, while a member downloads it (TC-19.i). The restricted-item exclusion from search and collection surfaces is deferred to the sibling site-search and collection suites that own those surfaces.

## PR Check

**pr-check: PASS** — tested on `7d1ecee1969343d80692602875b21b8087855985`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "7d1ecee1969343d80692602875b21b8087855985"} -->
