### PR TITLE
LPD-97592 Prevent LPD-70396 from breaking Commerce category URLs

### DIFF
--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/asset/display/page/portlet/AssetCategoryAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/asset/display/page/portlet/AssetCategoryAssetDisplayPageFriendlyURLResolver.java
@@ -10,10 +10,8 @@ import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLRes
 import com.liferay.asset.display.page.util.AssetDisplayPageUtil;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetTag;
-import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.commerce.product.configuration.CPDisplayLayoutConfiguration;
 import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.constants.CPPortletKeys;
@@ -22,18 +20,15 @@ import com.liferay.commerce.product.model.CommerceChannel;
 import com.liferay.commerce.product.service.CPDisplayLayoutLocalService;
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
 import com.liferay.commerce.product.url.CPFriendlyURL;
-import com.liferay.friendly.url.constants.FriendlyURLEntryConstants;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -50,7 +45,6 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -204,53 +198,8 @@ public class AssetCategoryAssetDisplayPageFriendlyURLResolver
 	private FriendlyURLEntry _fetchAssetCategoryFriendlyURLEntry(
 		long groupId, String urlTitle) {
 
-		long classNameId = _portal.getClassNameId(AssetCategory.class);
-
-		Group group = _groupLocalService.fetchGroup(groupId);
-
-		if ((group == null) ||
-			!FeatureFlagManagerUtil.isEnabled(
-				group.getCompanyId(), "LPD-70396") ||
-			!urlTitle.contains(StringPool.SLASH)) {
-
-			return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
-				groupId, classNameId,
-				FriendlyURLEntryConstants.
-					FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
-				urlTitle);
-		}
-
-		String[] parts = StringUtil.split(urlTitle, CharPool.SLASH);
-
-		if (parts.length < 2) {
-			return null;
-		}
-
-		AssetVocabulary assetVocabulary =
-			_assetVocabularyLocalService.fetchGroupVocabulary(
-				groupId, parts[0]);
-
-		if (assetVocabulary == null) {
-			return null;
-		}
-
-		FriendlyURLEntry friendlyURLEntry = null;
-
-		long parentClassPK = assetVocabulary.getVocabularyId();
-
-		for (int i = 1; i < parts.length; i++) {
-			friendlyURLEntry =
-				_friendlyURLEntryLocalService.fetchFriendlyURLEntry(
-					groupId, classNameId, parentClassPK, parts[i]);
-
-			if (friendlyURLEntry == null) {
-				return null;
-			}
-
-			parentClassPK = friendlyURLEntry.getClassPK();
-		}
-
-		return friendlyURLEntry;
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+			groupId, _portal.getClassNameId(AssetCategory.class), urlTitle);
 	}
 
 	private Layout _getAssetCategoryLayout(
@@ -389,9 +338,6 @@ public class AssetCategoryAssetDisplayPageFriendlyURLResolver
 
 	@Reference
 	private AssetTagLocalService _assetTagLocalService;
-
-	@Reference
-	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Reference
 	private CommerceChannelLocalService _commerceChannelLocalService;

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/product/content/web/internal/asset/display/page/portlet/test/AssetCategoryAssetDisplayPageFriendlyURLResolverTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/product/content/web/internal/asset/display/page/portlet/test/AssetCategoryAssetDisplayPageFriendlyURLResolverTest.java
@@ -1,0 +1,212 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.product.content.web.internal.asset.display.page.portlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.commerce.currency.model.CommerceCurrency;
+import com.liferay.commerce.currency.test.util.CommerceCurrencyTestUtil;
+import com.liferay.commerce.product.importer.CPFileImporter;
+import com.liferay.commerce.test.util.CommerceTestUtil;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.InputStream;
+
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class AssetCategoryAssetDisplayPageFriendlyURLResolverTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_company = CompanyLocalServiceUtil.getCompany(_group.getCompanyId());
+
+		CommerceCurrency commerceCurrency =
+			CommerceCurrencyTestUtil.addCommerceCurrency(
+				_company.getCompanyId());
+
+		CommerceTestUtil.addCommerceChannel(
+			_group.getGroupId(), commerceCurrency.getCode());
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_company.getCompanyId(), _group.getGroupId(),
+			TestPropsValues.getUserId());
+
+		InputStream inputStream =
+			AssetCategoryAssetDisplayPageFriendlyURLResolverTest.class.
+				getResourceAsStream("dependencies/layouts.json");
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray(
+			StringUtil.read(inputStream));
+
+		_cpFileImporter.createLayouts(
+			jsonArray,
+			AssetCategoryAssetDisplayPageFriendlyURLResolverTest.class.
+				getClassLoader(),
+			null, _serviceContext);
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testGetLayoutFriendlyURLCompositeWithFlatEntry()
+		throws Exception {
+
+		AssetCategory assetCategory = _addAssetCategory();
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+				_portal.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		_assertResolves(friendlyURLEntry);
+	}
+
+	@Test
+	public void testGetLayoutFriendlyURLCompositeWithHierarchicalEntry()
+		throws Exception {
+
+		AssetCategory assetCategory = _addAssetCategory();
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+				_portal.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		String languageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
+
+		// Reproduce the state left by the LPD-70396 backfill: the friendly URL
+		// entry is reparented from the flat default to the vocabulary, so the
+		// legacy flat lookup at PARENT_CLASS_PK_DEFAULT no longer finds it.
+
+		_friendlyURLEntryLocalService.updateFriendlyURLEntry(
+			friendlyURLEntry.getFriendlyURLEntryId(),
+			_portal.getClassNameId(AssetCategory.class),
+			assetCategory.getVocabularyId(), assetCategory.getCategoryId(),
+			languageId,
+			Collections.singletonMap(
+				languageId, friendlyURLEntry.getUrlTitle(languageId)),
+			_serviceContext);
+
+		_assertResolves(friendlyURLEntry);
+	}
+
+	private AssetCategory _addAssetCategory() throws Exception {
+
+		// The Commerce category resolver looks up the friendly URL entry in the
+		// company group, so the category must live there for /g/ to resolve.
+
+		_assetVocabulary = _assetVocabularyLocalService.addVocabulary(
+			TestPropsValues.getUserId(), _company.getGroupId(),
+			RandomTestUtil.randomString(), _serviceContext);
+
+		return _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _company.getGroupId(),
+			RandomTestUtil.randomString(), _assetVocabulary.getVocabularyId(),
+			_serviceContext);
+	}
+
+	private void _assertResolves(FriendlyURLEntry friendlyURLEntry)
+		throws Exception {
+
+		String urlTitle = friendlyURLEntry.getUrlTitle(
+			LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
+
+		String friendlyURL = _friendlyURLResolver.getURLSeparator() + urlTitle;
+
+		Assert.assertNotNull(
+			_friendlyURLResolver.getLayoutFriendlyURLComposite(
+				_company.getCompanyId(), _group.getGroupId(), false,
+				friendlyURL, Collections.<String, String[]>emptyMap(),
+				Collections.<String, Object>singletonMap(
+					WebKeys.LOCALE, LocaleUtil.getSiteDefault())));
+	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@DeleteAfterTestRun
+	private AssetVocabulary _assetVocabulary;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	private Company _company;
+
+	@Inject
+	private CPFileImporter _cpFileImporter;
+
+	@Inject
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.commerce.product.content.web.internal.asset.display.page.portlet.AssetCategoryAssetDisplayPageFriendlyURLResolver"
+	)
+	private FriendlyURLResolver _friendlyURLResolver;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private JSONFactory _jsonFactory;
+
+	@Inject
+	private Portal _portal;
+
+	private ServiceContext _serviceContext;
+
+}

