### PR TITLE
LPD-97553 Shrink the Recycle Bin Poshi test suite

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
@@ -544,7 +544,7 @@ definition {
 
 	@description = "This is a test for LPS-190757. The Home folder of document should be visible on Warning modal."
 	@priority = 5
-	test RestoreDocumentToExistingFolder {
+	test RestoreContentToExistingFolder {
 		property portal.acceptance = "true";
 
 		task ("Given a site administrator has folders with documents") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
@@ -542,7 +542,7 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-190757. The Home folder of document should be visible on Warning modal."
+	@description = "This is a test for LPS-190757. The Home folder of document and web content should be visible on Warning modal."
 	@priority = 5
 	test RestoreContentToExistingFolder {
 		property portal.acceptance = "true";
@@ -606,11 +606,7 @@ definition {
 
 			DMDocument.viewCP(dmDocumentTitle = "DM Document Title 3");
 		}
-	}
 
-	@description = "This is a test for LPS-190757. The Home folder of web content should be visible on Warning modal."
-	@priority = 4
-	test RestoreWebContentToExistingFolder {
 		task ("Given a site administrator has folders with web contents") {
 			for (var i : list "1,2") {
 				JSONWebcontent.addFolder(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
@@ -651,12 +651,8 @@ definition {
 
 			RecycleBin.viewDuplicateNames(assetName = "WC WebContent Title");
 		}
-	}
 
-	@description = "Can have 2 duplicate folder names in recycle bin."
-	@priority = 4
-	test ViewDuplicateFolderNamesInRecycleBin {
-		task ("View 2 web content with same title exist") {
+		task ("Add a web content folder and move it to recycle bin") {
 			JSONWebcontent.addFolder(
 				folderName = "WC Folder Name",
 				groupName = "Test Site Name");
@@ -668,7 +664,7 @@ definition {
 				folderName = "WC Folder Name");
 		}
 
-		task ("View 2 web content with same title exist") {
+		task ("View folder exists in recycle bin") {
 			RecycleBin.openRecycleBinAdmin(siteURLKey = "test-site-name");
 
 			RecycleBin.viewCP(
@@ -677,7 +673,7 @@ definition {
 				deleteUser = "Test Test");
 		}
 
-		task ("View 2 web content with same title exist") {
+		task ("Add a same name folder and move it to recycle bin") {
 			JSONWebcontent.addFolder(
 				folderName = "WC Folder Name",
 				groupName = "Test Site Name");
@@ -689,7 +685,7 @@ definition {
 				folderName = "WC Folder Name");
 		}
 
-		task ("View 2 web content with same title exist") {
+		task ("View 2 folders with same name exist") {
 			RecycleBin.openRecycleBinAdmin(siteURLKey = "test-site-name");
 
 			RecycleBin.viewDuplicateNames(assetName = "WC Folder Name");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
@@ -84,41 +84,6 @@ definition {
 		}
 	}
 
-	@description = "Move folder with web content to recycle bin."
-	@priority = 3
-	test MoveFolderWithWebContentToRecycleBin {
-		task ("Add a wc folder and web content in the folder") {
-			JSONWebcontent.addFolder(
-				folderName = "WC Folder Name",
-				groupName = "Test Site Name");
-
-			JSONWebcontent.addWebContent(
-				content = "WC WebContent Content",
-				folderName = "WC Folder Name",
-				groupName = "Test Site Name",
-				title = "WC WebContent Title");
-		}
-
-		task ("Move the folder with web content to recycle bin") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			WebContentFolder.moveToRecycleBinCP(
-				assetType = "Web Content Folder",
-				folderName = "WC Folder Name");
-		}
-
-		task ("Assert asset does not exist in web content and exists in recycle bin") {
-			WebContent.viewDefaultCP(webContentTitle = "WC Folder Name");
-
-			RecycleBin.openRecycleBinAdmin(siteURLKey = "test-site-name");
-
-			RecycleBin.viewCP(
-				assetName = "WC Folder Name",
-				assetType = "Web Content Folder",
-				deleteUser = "Test Test");
-		}
-	}
-
 	@description = "This is a use case for LPS-123274. Can move web content to recycle bin via drag and drop."
 	@priority = 3
 	test MoveWebContentToRecycleBinViaDragAndDrop {
@@ -411,7 +376,7 @@ definition {
 		}
 	}
 
-	@description = "Can restore web content within WC folder in recycle bin."
+	@description = "Can move a WC folder with web content to the recycle bin and restore the web content within it."
 	@priority = 3
 	test RestoreWebContentFromFolderCP {
 		task ("Add a WC folder and a web content to it") {
@@ -426,13 +391,24 @@ definition {
 				title = "Web Content Title");
 		}
 
-		task ("Move WC folder to recycle bin and restore the WC") {
+		task ("Move WC folder to recycle bin and assert it exists in recycle bin") {
 			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
 			WebContentFolder.moveToRecycleBinCP(
 				assetType = "Web Content Folder",
 				folderName = "WC Folder Name");
 
+			WebContent.viewDefaultCP(webContentTitle = "WC Folder Name");
+
+			RecycleBin.openRecycleBinAdmin(siteURLKey = "test-site-name");
+
+			RecycleBin.viewCP(
+				assetName = "WC Folder Name",
+				assetType = "Web Content Folder",
+				deleteUser = "Test Test");
+		}
+
+		task ("Restore the WC from the folder in recycle bin") {
 			RecycleBin.openRecycleBinAdmin(siteURLKey = "test-site-name");
 
 			RecycleBin.restoreContentFromFolderCP(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
@@ -614,7 +614,7 @@ definition {
 
 	@description = "Can have 2 duplicate asset names in recycle bin."
 	@priority = 3
-	test ViewDuplicateAssetNamesInRecycleBin {
+	test ViewDuplicateNamesInRecycleBin {
 		task ("Add a web content and move it to recycle bin via delete icon") {
 			JSONWebcontent.addWebContent(
 				content = "WC WebContent Content",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97553

## What Is Being Fixed

Ahead of migrating the Recycle Bin suite to Playwright, its Poshi tests contained overlapping cases that assert the same behavior across different asset types, inflating the suite the migration has to port.

## How It Is Being Fixed

Three overlapping tests are merged into keepers across two files, preserving every unique assertion. In RecycleBin.testcase, RestoreDocumentToExistingFolder and RestoreWebContentToExistingFolder both verified the LPS-190757 warning-modal behavior for restoring folder content, differing only in asset type, so they are merged into RestoreContentToExistingFolder. In RecycleBinWithWebContent.testcase, ViewDuplicateFolderNamesInRecycleBin is folded into ViewDuplicateNamesInRecycleBin (article plus folder duplicates), and MoveFolderWithWebContentToRecycleBin is folded into RestoreWebContentFromFolderCP, whose setup already moved a folder to the Recycle Bin. RecycleBinWithKeyboard.testcase is untouched. The suite goes from 28 to 25 tests with no change to pass/fail behavior.

## Why Are There No Tests?

This is a Poshi shrink pass: it only merges existing tests and touches no product code, so no new coverage applies. Every unique assertion from each merged test was carried into its keeper.

## PR Check

**pr-check: PASS** — tested on `9b095c2da2353f196d9f47591489ba5d0a7fb1a1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "9b095c2da2353f196d9f47591489ba5d0a7fb1a1"} -->
