### PR TITLE
LPD-97646 Shrink the Item Selector Poshi test suite

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-api/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-audiences-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Frontend JS Audiences API
 Bundle-SymbolicName: com.liferay.frontend.js.audiences.api
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package: com.liferay.frontend.js.audiences

--- a/modules/apps/frontend-js/frontend-js-audiences-api/src/main/java/com/liferay/frontend/js/audiences/ElementVariations.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-api/src/main/java/com/liferay/frontend/js/audiences/ElementVariations.java
@@ -5,10 +5,12 @@
 
 package com.liferay.frontend.js.audiences;
 
+import java.io.Serializable;
+
 /**
  * @author Iván Zaera Avellón
  */
-public class ElementVariations {
+public class ElementVariations implements Serializable {
 
 	public ElementVariations(String content, String hash) {
 		_content = content;

--- a/modules/apps/frontend-js/frontend-js-audiences-api/src/main/resources/com/liferay/frontend/js/audiences/packageinfo
+++ b/modules/apps/frontend-js/frontend-js-audiences-api/src/main/resources/com/liferay/frontend/js/audiences/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ImageEditor.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ImageEditor.testcase
@@ -26,9 +26,9 @@ definition {
 		}
 	}
 
-	@description = "This makes sure that canceling the image edition will preserve the original image."
-	@priority = 4
-	test CanDiscardChange {
+	@description = "This makes sure that canceling the image edition preserves the original image and that a rotated image can be saved."
+	@priority = 5
+	test CanDiscardAndSaveRotatedImage {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -59,6 +59,28 @@ definition {
 
 		DMDocument.viewDocumentMetadataCP(
 			metadataData = 500,
+			metadataLabel = "Image Width");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+		DMNavigator.gotoEditImage(dmDocumentTitle = "Document_2.jpg");
+
+		ImageEditor.rotateImage();
+
+		ImageEditor.saveChanges();
+
+		Refresh();
+
+		LexiconCard.checkCardCheckbox(card = "Document_2.jpg");
+
+		DMDocument.expandInfo();
+
+		DMDocument.viewDocumentMetadataCP(
+			metadataData = 313,
+			metadataLabel = "Image Length");
+
+		DMDocument.viewDocumentMetadataCP(
+			metadataData = 195,
 			metadataLabel = "Image Width");
 	}
 
@@ -159,42 +181,6 @@ definition {
 
 		DMDocument.viewDocumentMetadataCP(
 			metadataData = 500,
-			metadataLabel = "Image Width");
-	}
-
-	@description = "This makes sure that a rotated image can be saved."
-	@priority = 5
-	test CanSaveRotatedImage {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_2.jpg",
-			groupName = "Guest",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_2.jpg");
-
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
-
-		DMNavigator.gotoEditImage(dmDocumentTitle = "Document_2.jpg");
-
-		ImageEditor.rotateImage();
-
-		ImageEditor.saveChanges();
-
-		Refresh();
-
-		LexiconCard.checkCardCheckbox(card = "Document_2.jpg");
-
-		DMDocument.expandInfo();
-
-		DMDocument.viewDocumentMetadataCP(
-			metadataData = 313,
-			metadataLabel = "Image Length");
-
-		DMDocument.viewDocumentMetadataCP(
-			metadataData = 195,
 			metadataLabel = "Image Width");
 	}
 

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
@@ -111,81 +111,6 @@ definition {
 		NavigationMenusAdmin.viewItem(itemName = "Test Page Name 2");
 	}
 
-	@description = "This test covers LPS-119899 and LPS-119707. It ensures that the search results can be cleared after filtering everywhere in the item selector and that web content in a connected depot folder can be viewed through the everywhere filter."
-	@priority = 4
-	@refactordone
-	test FilterWebContentEverywhere {
-		JSONDepot.addDepot(
-			depotDescription = "This is the description of a depot",
-			depotName = "Test Depot Name");
-
-		JSONWebcontent.addWebContent(
-			content = "Web Content Content From Depot",
-			groupName = "Test Depot Name",
-			site = "false",
-			title = "Web Content From Depot");
-
-		JSONWebcontent.addFolder(
-			folderDescription = "WC Folder Description",
-			folderName = "WC Folder Name",
-			groupName = "Test Depot Name",
-			site = "false");
-
-		JSONWebcontent.addWebContent(
-			content = "Webcontent Content",
-			folderName = "WC Folder Name",
-			groupName = "Test Depot Name",
-			site = "false",
-			title = "WC WebContent From Depot");
-
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONWebcontent.addWebContent(
-			content = "WC WebContent Site",
-			groupName = "Site Name",
-			title = "WC WebContent From Site");
-
-		JSONDepot.connectSite(
-			depotName = "Test Depot Name",
-			groupName = "Site Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
-
-		NavItem.gotoStructures();
-
-		WebContentStructures.addCP(
-			structureDescription = "WC Structure Description",
-			structureName = "WC Structure Name");
-
-		DataEngine.addField(
-			fieldFieldLabel = "Web Content",
-			fieldName = "Web Content");
-
-		WebContentStructures.saveCP(structureName = "WC Structure Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
-
-		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-		Click(
-			fieldLabel = "Web Content",
-			locator1 = "Button#BUTTON_LABEL",
-			text = "Select");
-
-		ItemSelector.viewWCEverywhereFilterResults(webContentTitle = "Web Content From Depot,WC WebContent From Site");
-
-		ItemSelector.clearFilterResults(
-			currentSiteWebContentTitle = "WC WebContent From Site",
-			webContentTitle = "Web Content From Depot");
-
-		ItemSelector.viewWCEverywhereFilterResults(
-			folderWebContentTitle = "WC WebContent From Depot",
-			siteName = "Test Depot Name",
-			viewFolderWc = "true",
-			wcFolderName = "WC Folder Name",
-			webContentTitle = "WC WebContent From Site");
-	}
-
 	@description = "This is a test for LPS-107014. It checks that the site pagination can be displayed correctly in item selector."
 	@priority = 4
 	test CanDisplaySitePaginationCorrectly {
@@ -210,63 +135,6 @@ definition {
 		AssertTextNotPresent(
 			locator1 = "Message#EMPTY_INFO",
 			value1 = "No sites were found.");
-	}
-
-	@description = "This test covers LPS-118808. It ensures that images can be filtered by the current site and that an image in a connected depot folder can be viewed through the everywhere filter."
-	@priority = 5
-	@refactordone
-	test FilterImagesByScope {
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONDepot.addDepot(
-			depotDescription = "This is the description of a depot",
-			depotName = "Test Depot Name");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.jpg",
-			groupName = "Test Depot Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_2.jpg",
-			groupName = "Site Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_2.jpg");
-
-		JSONFolder.addFolder(
-			dmFolderDescription = "DM Folder Description",
-			dmFolderName = "DM Folder Name",
-			groupName = "Test Depot Name");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_3.jpg",
-			folderName = "DM Folder Name",
-			groupName = "Test Depot Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_3.jpg");
-
-		JSONDepot.connectSite(
-			depotName = "Test Depot Name",
-			groupName = "Site Name");
-
-		BlogsNavigator.openToAddEntry(siteURLKey = "site-name");
-
-		BlogsNavigator.gotoSelectFile();
-
-		ItemSelector.viewCurrentSiteFilterResults(
-			imageFileName = "Document_2.jpg",
-			navTab = "Documents and Media",
-			noImageFileName = "Document_1.jpg",
-			viewNoLocationInfo = "Site Name");
-
-		ItemSelector.viewEverywhereFilterResults(
-			dmFolderName = "DM Folder Name",
-			imageFileName = "Document_3.jpg",
-			navTab = "Documents and Media");
 	}
 
 	@description = "This ensures that a message is displayed in the preview section of the item selector when pasting an invalid URL."
@@ -869,6 +737,138 @@ definition {
 		Click(locator1 = "Pagination#NEXT_LINK");
 
 		Pagination.viewResults(results = "Showing 21 to 30 of 30 entries.");
+	}
+
+	@description = "This test covers LPS-118808. It ensures that images can be filtered by the current site and that an image in a connected depot folder can be viewed through the everywhere filter."
+	@priority = 5
+	@refactordone
+	test FilterImagesByScope {
+		HeadlessSite.addSite(siteName = "Site Name");
+
+		JSONDepot.addDepot(
+			depotDescription = "This is the description of a depot",
+			depotName = "Test Depot Name");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Document_1.jpg",
+			groupName = "Test Depot Name",
+			mimeType = "image/jpeg",
+			sourceFileName = "Document_1.jpg");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Document_2.jpg",
+			groupName = "Site Name",
+			mimeType = "image/jpeg",
+			sourceFileName = "Document_2.jpg");
+
+		JSONFolder.addFolder(
+			dmFolderDescription = "DM Folder Description",
+			dmFolderName = "DM Folder Name",
+			groupName = "Test Depot Name");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Document_3.jpg",
+			folderName = "DM Folder Name",
+			groupName = "Test Depot Name",
+			mimeType = "image/jpeg",
+			sourceFileName = "Document_3.jpg");
+
+		JSONDepot.connectSite(
+			depotName = "Test Depot Name",
+			groupName = "Site Name");
+
+		BlogsNavigator.openToAddEntry(siteURLKey = "site-name");
+
+		BlogsNavigator.gotoSelectFile();
+
+		ItemSelector.viewCurrentSiteFilterResults(
+			imageFileName = "Document_2.jpg",
+			navTab = "Documents and Media",
+			noImageFileName = "Document_1.jpg",
+			viewNoLocationInfo = "Site Name");
+
+		ItemSelector.viewEverywhereFilterResults(
+			dmFolderName = "DM Folder Name",
+			imageFileName = "Document_3.jpg",
+			navTab = "Documents and Media");
+	}
+
+	@description = "This test covers LPS-119899 and LPS-119707. It ensures that the search results can be cleared after filtering everywhere in the item selector and that web content in a connected depot folder can be viewed through the everywhere filter."
+	@priority = 4
+	@refactordone
+	test FilterWebContentEverywhere {
+		JSONDepot.addDepot(
+			depotDescription = "This is the description of a depot",
+			depotName = "Test Depot Name");
+
+		JSONWebcontent.addWebContent(
+			content = "Web Content Content From Depot",
+			groupName = "Test Depot Name",
+			site = "false",
+			title = "Web Content From Depot");
+
+		JSONWebcontent.addFolder(
+			folderDescription = "WC Folder Description",
+			folderName = "WC Folder Name",
+			groupName = "Test Depot Name",
+			site = "false");
+
+		JSONWebcontent.addWebContent(
+			content = "Webcontent Content",
+			folderName = "WC Folder Name",
+			groupName = "Test Depot Name",
+			site = "false",
+			title = "WC WebContent From Depot");
+
+		HeadlessSite.addSite(siteName = "Site Name");
+
+		JSONWebcontent.addWebContent(
+			content = "WC WebContent Site",
+			groupName = "Site Name",
+			title = "WC WebContent From Site");
+
+		JSONDepot.connectSite(
+			depotName = "Test Depot Name",
+			groupName = "Site Name");
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
+
+		NavItem.gotoStructures();
+
+		WebContentStructures.addCP(
+			structureDescription = "WC Structure Description",
+			structureName = "WC Structure Name");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Web Content",
+			fieldName = "Web Content");
+
+		WebContentStructures.saveCP(structureName = "WC Structure Name");
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
+
+		Click(
+			fieldLabel = "Web Content",
+			locator1 = "Button#BUTTON_LABEL",
+			text = "Select");
+
+		ItemSelector.viewWCEverywhereFilterResults(webContentTitle = "Web Content From Depot,WC WebContent From Site");
+
+		ItemSelector.clearFilterResults(
+			currentSiteWebContentTitle = "WC WebContent From Site",
+			webContentTitle = "Web Content From Depot");
+
+		ItemSelector.viewWCEverywhereFilterResults(
+			folderWebContentTitle = "WC WebContent From Depot",
+			siteName = "Test Depot Name",
+			viewFolderWc = "true",
+			wcFolderName = "WC Folder Name",
+			webContentTitle = "WC WebContent From Site");
 	}
 
 	@description = "The user should see horizontal nav tabs when less than and equal 5 nav items appear on item selector modal."

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
@@ -1045,9 +1045,9 @@ definition {
 			navTab = "Web Content");
 	}
 