--- a/modules/apps/commerce/commerce-test/src/testIntegration/resources/com/liferay/commerce/product/content/web/internal/asset/display/page/portlet/test/dependencies/layouts.json
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/resources/com/liferay/commerce/product/content/web/internal/asset/display/page/portlet/test/dependencies/layouts.json
@@ -1,0 +1,14 @@
+[
+	{
+		"layoutTemplateId": "1_column",
+		"name": "Category",
+		"portlets": [
+			{
+				"layoutColumnId": "column-1",
+				"layoutColumnPos": 0,
+				"portletName": "com_liferay_commerce_product_content_web_internal_portlet_CPCategoryContentPortlet"
+			}
+		],
+		"privateLayout": false
+	}
+]

--- a/modules/apps/friendly-url/friendly-url-api/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL API
 Bundle-SymbolicName: com.liferay.friendly.url.api
-Bundle-Version: 13.2.1
+Bundle-Version: 13.3.0
 Export-Package:\
 	com.liferay.friendly.url.checker,\
 	com.liferay.friendly.url.configuration,\

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -248,6 +248,10 @@ public interface FriendlyURLEntryLocalService
 	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, long parentClassPK, String urlTitle);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle);
+
 	/**
 	 * Returns the friendly url entry matching the UUID and group.
 	 *
@@ -521,4 +525,4 @@ public interface FriendlyURLEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1460019721
+// LIFERAY-SERVICE-BUILDER-HASH:-1021384353

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -294,6 +294,13 @@ public class FriendlyURLEntryLocalServiceUtil {
 			groupId, classNameId, parentClassPK, urlTitle);
 	}
 
+	public static FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle) {
+
+		return getService().fetchFriendlyURLEntry(
+			groupId, classNameId, urlTitle);
+	}
+
 	/**
 	 * Returns the friendly url entry matching the UUID and group.
 	 *
@@ -717,4 +724,4 @@ public class FriendlyURLEntryLocalServiceUtil {
 			FriendlyURLEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2066583604
+// LIFERAY-SERVICE-BUILDER-HASH:-1252061885

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -326,6 +326,14 @@ public class FriendlyURLEntryLocalServiceWrapper
 			groupId, classNameId, parentClassPK, urlTitle);
 	}
 
+	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle) {
+
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+			groupId, classNameId, urlTitle);
+	}
+
 	/**
 	 * Returns the friendly url entry matching the UUID and group.
 	 *
@@ -830,4 +838,4 @@ public class FriendlyURLEntryLocalServiceWrapper
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-765987413
+// LIFERAY-SERVICE-BUILDER-HASH:89411744

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationPersistence.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationPersistence.java
@@ -141,6 +141,77 @@ public interface FriendlyURLEntryLocalizationPersistence
 		long friendlyURLEntryId, String languageId);
 
 	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization findByG_C_U_First(
+			long groupId, long classNameId, String urlTitle,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_U_First(
+		long groupId, long classNameId, String urlTitle,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator);
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 */
+	public void removeByG_C_U(long groupId, long classNameId, String urlTitle);
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public int countByG_C_U(long groupId, long classNameId, String urlTitle);
+
+	/**
 	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and parentClassPK = &#63; and urlTitle = &#63;.
 	 *
 	 * <p>
@@ -717,6 +788,69 @@ public interface FriendlyURLEntryLocalizationPersistence
 	}
 
 	/**
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localizations
+	 */
+	public default java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle) {
+
+		return findByG_C_U(
+			groupId, classNameId, urlTitle,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
+	 */
+	public default java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end) {
+
+		return findByG_C_U(
+			groupId, classNameId, urlTitle, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public default java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return findByG_C_U(
+			groupId, classNameId, urlTitle, start, end, orderByComparator,
+			true);
+	}
+
+	/**
 	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and parentClassPK = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -924,4 +1058,4 @@ public interface FriendlyURLEntryLocalizationPersistence
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1155070658
+// LIFERAY-SERVICE-BUILDER-HASH:-979045191

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationUtil.java
@@ -276,6 +276,96 @@ public class FriendlyURLEntryLocalizationUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_U(
+			groupId, classNameId, urlTitle, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization findByG_C_U_First(
+			long groupId, long classNameId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_U_First(
+			groupId, classNameId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_U_First(
+		long groupId, long classNameId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().fetchByG_C_U_First(
+			groupId, classNameId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 */
+	public static void removeByG_C_U(
+		long groupId, long classNameId, String urlTitle) {
+
+		getPersistence().removeByG_C_U(groupId, classNameId, urlTitle);
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public static int countByG_C_U(
+		long groupId, long classNameId, String urlTitle) {
+
+		return getPersistence().countByG_C_U(groupId, classNameId, urlTitle);
+	}
+
+	/**
 	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and parentClassPK = &#63; and urlTitle = &#63;.
 	 *
 	 * <p>
@@ -980,6 +1070,64 @@ public class FriendlyURLEntryLocalizationUtil {
 	}
 
 	/**
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle) {
+
+		return getPersistence().findByG_C_U(groupId, classNameId, urlTitle);
+	}
+
+	/**
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end) {
+
+		return getPersistence().findByG_C_U(
+			groupId, classNameId, urlTitle, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().findByG_C_U(
+			groupId, classNameId, urlTitle, start, end, orderByComparator);
+	}
+
+	/**
 	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and parentClassPK = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -1189,4 +1337,4 @@ public class FriendlyURLEntryLocalizationUtil {
 		_persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1221548807
+// LIFERAY-SERVICE-BUILDER-HASH:-1827048853

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/persistence/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/friendly-url/friendly-url-service/service.xml
+++ b/modules/apps/friendly-url/friendly-url-service/service.xml
@@ -36,6 +36,11 @@
 
 			<!-- Finder methods -->
 
+			<finder name="G_C_U" return-type="Collection">
+				<finder-column name="groupId" />
+				<finder-column name="classNameId" />
+				<finder-column name="urlTitle" />
+			</finder>
 			<finder name="G_C_P_U" return-type="Collection">
 				<finder-column name="groupId" />
 				<finder-column name="classNameId" />

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -355,6 +355,23 @@ public class FriendlyURLEntryLocalServiceImpl
 	}
 
 	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle) {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			friendlyURLEntryLocalizationPersistence.fetchByG_C_U_First(
+				groupId, classNameId,
+				_friendlyURLNormalizer.normalizeWithEncoding(urlTitle), null);
+
+		if (friendlyURLEntryLocalization == null) {
+			return null;
+		}
+
+		return friendlyURLEntryPersistence.fetchByPrimaryKey(
+			friendlyURLEntryLocalization.getFriendlyURLEntryId());
+	}
+
+	@Override
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long groupId, long classNameId, long parentClassPK, String urlTitle) {
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryLocalizationPersistenceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryLocalizationPersistenceImpl.java
@@ -242,6 +242,105 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 	private CollectionPersistenceFinder
 		<FriendlyURLEntryLocalization,
 		 NoSuchFriendlyURLEntryLocalizationException>
+			_collectionPersistenceFinderByG_C_U;
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	@Override
+	public List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByG_C_U.find(
+			finderCache, new Object[] {groupId, classNameId, urlTitle}, start,
+			end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization findByG_C_U_First(
+			long groupId, long classNameId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		return _collectionPersistenceFinderByG_C_U.findFirst(
+			finderCache, new Object[] {groupId, classNameId, urlTitle},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_U_First(
+		long groupId, long classNameId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return _collectionPersistenceFinderByG_C_U.fetchFirst(
+			finderCache, new Object[] {groupId, classNameId, urlTitle},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 */
+	@Override
+	public void removeByG_C_U(long groupId, long classNameId, String urlTitle) {
+		_collectionPersistenceFinderByG_C_U.remove(
+			finderCache, new Object[] {groupId, classNameId, urlTitle});
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	@Override
+	public int countByG_C_U(long groupId, long classNameId, String urlTitle) {
+		return _collectionPersistenceFinderByG_C_U.count(
+			finderCache, new Object[] {groupId, classNameId, urlTitle});
+	}
+
+	private CollectionPersistenceFinder
+		<FriendlyURLEntryLocalization,
+		 NoSuchFriendlyURLEntryLocalizationException>
 			_collectionPersistenceFinderByG_C_P_U;
 
 	/**
@@ -1218,6 +1317,49 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					FriendlyURLEntryLocalization::getLanguageId));
 
+		_collectionPersistenceFinderByG_C_U = new CollectionPersistenceFinder<>(
+			this,
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_U",
+				new String[] {
+					Long.class.getName(), Long.class.getName(),
+					String.class.getName(), Integer.class.getName(),
+					Integer.class.getName(), OrderByComparator.class.getName()
+				},
+				new String[] {"groupId", "classNameId", "urlTitle"}, true),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_U",
+				new String[] {
+					Long.class.getName(), Long.class.getName(),
+					String.class.getName()
+				},
+				new String[] {"groupId", "classNameId", "urlTitle"}, 0, 4, true,
+				null),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_U",
+				new String[] {
+					Long.class.getName(), Long.class.getName(),
+					String.class.getName()
+				},
+				new String[] {"groupId", "classNameId", "urlTitle"}, 0, 4,
+				false, null),
+			_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE,
+			_SQL_COUNT_FRIENDLYURLENTRYLOCALIZATION_WHERE,
+			FriendlyURLEntryLocalizationModelImpl.ORDER_BY_JPQL,
+			_ENTITY_ALIAS_PREFIX, "", "", null,
+			new FinderColumn<>(
+				"friendlyURLEntryLocalization.", "groupId",
+				FinderColumn.Type.LONG, "=", true, true,
+				FriendlyURLEntryLocalization::getGroupId),
+			new FinderColumn<>(
+				"friendlyURLEntryLocalization.", "classNameId",
+				FinderColumn.Type.LONG, "=", true, true,
+				FriendlyURLEntryLocalization::getClassNameId),
+			new FinderColumn<>(
+				"friendlyURLEntryLocalization.", "urlTitle",
+				FinderColumn.Type.STRING, "=", true, true,
+				FriendlyURLEntryLocalization::getUrlTitle));
+
 		_collectionPersistenceFinderByG_C_P_U =
 			new CollectionPersistenceFinder<>(
 				this,
@@ -1548,4 +1690,4 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:569006636
+// LIFERAY-SERVICE-BUILDER-HASH:-1381039834

--- a/modules/apps/friendly-url/friendly-url-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/resources/META-INF/sql/indexes.sql
@@ -3,7 +3,7 @@ create index IX_F3DC928B on FriendlyURLEntry (groupId, classNameId, classPK);
 create unique index IX_D51F1A48 on FriendlyURLEntry (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
 create index IX_2B00D1D3 on FriendlyURLEntryLocalization (classNameId, groupId, languageId[$COLUMN_LENGTH:75$], classPK);
-create unique index IX_4B550BAA on FriendlyURLEntryLocalization (classNameId, groupId, languageId[$COLUMN_LENGTH:75$], urlTitle[$COLUMN_LENGTH:255$], parentClassPK, ctCollectionId);
+create unique index IX_7FE9DA6A on FriendlyURLEntryLocalization (classNameId, groupId, urlTitle[$COLUMN_LENGTH:255$], languageId[$COLUMN_LENGTH:75$], parentClassPK, ctCollectionId);
 create index IX_B5E04A33 on FriendlyURLEntryLocalization (classNameId, groupId, urlTitle[$COLUMN_LENGTH:255$], parentClassPK);
 create index IX_8EAFA9A8 on FriendlyURLEntryLocalization (classNameId, urlTitle[$COLUMN_LENGTH:255$], companyId, ctCollectionId);
 create index IX_BFA6E36A on FriendlyURLEntryLocalization (friendlyURLEntryId);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/resources/service.properties
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.friendly.url.service
-    build.number=4
-    build.date=1779951572280
+    build.number=5
+    build.date=1783514874405

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
@@ -202,6 +202,16 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_C_U() throws Exception {
+		_persistence.countByG_C_U(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_C_U(0L, 0L, "null");
+
+		_persistence.countByG_C_U(0L, 0L, (String)null);
+	}
+
+	@Test
 	public void testCountByG_C_P_U() throws Exception {
 		_persistence.countByG_C_P_U(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
@@ -652,4 +662,4 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1803230131
+// LIFERAY-SERVICE-BUILDER-HASH:-1448802319


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97592

## What Is Being Fixed

The "friendly category URLs by name" feature (epic LPD-70396 / LPD-90910) added per-parent (`parentClassPK`) uniqueness to `FriendlyURLEntry` and a flag-gated hierarchical resolver for the display-page `/v/` URLs. As part of that work the shared `FriendlyURLEntryLocalService` lookup finder gained a `parentClassPK` column (`G_C_U` was replaced by `G_C_P_U`), and the Commerce category resolver (`AssetCategoryAssetDisplayPageFriendlyURLResolver`) was changed to look up at `PARENT_CLASS_PK_DEFAULT` behind the `LPD-70396` flag.

As a result, when the `LPD-70396` feature flag is enabled, Commerce storefront category URLs (`/g/<slug>`) return 404. The flag's backfill (`AssetCategoryFriendlyURLFeatureFlagListener`) re-parents each category's `FriendlyURLEntry` from the flat `parentClassPK=0` to `parentClassPK=vocabularyId`, but the Commerce resolver still looked it up at `parentClassPK=0`, so the entry was no longer found.

## How It Is Being Fixed

The goal is to make LPD-70396 a no-op for the Commerce `/g/` path, so Commerce category resolution behaves exactly as it did before LPD-90910, independent of the flag, while the general `/v/` feature keeps working. The Commerce team can decide separately whether to adopt the hierarchical scheme.

The parent-agnostic `G_C_U` finder and the `fetchFriendlyURLEntry(long groupId, long classNameId, String urlTitle)` service method that LPD-90910 removed are restored. The restored finder coexists with the `G_C_P_U` finder the general feature uses and reuses the existing localization index, so no new database index is introduced. The Commerce resolver is reverted to the pre-LPD-90910 lookup: it resolves the category by url title in the company group ignoring `parentClassPK` and no longer references the `LPD-70396` flag. Because the lookup no longer filters by `parentClassPK`, it resolves the category whether its entry is flat (flag off) or re-parented to the vocabulary (flag on). The general LPD-70396 listeners, per-parent uniqueness, and `/v/` display-page resolution are left untouched.

## Tests

A new integration test `AssetCategoryAssetDisplayPageFriendlyURLResolverTest` in `commerce-test` resolves `/g/<slug>` for a flat entry (`parentClassPK=0`) and for a hierarchical entry re-parented to the vocabulary (the flag-on state produced by the backfill); both pass, and the hierarchical case fails without this fix. The related regression tests were run green: the `FriendlyURLEntryLocalServiceImpl` unit test, the `FriendlyURLEntryLocalServiceTest` integration test, `CommerceSitemapURLProviderTest`, `FriendlyURLServletTest`, and `CommerceOrderAssetDisplayPageFriendlyURLResolverTest`. The change was also validated end-to-end on a Commerce site created with the Commerce site initializer: with `LPD-70396` enabled, the catalog categories' friendly URL entries re-parent to `parentClassPK=vocabularyId` (verified in the database) and `/g/<slug>` still resolves in the storefront.

## PR Check

**pr-check: PASS** — tested on `eb7f47cdaca9ec7192ecea96e0ecf7c64b6e0e0c`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "eb7f47cdaca9ec7192ecea96e0ecf7c64b6e0e0c"} -->
