### PR TITLE
LPD-97572 Hide the Space tab when selecting legacy content

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.search.GroupSearch;
 
@@ -117,7 +118,7 @@ public class GroupSelectorDisplayContext {
 			if (parts.contains("file") || parts.contains("folder") ||
 				parts.contains("image") ||
 				(parts.contains("infoitem") &&
-				 _isJournalArticleItemSelectorCriterion())) {
+				 _isLegacyAssetItemSelectorCriterion())) {
 
 				groupItemSelectorProviderTypes.remove("space-depot");
 
@@ -244,7 +245,7 @@ public class GroupSelectorDisplayContext {
 		return _selectedTab;
 	}
 
-	private boolean _isJournalArticleItemSelectorCriterion() {
+	private boolean _isLegacyAssetItemSelectorCriterion() {
 		ItemSelector itemSelector = _getItemSelector();
 
 		for (ItemSelectorCriterion itemSelectorCriterion :
@@ -268,6 +269,16 @@ public class GroupSelectorDisplayContext {
 			}
 		}
 
+		String selectedTab = _getSelectedTab();
+
+		if (Validator.isNotNull(selectedTab) &&
+			!selectedTab.startsWith(
+				_CLASS_NAME_OBJECT_ENTRY_ITEM_SELECTOR_VIEW +
+					StringPool.UNDERLINE)) {
+
+			return true;
+		}
+
 		return false;
 	}
 
@@ -281,6 +292,10 @@ public class GroupSelectorDisplayContext {
 
 		return _scopeGroupType;
 	}
+
+	private static final String _CLASS_NAME_OBJECT_ENTRY_ITEM_SELECTOR_VIEW =
+		"com.liferay.object.web.internal.item.selector." +
+			"ObjectEntryItemSelectorView";
 
 	private String _groupType;
 	private final LiferayPortletRequest _liferayPortletRequest;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
@@ -242,6 +242,12 @@ public class GroupSelectorDisplayContext {
 		_selectedTab = ParamUtil.getString(
 			_liferayPortletRequest, "selectedTab");
 
+		if (Validator.isNull(_selectedTab)) {
+			_selectedTab = GetterUtil.getString(
+				_liferayPortletRequest.getAttribute(
+					"liferay-item-selector:group-selector:selectedTab"));
+		}
+
 		return _selectedTab;
 	}
 

--- a/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
@@ -126,6 +126,7 @@ public class GroupSelectorDisplayContextTest {
 	@Test
 	public void testGetGroupTypes() {
 		_testGetGroupTypesWithoutCMSFeatureFlag();
+		_testGetGroupTypesWithDefaultSelectedTabRequestAttribute();
 		_testGetGroupTypesWithFileItemSelectorCriterion();
 		_testGetGroupTypesWithJournalArticleInfoItemItemSelectorCriterion();
 		_testGetGroupTypesWithLegacyItemSelectorViewSelectedTab();
@@ -146,6 +147,34 @@ public class GroupSelectorDisplayContextTest {
 		);
 
 		return featureFlagManagerUtilMockedStatic;
+	}
+
+	private void _testGetGroupTypesWithDefaultSelectedTabRequestAttribute() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+			mockLiferayResourceRequest.setAttribute(
+				"liferay-item-selector:group-selector:selectedTab",
+				"com.liferay.document.library.item.selector.web.internal." +
+					"info.item.DLInfoItemItemSelectorView_Documents and Media");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
 	}
 
 	private void _testGetGroupTypesWithFileItemSelectorCriterion() {

--- a/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
@@ -128,6 +128,8 @@ public class GroupSelectorDisplayContextTest {
 		_testGetGroupTypesWithoutCMSFeatureFlag();
 		_testGetGroupTypesWithFileItemSelectorCriterion();
 		_testGetGroupTypesWithJournalArticleInfoItemItemSelectorCriterion();
+		_testGetGroupTypesWithLegacyItemSelectorViewSelectedTab();
+		_testGetGroupTypesWithObjectEntryItemSelectorViewSelectedTab();
 		_testGetGroupTypesWithoutJournalArticleInfoItemItemSelectorCriterion();
 	}
 
@@ -190,6 +192,62 @@ public class GroupSelectorDisplayContextTest {
 
 			Assert.assertEquals(
 				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithLegacyItemSelectorViewSelectedTab() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+			mockLiferayResourceRequest.addParameter(
+				"selectedTab",
+				"com.liferay.commerce.order.content.web.internal.item." +
+					"selector.CommerceOrderItemSelectorView_Orders");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithObjectEntryItemSelectorViewSelectedTab() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+			mockLiferayResourceRequest.addParameter(
+				"selectedTab",
+				"com.liferay.object.web.internal.item.selector." +
+					"ObjectEntryItemSelectorView_Basic Web Content");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				SetUtil.fromArray("space-depot", "test"),
 				groupSelectorDisplayContext.getGroupTypes());
 		}
 	}

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/ItemSelectorPortlet.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/ItemSelectorPortlet.java
@@ -5,6 +5,7 @@
 
 package com.liferay.item.selector.web.internal.portlet;
 
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorRendering;
 import com.liferay.item.selector.constants.ItemSelectorPortletKeys;
@@ -12,6 +13,7 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.Portlet;
@@ -20,6 +22,8 @@ import jakarta.portlet.RenderRequest;
 import jakarta.portlet.RenderResponse;
 
 import java.io.IOException;
+
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,7 +73,32 @@ public class ItemSelectorPortlet extends MVCPortlet {
 
 		localizedItemSelectorRendering.store(renderRequest);
 
+		_storeSelectedTab(renderRequest, localizedItemSelectorRendering);
+
 		super.render(renderRequest, renderResponse);
+	}
+
+	private void _storeSelectedTab(
+		RenderRequest renderRequest,
+		LocalizedItemSelectorRendering localizedItemSelectorRendering) {
+
+		NavigationItem activeNavigationItem =
+			localizedItemSelectorRendering.getActiveNavigationItem();
+
+		if (activeNavigationItem == null) {
+			return;
+		}
+
+		Map<String, Object> data =
+			(Map<String, Object>)activeNavigationItem.get("data");
+
+		if (data == null) {
+			return;
+		}
+
+		renderRequest.setAttribute(
+			"liferay-item-selector:group-selector:selectedTab",
+			MapUtil.getString(data, "id"));
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97572
https://liferay.atlassian.net/browse/LPD-97269

## What Is Being Fixed

The Page Editor's content-mapping item selector let users pick web content, documents, blogs, knowledge base articles, and similar legacy DXP assets from a connected CMS Space, even though Spaces never hold that kind of content — Spaces exclusively hold Object-Entry-backed CMS content. The Space tab showed up both when a legacy asset type was explicitly selected and, more subtly, for whichever asset type came pre-selected by default when the mapping modal first opened, before any tab was clicked.

## How It Is Being Fixed

GroupSelectorDisplayContext's existing JournalArticle-only check is generalized into a legacy-asset check that reads the selectedTab parameter identifying which ItemSelectorView is currently active, hiding the Space tab for anything other than the CMS-backed ObjectEntryItemSelectorView. This covers Documents and Media, Blogs, Knowledge Base Articles, Commerce Orders, Commerce Products, and any future legacy type without enumerating each one individually. Separately, the asset type selected by default when the modal first opens is resolved internally by LocalizedItemSelectorRendering and never reaches the selectedTab request parameter, so ItemSelectorPortlet now stores that resolved default as a request attribute that GroupSelectorDisplayContext falls back to when selectedTab itself is blank.

## PR Check

**pr-check: PASS** — tested on `ce31314fa16a1fa5229f131fcd37d7641a9fa68d`

| Validation | Result |
| --- | --- |
| Portlet Title | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Source Format | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ce31314fa16a1fa5229f131fcd37d7641a9fa68d"} -->