-	@description = "This is a test for LPS-136945. It checks that only 'File Upload', 'Folder', and 'External Video Shortcut' options appear when adding a document."
+	@description = "This test covers LPS-136945 and LPS-136943. It checks that only 'File Upload', 'Folder', and 'External Video Shortcut' options appear when adding a document and that only 'File Upload' and 'Folder' options appear when adding images."
 	@priority = 3
-	test OnlyRelevantSelectionsAppearWhenAddingDocuments {
+	test OnlyRelevantSelectionsAppearWhenAddingItems {
 		property portal.acceptance = "false";
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
@@ -1071,12 +1071,6 @@ definition {
 			locator1 = "Button#ANY_LAST");
 
 		ItemSelector.viewRelevantSelections(addDocumentOptions = "true");
-	}
-
-	@description = "This is a test for LPS-136943. It checks that only 'File Upload' and 'Folder' options appear when adding images."
-	@priority = 3
-	test OnlyRelevantSelectionsAppearWhenAddingImages {
-		property portal.acceptance = "false";
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
 

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
@@ -111,10 +111,10 @@ definition {
 		NavigationMenusAdmin.viewItem(itemName = "Test Page Name 2");
 	}
 
-	@description = "This test covers LPS-119899, It ensures that the search results can be cleared after filtering everywhere in the item selector."
+	@description = "This test covers LPS-119899 and LPS-119707. It ensures that the search results can be cleared after filtering everywhere in the item selector and that web content in a connected depot folder can be viewed through the everywhere filter."
 	@priority = 4
 	@refactordone
-	test CanClearFilterResults {
+	test FilterWebContentEverywhere {
 		JSONDepot.addDepot(
 			depotDescription = "This is the description of a depot",
 			depotName = "Test Depot Name");
@@ -124,6 +124,19 @@ definition {
 			groupName = "Test Depot Name",
 			site = "false",
 			title = "Web Content From Depot");
+
+		JSONWebcontent.addFolder(
+			folderDescription = "WC Folder Description",
+			folderName = "WC Folder Name",
+			groupName = "Test Depot Name",
+			site = "false");
+
+		JSONWebcontent.addWebContent(
+			content = "Webcontent Content",
+			folderName = "WC Folder Name",
+			groupName = "Test Depot Name",
+			site = "false",
+			title = "WC WebContent From Depot");
 
 		HeadlessSite.addSite(siteName = "Site Name");
 
@@ -164,6 +177,13 @@ definition {
 		ItemSelector.clearFilterResults(
 			currentSiteWebContentTitle = "WC WebContent From Site",
 			webContentTitle = "Web Content From Depot");
+
+		ItemSelector.viewWCEverywhereFilterResults(
+			folderWebContentTitle = "WC WebContent From Depot",
+			siteName = "Test Depot Name",
+			viewFolderWc = "true",
+			wcFolderName = "WC Folder Name",
+			webContentTitle = "WC WebContent From Site");
 	}
 
 	@description = "This is a test for LPS-107014. It checks that the site pagination can be displayed correctly in item selector."
@@ -803,69 +823,6 @@ definition {
 			dmFolderName = "DM Folder Name",
 			imageFileName = "Document_2.jpg",
 			navTab = "Documents and Media");
-	}
-
-	@description = "This test covers LPS-119707. It ensures that the web content in the depot folder can be viewed through everywhere filter on a connected site."
-	@priority = 4
-	@refactordone
-	test CanViewFolderWCViaFilterResults {
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONDepot.addDepot(
-			depotDescription = "This is the description of a depot",
-			depotName = "Test Depot Name");
-
-		JSONWebcontent.addFolder(
-			folderDescription = "WC Folder Description",
-			folderName = "WC Folder Name",
-			groupName = "Test Depot Name",
-			site = "false");
-
-		JSONWebcontent.addWebContent(
-			content = "Webcontent Content",
-			folderName = "WC Folder Name",
-			groupName = "Test Depot Name",
-			site = "false",
-			title = "WC WebContent From Depot");
-
-		JSONWebcontent.addWebContent(
-			content = "WC WebContent Site",
-			groupName = "Site Name",
-			title = "WC WebContent From Site");
-
-		JSONDepot.connectSite(
-			depotName = "Test Depot Name",
-			groupName = "Site Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
-
-		NavItem.gotoStructures();
-
-		WebContentStructures.addCP(
-			structureDescription = "WC Structure Description",
-			structureName = "WC Structure Name");
-
-		DataEngine.addField(
-			fieldFieldLabel = "Web Content",
-			fieldName = "Web Content");
-
-		WebContentStructures.saveCP(structureName = "WC Structure Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
-
-		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-		Click(
-			fieldLabel = "Web Content",
-			locator1 = "Button#BUTTON_LABEL",
-			text = "Select");
-
-		ItemSelector.viewWCEverywhereFilterResults(
-			folderWebContentTitle = "WC WebContent From Depot",
-			siteName = "Test Depot Name",
-			viewFolderWc = "true",
-			wcFolderName = "WC Folder Name",
-			webContentTitle = "WC WebContent From Site");
 	}
 
 	@description = "This ensures that the video thumbnails can be viewed in Item Selector."

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
@@ -212,10 +212,10 @@ definition {
 			value1 = "No sites were found.");
 	}
 
-	@description = "This test ensures that documents can filter by the current site in the item selector."
+	@description = "This test covers LPS-118808. It ensures that images can be filtered by the current site and that an image in a connected depot folder can be viewed through the everywhere filter."
 	@priority = 5
 	@refactordone
-	test CanFilterByCurrentSite {
+	test FilterImagesByScope {
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		JSONDepot.addDepot(
@@ -236,6 +236,19 @@ definition {
 			mimeType = "image/jpeg",
 			sourceFileName = "Document_2.jpg");
 
+		JSONFolder.addFolder(
+			dmFolderDescription = "DM Folder Description",
+			dmFolderName = "DM Folder Name",
+			groupName = "Test Depot Name");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Document_3.jpg",
+			folderName = "DM Folder Name",
+			groupName = "Test Depot Name",
+			mimeType = "image/jpeg",
+			sourceFileName = "Document_3.jpg");
+
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");
@@ -249,6 +262,11 @@ definition {
 			navTab = "Documents and Media",
 			noImageFileName = "Document_1.jpg",
 			viewNoLocationInfo = "Site Name");
+
+		ItemSelector.viewEverywhereFilterResults(
+			dmFolderName = "DM Folder Name",
+			imageFileName = "Document_3.jpg",
+			navTab = "Documents and Media");
 	}
 
 	@description = "This ensures that a message is displayed in the preview section of the item selector when pasting an invalid URL."
@@ -679,43 +697,6 @@ definition {
 				navTab = "Documents and Media",
 				titleList = "Document_1.jpg,Document_2.jpg,DM Folder Name");
 		}
-	}
-
-	@description = "This test covers LPS-118808. It ensures that an image in the depot folder can be viewed through everywhere filter on a connected site."
-	@priority = 4
-	@refactordone
-	test CanViewFolderImageViaFilterResults {
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONDepot.addDepot(
-			depotDescription = "This is the description of a depot",
-			depotName = "Test Depot Name");
-
-		JSONFolder.addFolder(
-			dmFolderDescription = "DM Folder Description",
-			dmFolderName = "DM Folder Name",
-			groupName = "Test Depot Name");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_2.jpg",
-			folderName = "DM Folder Name",
-			groupName = "Test Depot Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_2.jpg");
-
-		JSONDepot.connectSite(
-			depotName = "Test Depot Name",
-			groupName = "Site Name");
-
-		BlogsNavigator.openToAddEntry(siteURLKey = "site-name");
-
-		BlogsNavigator.gotoSelectFile();
-
-		ItemSelector.viewEverywhereFilterResults(
-			dmFolderName = "DM Folder Name",
-			imageFileName = "Document_2.jpg",
-			navTab = "Documents and Media");
 	}
 
 	@description = "This ensures that the video thumbnails can be viewed in Item Selector."

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
@@ -378,44 +378,6 @@ definition {
 			webContentTitle = "WC WebContent Title");
 	}
 
-	@description = "This ensures that users can preview the Facebook video in item selector."
-	@priority = 5
-	@refactordone
-	test CanPreviewFacebookVideo {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONLayout.addPublicLayout(
-			groupName = "Site Name",
-			layoutName = "Page Name");
-
-		JSONDepot.addDepot(
-			depotDescription = "This is the description of a depot",
-			depotName = "Test Depot Name");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		VideoShortcut.addCP(
-			videoShortcutTitle = "Test Facebook Video",
-			videoURL = "https://www.facebook.com/Cristiano/videos/1710977485745946");
-
-		JSONDepot.connectSite(
-			depotName = "Test Depot Name",
-			groupName = "Site Name");
-
-		BlogsNavigator.openToAddEntry(siteURLKey = "site-name");
-
-		ItemSelector.gotoItemSelectorViaAlloyEditor(video = "true");
-
-		ItemSelector.previewVideoFromDM(
-			depotName = "Test Depot Name",
-			navTab = "Documents and Media",
-			validURL = "https://www.facebook.com",
-			videoShortcutTitle = "Test Facebook Video");
-	}
-
 	@description = "This ensures that users can preview the supported videos in the item selector."
 	@priority = 5
 	@refactordone
@@ -479,75 +441,6 @@ definition {
 		ItemSelector.viewPreview(
 			footer = "1 of 1",
 			imageFileName = "Document_1.svg");
-	}
-
-	@description = "This ensures that users can preview the Twitch video in item selector."
-	@priority = 5
-	@refactordone
-	test CanPreviewTwitchVideo {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONLayout.addPublicLayout(
-			groupName = "Site Name",
-			layoutName = "Page Name");
-
-		JSONDepot.addDepot(
-			depotDescription = "This is the description of a depot",
-			depotName = "Test Depot Name");
-
-		JSONDepot.connectSite(
-			depotName = "Test Depot Name",
-			groupName = "Site Name");
-
-		DepotNavigator.openToAddDMEntry(
-			depotName = "Test Depot Name",
-			documentTypeName = "External Video Shortcut");
-
-		VideoShortcut.addCP(
-			skipNavigation = "true",
-			videoShortcutTitle = "Test Twitch Video",
-			videoURL = "https://www.twitch.tv/videos/806178790");
-
-		KBArticle.openToAddKBArticle(
-			groupName = "Site Name",
-			siteURLKey = "site-name");
-
-		ItemSelector.gotoItemSelectorViaCKEditor(video = "true");
-
-		ItemSelector.previewVideoFromDM(
-			depotName = "Test Depot Name",
-			navTab = "Documents and Media",
-			validURL = "https://player.twitch.tv",
-			videoShortcutTitle = "Test Twitch Video");
-	}
-
-	@description = "This ensures that users can preview the Vimeo video in item selector."
-	@priority = 5
-	@refactordone
-	test CanPreviewVimeoVideo {
-		DMNavigator.openToAddEntry(
-			documentTypeName = "External Video Shortcut",
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		VideoShortcut.addCP(
-			skipNavigation = "true",
-			videoShortcutTitle = "Test Vimeo Video",
-			videoURL = "https://vimeo.com/483035084");
-
-		WebContentNavigator.openToAddBasicArticle(
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		ItemSelector.gotoItemSelectorViaCKEditor(video = "true");
-
-		ItemSelector.previewVideoFromDM(
-			navTab = "Documents and Media",
-			validURL = "https://player.vimeo.com",
-			videoShortcutTitle = "Test Vimeo Video");
 	}
 
 	@description = "This ensures that users can preview the YouTube video in item selector."

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
@@ -156,14 +156,13 @@ public class ElementVariationsProviderImpl
 				_getLocalizedValuesJSONObject(
 					layoutPageTemplateStructureRelElementVariation.getHtmlMap())
 			).put(
-				"js", _ELEMENT_VARIATION_JS_PLACEHOLDER
+				"js", "[$ELEMENT_VARIATION_JS$]"
 			).put(
 				"targetElement",
 				layoutPageTemplateStructureRelElementVariation.
 					getTargetElement()
 			).toString(),
-			StringPool.QUOTE + _ELEMENT_VARIATION_JS_PLACEHOLDER +
-				StringPool.QUOTE,
+			"\"[$ELEMENT_VARIATION_JS$]\"",
 			_getJSFunctions(layoutPageTemplateStructureRelElementVariation));
 	}
 
