### PR TITLE
LPD-97250 Compare XLIFF 2.0 export output semantically

### DIFF
--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF20TranslationInfoItemFieldValuesExporterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/exporter/test/XLIFF20TranslationInfoItemFieldValuesExporterTest.java
@@ -88,18 +88,20 @@ public class XLIFF20TranslationInfoItemFieldValuesExporterTest {
 			_group, _ddmFormDeserializer);
 
 		Assert.assertEquals(
-			StringUtil.replace(
-				TranslationTestUtil.readFileToString(
-					"test-journal-article.xlf"),
-				"[$JOURNAL_ARTICLE_ID$]",
-				String.valueOf(journalArticle.getResourcePrimKey())),
-			StreamUtil.toString(
-				_xliffTranslationInfoItemFieldValuesExporter.
-					exportInfoItemFieldValues(
-						infoItemFieldValuesProvider.getInfoItemFieldValues(
-							journalArticle),
-						LocaleUtil.getDefault(),
-						LocaleUtil.fromLanguageId("es_ES"))));
+			TranslationTestUtil.toFormattedString(
+				StringUtil.replace(
+					TranslationTestUtil.readFileToString(
+						"test-journal-article.xlf"),
+					"[$JOURNAL_ARTICLE_ID$]",
+					String.valueOf(journalArticle.getResourcePrimKey()))),
+			TranslationTestUtil.toFormattedString(
+				StreamUtil.toString(
+					_xliffTranslationInfoItemFieldValuesExporter.
+						exportInfoItemFieldValues(
+							infoItemFieldValuesProvider.getInfoItemFieldValues(
+								journalArticle),
+							LocaleUtil.getDefault(),
+							LocaleUtil.fromLanguageId("es_ES")))));
 	}
 
 	@Inject(filter = "ddm.form.deserializer.type=json")


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97250

## What Is Being Fixed

The integration test `XLIFF20TranslationInfoItemFieldValuesExporterTest.testExportReturnsTheXLIFFRepresentationOfAJournalArticle` started failing. It compared the exporter's serialized output against the pretty-printed fixture `test-journal-article.xlf` with an exact-string `assertEquals`. The serialized `xliff` root element now emits its `xmlns` namespace declaration before the `srcLang`/`trgLang`/`version` attributes, so the assertion failed on attribute framing even though the XML is semantically identical and the translation-unit content matched.

## How It Is Being Fixed

LPD-96570 already addressed this class of brittleness by canonicalizing both sides of the comparison through `TranslationTestUtil.toFormattedString()`, which re-parses and re-serializes each side so framing differences disappear. That change updated the XLIFF 1.2 exporter test and `TranslationManagerTest` but missed this method in the XLIFF 2.0 test. This applies the same `toFormattedString()` treatment to both the expected fixture and the exporter output here, mirroring the sibling tests and keeping the fixture human-readable.

## PR Check

**pr-check: PASS** — tested on `b2b1fdbd3a8e8e4efb357337bacdab65dfa5ee70`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b2b1fdbd3a8e8e4efb357337bacdab65dfa5ee70"} -->
