### PR TITLE
LPD-94145 Allow components from other modules

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AddSpaceMembersFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AddSpaceMembersFragmentRenderer.java
@@ -39,13 +39,13 @@ public class AddSpaceMembersFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "add-members";
+	protected String getComponentName() {
+		return "AddSpaceMembers";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "AddSpaceMembers";
+	protected String getLabelKey() {
+		return "add-members";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BaseComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BaseComponentSectionFragmentRenderer.java
@@ -7,6 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.frontend.taglib.react.servlet.taglib.ComponentTag;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.taglib.servlet.PageContextFactoryUtil;
 
@@ -49,7 +50,8 @@ public abstract class BaseComponentSectionFragmentRenderer
 			ComponentTag componentTag = new ComponentTag();
 
 			componentTag.setModule(
-				"{" + getModuleName() + "} from site-cms-site-initializer");
+				StringBundler.concat(
+					"{", getComponentName(), "} from ", getModuleName()));
 			componentTag.setPageContext(
 				PageContextFactoryUtil.create(
 					httpServletRequest, httpServletResponse));
@@ -71,9 +73,13 @@ public abstract class BaseComponentSectionFragmentRenderer
 		}
 	}
 
+	protected abstract String getComponentName();
+
 	protected abstract String getLabelKey();
 