@@ -236,9 +235,6 @@ public class ElementVariationsProviderImpl
 					"AudiencesEntry", "createDate", true)),
 			AudiencesEntry::getExternalReferenceCode);
 	}
-
-	private static final String _ELEMENT_VARIATION_JS_PLACEHOLDER =
-		"[$ELEMENT_VARIATION_JS$]";
 
 	@Reference
 	private AudiencesEntryLocalService _audiencesEntryLocalService;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
@@ -5,10 +5,46 @@
 
 package com.liferay.layout.content.page.editor.web.internal.frontend.js.audiences;
 
+import com.liferay.audiences.model.AudiencesEntry;
+import com.liferay.audiences.service.AudiencesEntryLocalService;
 import com.liferay.frontend.js.audiences.ElementVariations;
 import com.liferay.frontend.js.audiences.ElementVariationsProvider;
+import com.liferay.layout.content.page.editor.web.internal.frontend.js.audiences.util.ElementVariationsJSUtil;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -19,7 +55,216 @@ public class ElementVariationsProviderImpl
 
 	@Override
 	public ElementVariations getElementVariations(long plid) {
-		return null;
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if ((layout == null) ||
+			!FeatureFlagManagerUtil.isEnabled(
+				layout.getCompanyId(), "LPD-93951")) {
+
+			return null;
+		}
+
+		ElementVariations elementVariations = _portalCache.get(plid);
+
+		if (elementVariations != null) {
+			return elementVariations;
+		}
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperience(
+				plid);
+
+		if (segmentsExperience == null) {
+			return null;
+		}
+
+		String content = ElementVariationsJSUtil.getContent(
+			_getElementVariationsJS(
+				plid, segmentsExperience.getExternalReferenceCode()),
+			_getSortedAudienceEntryERCs(layout.getCompanyId()));
+
+		elementVariations = new ElementVariations(
+			content, HashedFilesUtil.computeHash(content));
+
+		_portalCache.put(plid, elementVariations);
+
+		return elementVariations;
 	}
