### PR TITLE
LPD-97625 Provision the CMS environment for the e2e-cms-dxp tests

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/config.ts
@@ -4,6 +4,7 @@
  */
 
 export const config = {
+	dependencies: ['site-cms-site.main'],
 	name: 'e2e-cms-dxp.main',
 	testDir: 'tests/e2e-cms-dxp/main',
 };


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97625

## What Is Being Fixed

The e2e-cms-dxp Playwright tests fail in the upstream cms suite (batch `playwright-js-tomcat101-postgresql163`). The failures split into two symptoms with one root cause:

- Tests that create a Space asset library fail at setup with `POST /o/headless-asset-library/v1.0/asset-libraries` returning `400 UnsupportedOperationException`, because the LPD-17564 feature flag is not effective (e.g. translations, structuredContentDPT).
- The display page template tests (fileDPT, pdfDPT, friendlyURLDPT) time out on `selectOption('Content Type')` because CMS content types such as Basic Document / CMSBasicDocument are never provisioned, so the option is missing from the dropdown.

Both stem from the same cause: the `e2e-cms-dxp.main` Playwright project, consolidated in LPD-97452, never declared a dependency on the `site-cms-site.main` setup project. Without it the CMS environment is not provisioned before the tests run - neither the LPD-17564 flag transition nor the CMS object definitions created by the CMS site initializer.

## How It Is Being Fixed

Add `dependencies: ['site-cms-site.main']` to `tests/e2e-cms-dxp/main/config.ts`, mirroring the `site-cms-site-initializer` projects. Playwright now runs the `site-cms-site.main` setup (enables LPD-34594 then LPD-17564 in dependency order, triggers the CMS site initializer, and creates the shared Space) before the e2e-cms-dxp tests, and `site-cms-site.teardown` afterwards. Verified with `playwright test --list`: the `e2e-cms-dxp.main` project now chains `site-cms-site.main` and `site-cms-site.teardown`.

## Why Are There No Tests?

This change only wires the existing e2e-cms-dxp Playwright project to the CMS setup project. It is a test-infrastructure fix for tests that already exist; no new test is warranted.

## PR Check

**pr-check: PASS** - tested on `1940170c25b8ade1dac2dc8328a31e0d0721a5e1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Config load / dependency resolves (playwright `--list`) | PASS |

<!-- pr-check {"result": "success", "sha": "1940170c25b8ade1dac2dc8328a31e0d0721a5e1"} -->