-	protected abstract String getModuleName();
+	protected String getModuleName() {
+		return "site-cms-site-initializer";
+	}
 
 	protected abstract Map<String, Object> getProps(
 			FragmentRendererContext fragmentRendererContext,

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
@@ -36,13 +36,13 @@ public class BreadcrumbComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "breadcrumb";
+	protected String getComponentName() {
+		return "Breadcrumb";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "Breadcrumb";
+	protected String getLabelKey() {
+		return "breadcrumb";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BulkActionsMonitorComponentSectionFragmentRender.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BulkActionsMonitorComponentSectionFragmentRender.java
@@ -33,13 +33,13 @@ public class BulkActionsMonitorComponentSectionFragmentRender
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "bulk-actions-monitor";
+	protected String getComponentName() {
+		return "BulkActionsMonitor";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "BulkActionsMonitor";
+	protected String getLabelKey() {
+		return "bulk-actions-monitor";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorPreviewComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorPreviewComponentSectionFragmentRenderer.java
@@ -66,13 +66,13 @@ public class ContentEditorPreviewComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "content-editor-preview";
+	protected String getComponentName() {
+		return "ContentEditorPreview";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "ContentEditorPreview";
+	protected String getLabelKey() {
+		return "content-editor-preview";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorSidePanelComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorSidePanelComponentSectionFragmentRenderer.java
@@ -85,13 +85,13 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "content-editor-side-panel";
+	protected String getComponentName() {
+		return "ContentEditorSidePanel";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "ContentEditorSidePanel";
+	protected String getLabelKey() {
+		return "content-editor-side-panel";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
@@ -71,13 +71,13 @@ public class ContentEditorToolbarComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "content-editor-management-bar";
+	protected String getComponentName() {
+		return "ContentEditorToolbar";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "ContentEditorToolbar";
+	protected String getLabelKey() {
+		return "content-editor-management-bar";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/DurationBulkActionTaskComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/DurationBulkActionTaskComponentSectionFragmentRenderer.java
@@ -29,13 +29,13 @@ public class DurationBulkActionTaskComponentSectionFragmentRenderer
 	extends BaseBulkActionTaskComponentSectionFragmentRenderer {
 
 	@Override
-	protected String getLabelKey() {
-		return "bulk-action-task-duration";
+	protected String getComponentName() {
+		return "BulkActionTaskDuration";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "BulkActionTaskDuration";
+	protected String getLabelKey() {
+		return "bulk-action-task-duration";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EditFolderComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EditFolderComponentSectionFragmentRenderer.java
@@ -31,13 +31,13 @@ public class EditFolderComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "edit-folder";
+	protected String getComponentName() {
+		return "EditFolder";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "EditFolder";
+	protected String getLabelKey() {
+		return "edit-folder";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EnterpriseProductMenuBannerFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EnterpriseProductMenuBannerFragmentRenderer.java
@@ -52,13 +52,13 @@ public class EnterpriseProductMenuBannerFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "enterprise-product-menu-banner-label";
+	protected String getComponentName() {
+		return "EnterpriseProductMenuBanner";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "EnterpriseProductMenuBanner";
+	protected String getLabelKey() {
+		return "enterprise-product-menu-banner-label";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/FailedAssetsBulkActionTaskComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/FailedAssetsBulkActionTaskComponentSectionFragmentRenderer.java
@@ -24,13 +24,13 @@ public class FailedAssetsBulkActionTaskComponentSectionFragmentRenderer
 	extends BaseBulkActionTaskComponentSectionFragmentRenderer {
 
 	@Override
-	protected String getLabelKey() {
-		return "bulk-action-task-failed-assets";
+	protected String getComponentName() {
+		return "BulkActionTaskAssets";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "BulkActionTaskAssets";
+	protected String getLabelKey() {
+		return "bulk-action-task-failed-assets";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/NewSpaceComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/NewSpaceComponentSectionFragmentRenderer.java
@@ -38,13 +38,13 @@ public class NewSpaceComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "new-space";
+	protected String getComponentName() {
+		return "NewSpace";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "NewSpace";
+	protected String getLabelKey() {
+		return "new-space";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/PicklistBuilderComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/PicklistBuilderComponentSectionFragmentRenderer.java
@@ -32,13 +32,13 @@ public class PicklistBuilderComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "picklist-builder";
+	protected String getComponentName() {
+		return "PicklistBuilder";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "PicklistBuilder";
+	protected String getLabelKey() {
+		return "picklist-builder";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpaceSettingsComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpaceSettingsComponentSectionFragmentRenderer.java
@@ -41,13 +41,13 @@ public class SpaceSettingsComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "space-settings";
+	protected String getComponentName() {
+		return "SpaceSettings";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "SpaceSettings";
+	protected String getLabelKey() {
+		return "space-settings";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesComponentSectionFragmentRenderer.java
@@ -45,13 +45,13 @@ public class SpacesComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "spaces";
+	protected String getComponentName() {
+		return "Spaces";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "Spaces";
+	protected String getLabelKey() {
+		return "spaces";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/StatusBulkActionTaskComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/StatusBulkActionTaskComponentSectionFragmentRenderer.java
@@ -27,13 +27,13 @@ public class StatusBulkActionTaskComponentSectionFragmentRenderer
 	extends BaseBulkActionTaskComponentSectionFragmentRenderer {
 
 	@Override
-	protected String getLabelKey() {
-		return "bulk-action-task-status";
+	protected String getComponentName() {
+		return "BulkActionTaskStatus";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "BulkActionTaskStatus";
+	protected String getLabelKey() {
+		return "bulk-action-task-status";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/StructureBuilderComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/StructureBuilderComponentSectionFragmentRenderer.java
@@ -63,7 +63,7 @@ public class StructureBuilderComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getModuleName() {
+	protected String getComponentName() {
 		return "StructureBuilder";
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SuccessfulAssetsBulkActionTaskComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SuccessfulAssetsBulkActionTaskComponentSectionFragmentRenderer.java
@@ -24,13 +24,13 @@ public class SuccessfulAssetsBulkActionTaskComponentSectionFragmentRenderer
 	extends BaseBulkActionTaskComponentSectionFragmentRenderer {
 
 	@Override
-	protected String getLabelKey() {
-		return "bulk-action-task-successful-assets";
+	protected String getComponentName() {
+		return "BulkActionTaskAssets";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "BulkActionTaskAssets";
+	protected String getLabelKey() {
+		return "bulk-action-task-successful-assets";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewSpacesComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewSpacesComponentSectionFragmentRenderer.java
@@ -34,13 +34,13 @@ public class ViewSpacesComponentSectionFragmentRenderer
 	}
 
 	@Override
-	protected String getLabelKey() {
-		return "spaces";
+	protected String getComponentName() {
+		return "SpacesNavigation";
 	}
 
 	@Override
-	protected String getModuleName() {
-		return "SpacesNavigation";
+	protected String getLabelKey() {
+		return "spaces";
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94145

## What Is Being Fixed

The base component-section fragment renderer hardcoded the module to `site-cms-site-initializer` and derived the React component name from `getModuleName()`, so a renderer could only mount components bundled in this module. This blocked importing the AI Assistant into the CMS, whose React component lives in another module.

## How It Is Being Fixed

Separate the component name from the module name: `getComponentName()` now supplies the React component name, while `getModuleName()` defaults to `site-cms-site-initializer` but can be overridden. Renderers can therefore import React components from other modules. This change was necessary to import the AI Assistant into the CMS.

## Why Are There No Tests?

This commit is a pure enabling refactor — it separates the React component name from the owning module name so fragment renderers can load components from other modules. Behavior is unchanged and the existing `SpacesComponentSectionFragmentRendererTest` still covers the renderer. The feature that consumes this capability (importing the AI Assistant into the CMS) lands in the follow-up commits, which carry their own tests.

## PR Check

**pr-check: PASS** — tested on `4684d2cb19bf8c0fe0d3142e3940bb3245b111fb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4684d2cb19bf8c0fe0d3142e3940bb3245b111fb"} -->