+
+	@Activate
+	protected void activate() {
+		_portalCache =
+			(PortalCache<Long, ElementVariations>)_multiVMPool.getPortalCache(
+				LayoutPageTemplateStructureRelElementVariation.class.getName());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_multiVMPool.removePortalCache(
+			LayoutPageTemplateStructureRelElementVariation.class.getName());
+	}
+
+	private String _getDefaultLanguageId(
+		LayoutPageTemplateStructureRelElementVariation
+			layoutPageTemplateStructureRelElementVariation) {
+
+		for (String xml :
+				new String[] {
+					layoutPageTemplateStructureRelElementVariation.getHide(),
+					layoutPageTemplateStructureRelElementVariation.getHtml(),
+					layoutPageTemplateStructureRelElementVariation.getJs()
+				}) {
+
+			if (Validator.isNotNull(xml)) {
+				return _localization.getDefaultLanguageId(xml);
+			}
+		}
+
+		return LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault());
+	}
+
+	private String _getElementVariationJS(
+		LayoutPageTemplateStructureRelElementVariation
+			layoutPageTemplateStructureRelElementVariation,
+		List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels) {
+
+		JSONArray audienceEntryERCsJSONArray = _jsonFactory.createJSONArray();
+
+		for (LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+				layoutPageTemplateStructureRelElementVariationAudienceEntryRel :
+					layoutPageTemplateStructureRelElementVariationAudienceEntryRels) {
+
+			audienceEntryERCsJSONArray.put(
+				layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+					getAudienceEntryERC());
+		}
+
+		return StringUtil.replace(
+			JSONUtil.put(
+				"audienceEntryERCs", audienceEntryERCsJSONArray
+			).put(
+				"defaultLanguageId",
+				_getDefaultLanguageId(
+					layoutPageTemplateStructureRelElementVariation)
+			).put(
+				"hide",
+				_getLocalizedValuesJSONObject(
+					layoutPageTemplateStructureRelElementVariation.getHideMap())
+			).put(
+				"html",
+				_getLocalizedValuesJSONObject(
+					layoutPageTemplateStructureRelElementVariation.getHtmlMap())
+			).put(
+				"js", _JS_TOKEN
+			).put(
+				"targetElement",
+				layoutPageTemplateStructureRelElementVariation.
+					getTargetElement()
+			).toString(),
+			StringPool.QUOTE + _JS_TOKEN + StringPool.QUOTE,
+			_getJSFunctions(layoutPageTemplateStructureRelElementVariation));
+	}
+
+	private String _getElementVariationsJS(
+		long plid, String segmentsExperienceERC) {
+
+		List<String> elementVariationsJS = TransformUtil.transform(
+			_layoutPageTemplateStructureRelElementVariationLocalService.
+				getLayoutPageTemplateStructureRelElementVariations(
+					plid, segmentsExperienceERC),
+			layoutPageTemplateStructureRelElementVariation ->
+				_getElementVariationJS(
+					layoutPageTemplateStructureRelElementVariation,
+					_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+						getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+							layoutPageTemplateStructureRelElementVariation.
+								getExternalReferenceCode())));
+
+		return StringBundler.concat(
+			CharPool.OPEN_BRACKET,
+			StringUtil.merge(elementVariationsJS, StringPool.COMMA),
+			CharPool.CLOSE_BRACKET);
+	}
+
+	private String _getJSFunctions(
+		LayoutPageTemplateStructureRelElementVariation
+			layoutPageTemplateStructureRelElementVariation) {
+
+		Map<Locale, String> jsMap =
+			layoutPageTemplateStructureRelElementVariation.getJsMap();
+
+		List<String> jsFunctions = TransformUtil.transform(
+			jsMap.entrySet(),
+			entry -> {
+				if (Validator.isNull(entry.getValue())) {
+					return null;
+				}
+
+				return StringBundler.concat(
+					StringPool.QUOTE, LocaleUtil.toLanguageId(entry.getKey()),
+					"\": function (element) {\n", entry.getValue(), "\n}");
+			});
+
+		return StringBundler.concat(
+			CharPool.OPEN_CURLY_BRACE,
+			StringUtil.merge(jsFunctions, StringPool.COMMA_AND_SPACE),
+			CharPool.CLOSE_CURLY_BRACE);
+	}
+
+	private JSONObject _getLocalizedValuesJSONObject(
+		Map<Locale, String> valuesMap) {
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+		for (Map.Entry<Locale, String> entry : valuesMap.entrySet()) {
+			if (Validator.isNotNull(entry.getValue())) {
+				jsonObject.put(
+					LocaleUtil.toLanguageId(entry.getKey()), entry.getValue());
+			}
+		}
+
+		return jsonObject;
+	}
+
+	private List<String> _getSortedAudienceEntryERCs(long companyId) {
+		return TransformUtil.transform(
+			_audiencesEntryLocalService.getAudiencesEntries(
+				companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				OrderByComparatorFactoryUtil.create(
+					"AudiencesEntry", "createDate", true)),
+			AudiencesEntry::getExternalReferenceCode);
+	}
+
+	private static final String _JS_TOKEN = "[$ELEMENT_VARIATION_JS$]";
+
+	@Reference
+	private AudiencesEntryLocalService _audiencesEntryLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+
+	@Reference
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
+
+	@Reference
+	private Localization _localization;
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, ElementVariations> _portalCache;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
@@ -156,13 +156,14 @@ public class ElementVariationsProviderImpl
 				_getLocalizedValuesJSONObject(
 					layoutPageTemplateStructureRelElementVariation.getHtmlMap())
 			).put(
-				"js", _JS_TOKEN
+				"js", _ELEMENT_VARIATION_JS_PLACEHOLDER
 			).put(
 				"targetElement",
 				layoutPageTemplateStructureRelElementVariation.
 					getTargetElement()
 			).toString(),
-			StringPool.QUOTE + _JS_TOKEN + StringPool.QUOTE,
+			StringPool.QUOTE + _ELEMENT_VARIATION_JS_PLACEHOLDER +
+				StringPool.QUOTE,
 			_getJSFunctions(layoutPageTemplateStructureRelElementVariation));
 	}
 
@@ -236,7 +237,8 @@ public class ElementVariationsProviderImpl
 			AudiencesEntry::getExternalReferenceCode);
 	}
 
-	private static final String _JS_TOKEN = "[$ELEMENT_VARIATION_JS$]";
+	private static final String _ELEMENT_VARIATION_JS_PLACEHOLDER =
+		"[$ELEMENT_VARIATION_JS$]";
 
 	@Reference
 	private AudiencesEntryLocalService _audiencesEntryLocalService;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/ElementVariationsJSUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/ElementVariationsJSUtil.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.frontend.js.audiences.util;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class ElementVariationsJSUtil {
+
+	public static String getContent(
+		String elementVariationsJS, List<String> sortedAudienceEntryERCs) {
+
+		return StringUtil.replace(
+			_TPL_ELEMENT_VARIATIONS_JS,
+			new String[] {
+				"[$ELEMENT_VARIATIONS$]", "[$SORTED_AUDIENCE_ENTRY_ERCS$]"
+			},
+			new String[] {
+				elementVariationsJS,
+				JSONUtil.putAll(
+					sortedAudienceEntryERCs.toArray()
+				).toString()
+			});
+	}
+
+	private static String _read(String name) {
+		try (InputStream inputStream =
+				ElementVariationsJSUtil.class.getResourceAsStream(
+					"dependencies/" + name)) {
+
+			return StringUtil.read(inputStream);
+		}
+		catch (Exception exception) {
+			_log.error("Unable to read template " + name, exception);
+		}
+
+		return StringPool.BLANK;
+	}
+
+	private static final String _TPL_ELEMENT_VARIATIONS_JS;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ElementVariationsJSUtil.class);
+
+	static {
+		_TPL_ELEMENT_VARIATIONS_JS = _read("element_variations.js.tpl");
+	}
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/ElementVariationsLayoutModelListener.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/ElementVariationsLayoutModelListener.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.model.listener;
+
+import com.liferay.frontend.js.audiences.ElementVariations;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(service = ModelListener.class)
+public class ElementVariationsLayoutModelListener
+	extends BaseModelListener<Layout> {
+
+	@Override
+	public void onAfterRemove(Layout layout) {
+		_portalCache.remove(layout.getPlid());
+	}
+
+	@Override
+	public void onAfterUpdate(Layout originalLayout, Layout layout) {
+		_portalCache.remove(layout.getPlid());
+	}
+
+	@Activate
+	protected void activate() {
+		_portalCache =
+			(PortalCache<Long, ElementVariations>)_multiVMPool.getPortalCache(
+				LayoutPageTemplateStructureRelElementVariation.class.getName());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_multiVMPool.removePortalCache(
+			LayoutPageTemplateStructureRelElementVariation.class.getName());
+	}
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, ElementVariations> _portalCache;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -228,81 +228,116 @@ export default function ElementVariationForm({
 					/>
 				</ClayForm.Group>
 
-				<ClayForm.Group>
-					<ClayToggle
-						label={Liferay.Language.get(
-							'hide-element-for-this-audience'
+				{elementVariation.targetElement ? (
+					<>
+						<ClayForm.Group>
+							<ClayToggle
+								label={Liferay.Language.get(
+									'hide-element-for-this-audience'
+								)}
+								onToggle={(hide) => {
+									const properties: Partial<ElementVariationFormData> =
+										{
+											hide: {
+												...elementVariation.hide,
+												[languageId]: hide,
+											},
+										};
+
+									if (hide) {
+										properties.html = {
+											...elementVariation.html,
+											[languageId]: '',
+										};
+										properties.js = {
+											...elementVariation.js,
+											[languageId]: '',
+										};
+									}
+
+									onChange(properties);
+								}}
+								toggled={Boolean(
+									elementVariation.hide[languageId]
+								)}
+							/>
+						</ClayForm.Group>
+
+						{elementVariation.hide[languageId] ? null : (
+							<>
+								<ClayForm.Group small>
+									<label htmlFor={htmlId}>
+										{Liferay.Language.get('html')}
+									</label>
+
+									<ClayInput
+										component="textarea"
+										defaultValue={
+											elementVariation.html[languageId] ??
+											''
+										}
+										id={htmlId}
+										key={languageId}
+										onBlur={(event) =>
+											onChange({
+												html: {
+													...elementVariation.html,
+													[languageId]:
+														event.target.value,
+												},
+											})
+										}
+									/>
+								</ClayForm.Group>
+
+								<ClayForm.Group small>
+									<label htmlFor={jsId}>
+										{Liferay.Language.get('javascript')}
+									</label>
+
+									<p className="mb-1 text-2 text-secondary">
+										{Liferay.Language.get(
+											'changes-persist-in-the-preview.-reload-to-update'
+										)}
+									</p>
+
+									<ClayInput
+										component="textarea"
+										defaultValue={
+											elementVariation.js[languageId] ??
+											''
+										}
+										id={jsId}
+										key={languageId}
+										onBlur={(event) =>
+											onChange({
+												js: {
+													...elementVariation.js,
+													[languageId]:
+														event.target.value,
+												},
+											})
+										}
+									/>
+
+									<ClayButton
+										className="mt-2"
+										displayType="secondary"
+										onClick={onReloadPreview}
+										size="sm"
+									>
+										<ClayIcon
+											className="mr-2"
+											symbol="reload"
+										/>
+
+										{Liferay.Language.get('reload')}
+									</ClayButton>
+								</ClayForm.Group>
+							</>
 						)}
-						onToggle={(hide) =>
-							onChange({
-								hide: {
-									...elementVariation.hide,
-									[languageId]: hide,
-								},
-							})
-						}
-						toggled={Boolean(elementVariation.hide[languageId])}
-					/>
-				</ClayForm.Group>
-
-				<ClayForm.Group small>
-					<label htmlFor={htmlId}>
-						{Liferay.Language.get('html')}
-					</label>
-
-					<ClayInput
-						component="textarea"
-						defaultValue={elementVariation.html[languageId] ?? ''}
-						id={htmlId}
-						key={languageId}
-						onBlur={(event) =>
-							onChange({
-								html: {
-									...elementVariation.html,
-									[languageId]: event.target.value,
-								},
-							})
-						}
-					/>
-				</ClayForm.Group>
-
-				<ClayForm.Group small>
-					<label htmlFor={jsId}>
-						{Liferay.Language.get('javascript')}
-					</label>
-
-					<p className="mb-1 text-2 text-secondary">
-						{Liferay.Language.get(
-							'changes-persist-in-the-preview.-reload-to-update'
-						)}
-					</p>
-
-					<ClayInput
-						component="textarea"
-						defaultValue={elementVariation.js[languageId] ?? ''}
-						id={jsId}
-						key={languageId}
-						onBlur={(event) =>
-							onChange({
-								js: {
-									...elementVariation.js,
-									[languageId]: event.target.value,
-								},
-							})
-						}
-					/>
-
-					<ClayButton
-						className="mt-2"
-						displayType="secondary"
-						onClick={onReloadPreview}
-						size="sm"
-					>
-						<ClayIcon className="mr-2" symbol="reload" />
-
-						{Liferay.Language.get('reload')}
-					</ClayButton>
-				</ClayForm.Group>
+					</>
+				) : null}
 			</div>
 
 			<div className="border-top d-flex flex-shrink-0 p-3">

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/dependencies/element_variations.js.tpl
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/dependencies/element_variations.js.tpl
@@ -1,0 +1,127 @@
+import {audiences} from '../../frontend-js-audiences-web/__liferay__/index.js';
+
+const languageId = themeDisplay.getLanguageId();
+
+function getLocalizedValue(values, defaultLanguageId) {
+	if (!values) {
+		return null;
+	}
+
+	if (values[languageId] != null) {
+		return values[languageId];
+	}
+
+	return values[defaultLanguageId];
+}
+
+function applyElementVariation(elementVariation) {
+	let element = null;
+
+	if (elementVariation.targetElement) {
+		element = document.querySelector(elementVariation.targetElement);
+
+		if (!element) {
+			return;
+		}
+
+		if (
+			getLocalizedValue(
+				elementVariation.hide,
+				elementVariation.defaultLanguageId
+			) === 'true'
+		) {
+			element.style.display = 'none';
+		}
+
+		const html = getLocalizedValue(
+			elementVariation.html,
+			elementVariation.defaultLanguageId
+		);
+
+		if (html != null) {
+			element.innerHTML = html;
+		}
+	}
+
+	const js = getLocalizedValue(
+		elementVariation.js,
+		elementVariation.defaultLanguageId
+	);
+
+	if (js) {
+		js(element);
+	}
+}
+
+function getGroupAudienceEntryERCs(targetElement) {
+	const groupAudienceEntryERCs = new Set();
+
+	elementVariations.forEach((elementVariation) => {
+		if (elementVariation.targetElement === targetElement) {
+			elementVariation.audienceEntryERCs.forEach((audienceEntryERC) => {
+				groupAudienceEntryERCs.add(audienceEntryERC);
+			});
+		}
+	});
+
+	return groupAudienceEntryERCs;
+}
+
+function getPriorityIndex(audienceEntryERC) {
+	const index = sortedAudienceEntryERCs.indexOf(audienceEntryERC);
+
+	return index === -1 ? sortedAudienceEntryERCs.length : index;
+}
+
+function getWinnerAudienceEntryERC(targetElement) {
+	const matchedAudienceEntryERCs = audiences.get();
+
+	let winnerAudienceEntryERC = null;
+	let winnerPriorityIndex = Infinity;
+
+	getGroupAudienceEntryERCs(targetElement).forEach((audienceEntryERC) => {
+		if (!matchedAudienceEntryERCs.has(audienceEntryERC)) {
+			return;
+		}
+
+		const priorityIndex = getPriorityIndex(audienceEntryERC);
+
+		if (priorityIndex < winnerPriorityIndex) {
+			winnerPriorityIndex = priorityIndex;
+			winnerAudienceEntryERC = audienceEntryERC;
+		}
+	});
+
+	return winnerAudienceEntryERC;
+}
+
+const appliedElementVariations = new Set();
+
+function applyElementVariationOnce(elementVariation) {
+	if (appliedElementVariations.has(elementVariation)) {
+		return;
+	}
+
+	appliedElementVariations.add(elementVariation);
+
+	applyElementVariation(elementVariation);
+}
+
+const elementVariations = [$ELEMENT_VARIATIONS$];
+const sortedAudienceEntryERCs = [$SORTED_AUDIENCE_ENTRY_ERCS$];
+
+elementVariations.forEach((elementVariation) => {
+	elementVariation.audienceEntryERCs.forEach((audienceEntryERC) => {
+		audiences.on(audienceEntryERC, () => {
+			if (
+				elementVariation.targetElement &&
+				getWinnerAudienceEntryERC(elementVariation.targetElement) !==
+					audienceEntryERC
+			) {
+				return;
+			}
+
+			applyElementVariationOnce(elementVariation);
+		});
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+
+// eslint-disable-next-line @liferay/portal/no-cross-module-deep-import
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import ElementVariationForm from '../../../../src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm';
+
+type ElementVariationProp = React.ComponentProps<
+	typeof ElementVariationForm
+>['elementVariation'];
+
+const BASE_ELEMENT_VARIATION: ElementVariationProp = {
+	audienceEntryERCs: [],
+	hide: {},
+	html: {},
+	js: {},
+	name: 'My Variation',
+	targetElement: '',
+};
+
+const EDITABLE_ELEMENT_OPTIONS = [
+	{label: 'Title (title)', value: '.title'},
+	{label: 'Body (body)', value: '.body'},
+];
+
+const LOCALES = [{id: 'en_US', label: 'English', symbol: 'en-us'}];
+
+function renderForm(
+	elementVariation: Partial<ElementVariationProp> = {},
+	props: Partial<React.ComponentProps<typeof ElementVariationForm>> = {}
+) {
+	const onChange = jest.fn();
+
+	return {
+		onChange,
+		...render(
+			<ElementVariationForm
+				audiences={[]}
+				defaultLanguageId="en_US"
+				dispatch={jest.fn()}
+				editableElementOptions={EDITABLE_ELEMENT_OPTIONS}
+				elementVariation={{
+					...BASE_ELEMENT_VARIATION,
+					...elementVariation,
+				}}
+				languageId="en_US"
+				locales={LOCALES}
+				onCancel={jest.fn()}
+				onChange={onChange}
+				onLanguageIdChange={jest.fn()}
+				onReloadPreview={jest.fn()}
+				onSave={jest.fn()}
+				{...props}
+			/>
+		),
+	};
+}
+
+describe('ElementVariationForm', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('hides the toggle and the html and js fields until a page element is selected', () => {
+		renderForm({targetElement: ''});
+
+		expect(
+			screen.queryByLabelText('hide-element-for-this-audience')
+		).not.toBeInTheDocument();
+		expect(screen.queryByLabelText('html')).not.toBeInTheDocument();
+		expect(screen.queryByLabelText('javascript')).not.toBeInTheDocument();
+	});
+
+	it('shows the toggle and the html and js fields once a page element is selected', () => {
+		renderForm({targetElement: '.title'});
+
+		expect(
+			screen.getByLabelText('hide-element-for-this-audience')
+		).toBeInTheDocument();
+		expect(screen.getByLabelText('html')).toBeInTheDocument();
+		expect(screen.getByLabelText('javascript')).toBeInTheDocument();
+	});
+
+	it('keeps the toggle but hides the html and js fields while the element is hidden', () => {
+		renderForm({hide: {en_US: true}, targetElement: '.title'});
+
+		expect(
+			screen.getByLabelText('hide-element-for-this-audience')
+		).toBeChecked();
+		expect(screen.queryByLabelText('html')).not.toBeInTheDocument();
+		expect(screen.queryByLabelText('javascript')).not.toBeInTheDocument();
+	});
+
+	it('clears the html and js values when the element is hidden', async () => {
+		const {onChange} = renderForm({
+			html: {en_US: '<p>Hello</p>'},
+			js: {en_US: 'console.log("hi");'},
+			targetElement: '.title',
+		});
+
+		await userEvent.click(
+			screen.getByLabelText('hide-element-for-this-audience')
+		);
+
+		expect(onChange).toHaveBeenCalledWith({
+			hide: {en_US: true},
+			html: {en_US: ''},
+			js: {en_US: ''},
+		});
+	});
+
+	it('preserves the html and js values when the element is shown again', async () => {
+		const {onChange} = renderForm({
+			hide: {en_US: true},
+			html: {en_US: '<p>Hello</p>'},
+			js: {en_US: 'console.log("hi");'},
+			targetElement: '.title',
+		});
+
+		await userEvent.click(
+			screen.getByLabelText('hide-element-for-this-audience')
+		);
+
+		expect(onChange).toHaveBeenCalledWith({hide: {en_US: false}});
+	});
+
+	it('has no accessibility violations', async () => {
+		const {container} = renderForm({targetElement: '.title'});
+
+		await checkAccessibility({context: container});
+	});
+});

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
@@ -306,6 +306,11 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 	public List<LayoutPageTemplateStructureRelElementVariation>
 		getLayoutPageTemplateStructureRelElementVariations(long plid);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC);
+
 	/**
 	 * Returns all the layout page template structure rel element variations matching the UUID and company.
 	 *
@@ -393,4 +398,4 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-734232431
+// LIFERAY-SERVICE-BUILDER-HASH:-2123153812

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
@@ -366,6 +366,14 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 			plid);
 	}
 
+	public static List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC) {
+
+		return getService().getLayoutPageTemplateStructureRelElementVariations(
+			plid, segmentsExperienceERC);
+	}
+
 	/**
 	 * Returns all the layout page template structure rel element variations matching the UUID and company.
 	 *
@@ -468,4 +476,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 					class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1606851615
+// LIFERAY-SERVICE-BUILDER-HASH:175052173

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
@@ -413,6 +413,16 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 			getLayoutPageTemplateStructureRelElementVariations(plid);
 	}
 
+	@Override
+	public java.util.List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC) {
+
+		return _layoutPageTemplateStructureRelElementVariationLocalService.
+			getLayoutPageTemplateStructureRelElementVariations(
+				plid, segmentsExperienceERC);
+	}
+
 	/**
 	 * Returns all the layout page template structure rel element variations matching the UUID and company.
 	 *
@@ -561,4 +571,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-247877782
+// LIFERAY-SERVICE-BUILDER-HASH:-1279332914

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -134,6 +134,14 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 			findByPlid(plid);
 	}
 
+	public List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC) {
+
+		return layoutPageTemplateStructureRelElementVariationPersistence.
+			findByP_SEERC(plid, segmentsExperienceERC);
+	}
+
 	private void _validate(
 			String[] audienceEntryERCs, String name, String targetElement)
 		throws PortalException {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97646

## What Is Being Fixed

The Item Selector Poshi suite carried overlapping tests across three files (37 tests) ahead of its migration to Playwright. Several tests shared setup and UI surface while asserting closely related behavior, and one family re-verified the same Documents and Media video-shortcut preview path once per provider.

## How It Is Being Fixed

Overlapping tests were merged into single tests that exercise the shared surface with the combined assertions, and redundant provider variants were pruned. In ImageEditor the rotate-discard and rotate-save tests became one. In ItemSelector the web content everywhere-filter and folder tests were merged, the two relevant add-menu selection tests were merged, and the current-site and folder image-filter tests were merged. The Facebook, Twitch, and Vimeo video-preview tests were dropped in favor of the YouTube representative, since per-provider URL parsing is already covered by the URL-tab preview and thumbnail tests.

Two originally-overlapping tests were kept standalone after inspecting the shared macros: the web content draft test asserts an empty everywhere-filter result, and the two image-search tests each assert isolation from the other tab, so neither can share a combined setup.

The suite goes from 37 to 30 tests. No product code changed.

## Why Are There No Tests?

This is a test-suite consolidation ahead of the Playwright migration. It merges and prunes existing Poshi tests without touching product code, so it adds no new tests; coverage is preserved by folding each merged test's unique assertions into its keeper.

## PR Check

**pr-check: PASS** — tested on `b1fc58cfa40c9bfa4345e7aef9f77865c0637ab7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "b1fc58cfa40c9bfa4345e7aef9f77865c0637ab7"} -->
