### PR TITLE
LPD-97548 Prevent adding subcategories to system categories

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/servlet/taglib/util/AssetCategoryActionDropdownItemsProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/servlet/taglib/util/AssetCategoryActionDropdownItemsProvider.java
@@ -108,6 +108,7 @@ public class AssetCategoryActionDropdownItemsProvider {
 					DropdownItemListBuilder.add(
 						() ->
 							!_assetCategoriesLimitExceeded &&
+							!_isSystemCategory(category) &&
 							_hasPermission(category, ActionKeys.ADD_CATEGORY),
 						dropdownItem -> {
 							dropdownItem.setHref(

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -274,6 +274,21 @@ public class AssetCategoryLocalServiceTest {
 			assetCategory.getTitleMap());
 	}
 
+	@FeatureFlag("LPD-86291")
+	@Test
+	public void testAddCategorySystemCategory() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotAddChild.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot have child categories"),
+			() -> AssetTestUtil.addCategory(
+				_group.getGroupId(), _assetVocabulary.getVocabularyId(),
+				assetCategory.getCategoryId()));
+	}
+
 	@Test
 	public void testAddCategoryWithExternalReferenceCode() throws Exception {
 		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
@@ -903,7 +918,7 @@ public class AssetCategoryLocalServiceTest {
 	@FeatureFlag("LPD-86291")
 	@Test
 	public void testMoveCategory() throws Exception {
-		AssetCategory assetCategory = _addSystemCategory();
+		AssetCategory assetCategory1 = _addSystemCategory();
 
 		AssetVocabulary assetVocabulary =
 			_assetVocabularyLocalService.addVocabulary(
@@ -915,12 +930,29 @@ public class AssetCategoryLocalServiceTest {
 		AssertUtils.assertFailure(
 			SystemCategoryException.MustNotModify.class,
 			StringBundler.concat(
-				"Category ", assetCategory.getCategoryId(),
+				"Category ", assetCategory1.getCategoryId(),
 				" cannot be modified"),
 			() -> _assetCategoryLocalService.moveCategory(
-				assetCategory.getCategoryId(),
+				assetCategory1.getCategoryId(),
 				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				assetVocabulary.getVocabularyId(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
+
+		AssetCategory assetCategory2 = _addSystemCategory();
+
+		AssetCategory assetCategory3 = AssetTestUtil.addCategory(
+			_group.getGroupId(), _assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotAddChild.class,
+			StringBundler.concat(
+				"Category ", assetCategory2.getCategoryId(),
+				" cannot have child categories"),
+			() -> _assetCategoryLocalService.moveCategory(
+				assetCategory3.getCategoryId(), assetCategory2.getCategoryId(),
+				_assetVocabulary.getVocabularyId(),
 				ServiceContextTestUtil.getServiceContext(
 					_group.getGroupId(), TestPropsValues.getUserId())));
 	}
@@ -1298,6 +1330,7 @@ public class AssetCategoryLocalServiceTest {
 	public void testUpdateCategory() throws Exception {
 		_testUpdateCategorySystemDescription();
 		_testUpdateCategorySystemExternalReferenceCode();
+		_testUpdateCategorySystemParent();
 		_testUpdateCategorySystemRename();
 		_testUpdateCategorySystemWhenImporting();
 		_testUpdateCategorySystemWithNullDescription();
@@ -1428,6 +1461,28 @@ public class AssetCategoryLocalServiceTest {
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				assetCategory.getCategoryId(),
 				assetCategory.getParentCategoryId(),
+				assetCategory.getTitleMap(), assetCategory.getDescriptionMap(),
+				assetCategory.getVocabularyId(), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _testUpdateCategorySystemParent() throws Exception {
+		AssetCategory parentAssetCategory = _addSystemCategory();
+
+		AssetCategory assetCategory = AssetTestUtil.addCategory(
+			_group.getGroupId(), _assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotAddChild.class,
+			StringBundler.concat(
+				"Category ", parentAssetCategory.getCategoryId(),
+				" cannot have child categories"),
+			() -> _assetCategoryLocalService.updateCategory(
+				assetCategory.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+				parentAssetCategory.getCategoryId(),
 				assetCategory.getTitleMap(), assetCategory.getDescriptionMap(),
 				assetCategory.getVocabularyId(), null,
 				ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -98,6 +98,7 @@ public class TaxonomyCategoryDTOConverter
 				assetCategory.getCompanyId(), "LPD-86291") &&
 			assetCategory.isSystem()) {
 
+			actions.remove("add-category");
 			actions.remove("delete");
 			actions.remove("replace");
 			actions.remove("update");

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -474,6 +474,7 @@ public class TaxonomyCategoryResourceTest
 		super.testPatchTaxonomyCategory();
 
 		_testPatchTaxonomyCategorySystem();
+		_testPatchTaxonomyCategorySystemParent();
 		_testPatchTaxonomyCategoryWithExistingParentTaxonomyCategory(
 			testPatchTaxonomyCategory_addTaxonomyCategory(),
 			_addAssetVocabulary());
@@ -515,6 +516,27 @@ public class TaxonomyCategoryResourceTest
 		_testPostSiteTaxonomyCategoryBatch("INSERT");
 		_testPostSiteTaxonomyCategoryBatch("UPSERT");
 		_testPostSiteTaxonomyCategoryWithNonexistingTaxonomyVocabulary();
+	}
+
+	@FeatureFlag("LPD-86291")
+	@Override
+	@Test
+	public void testPostTaxonomyCategoryTaxonomyCategory() throws Exception {
+		super.testPostTaxonomyCategoryTaxonomyCategory();
+
+		TaxonomyCategory parentTaxonomyCategory = _addSystemTaxonomyCategory();
+
+		try {
+			taxonomyCategoryResource.postTaxonomyCategoryTaxonomyCategory(
+				parentTaxonomyCategory.getId(), randomTaxonomyCategory());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
 	}
 
 	@Override
@@ -1421,6 +1443,44 @@ public class TaxonomyCategoryResourceTest
 		try {
 			taxonomyCategoryResource.patchTaxonomyCategory(
 				postTaxonomyCategory.getId(), postTaxonomyCategory);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testPatchTaxonomyCategorySystemParent() throws Exception {
+		TaxonomyCategory randomTaxonomyCategory = randomTaxonomyCategory();
+
+		randomTaxonomyCategory.setSystem(true);
+
+		TaxonomyCategory patchParentTaxonomyCategory =
+			taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				_assetVocabulary.getVocabularyId(), randomTaxonomyCategory);
+
+		TaxonomyCategory taxonomyCategory =
+			testPatchTaxonomyCategory_addTaxonomyCategory();
+
+		try {
+			taxonomyCategoryResource.patchTaxonomyCategory(
+				taxonomyCategory.getId(),
+				new TaxonomyCategory() {
+					{
+						parentTaxonomyCategory = new ParentTaxonomyCategory() {
+							{
+								externalReferenceCode =
+									patchParentTaxonomyCategory.
+										getExternalReferenceCode();
+								id = Long.valueOf(
+									patchParentTaxonomyCategory.getId());
+							}
+						};
+					}
+				});
 
 			Assert.fail();
 		}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -833,35 +833,17 @@ systemCategoryTest.describe('System category tests', () => {
 	);
 
 	systemCategoryTest(
-		'Add a subcategory to a system category',
-		{tag: '@LPD-96625'},
-		async ({categoriesPage, editCategoryPage, page}) => {
+		'Hide the add subcategory action for a system category',
+		{tag: '@LPD-97548'},
+		async ({categoriesPage}) => {
 			await categoriesPage.goto(systemVocabularyId, systemVocabularyName);
 
-			// Subcategories can still be added to a system category
+			// A subcategory cannot be added to a system category
 
-			await categoriesPage.execItemAction({
+			await categoriesPage.expectItemActionHidden({
 				action: 'Add Subcategory',
 				filter: systemCategoryName,
 			});
-
-			await expect(page.getByText('Basic Info')).toBeVisible();
-
-			const subcategoryName = getRandomString();
-
-			await editCategoryPage.fillName(subcategoryName);
-			await editCategoryPage.clickSave();
-
-			// The subcategory is created under the system category
-
-			await categoriesPage.gotoSubcategories(
-				systemCategoryId,
-				systemCategoryName,
-				systemVocabularyId,
-				systemVocabularyName
-			);
-
-			await expect(categoriesPage.getItem(subcategoryName)).toBeVisible();
 		}
 	);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -135,6 +135,8 @@ public class AssetCategoryLocalServiceImpl
 
 		validate(0, groupId, parentCategoryId, name, vocabularyId);
 
+		_checkSystemParentCategory(parentCategoryId);
+
 		AssetCategory parentCategory = null;
 
 		if (parentCategoryId > 0) {
@@ -936,6 +938,27 @@ public class AssetCategoryLocalServiceImpl
 		}
 	}
 
+	private void _checkSystemParentCategory(long parentCategoryId)
+		throws PortalException {
+
+		if (parentCategoryId <= 0) {
+			return;
+		}
+
+		AssetCategory parentCategory =
+			assetCategoryPersistence.findByPrimaryKey(parentCategoryId);
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				parentCategory.getCompanyId(), "LPD-86291") ||
+			!parentCategory.isSystem() ||
+			ExportImportThreadLocal.isImportInProcess()) {
+
+			return;
+		}
+
+		throw new SystemCategoryException.MustNotAddChild(parentCategoryId);
+	}
+
 	private boolean _equals(
 		Map<Locale, String> map1, Map<Locale, String> map2) {
 
@@ -964,6 +987,8 @@ public class AssetCategoryLocalServiceImpl
 	private AssetCategory _moveCategory(
 			AssetCategory category, long parentCategoryId, long vocabularyId)
 		throws PortalException {
+
+		_checkSystemParentCategory(parentCategoryId);
 
 		validate(
 			category.getCategoryId(), category.getGroupId(), parentCategoryId,

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/SystemCategoryException.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/SystemCategoryException.java
@@ -12,6 +12,20 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class SystemCategoryException extends PortalException {
 
+	public static class MustNotAddChild extends SystemCategoryException {
+
+		public MustNotAddChild(long categoryId) {
+			super(
+				String.format(
+					"Category %s cannot have child categories", categoryId));
+
+			this.categoryId = categoryId;
+		}
+
+		public long categoryId;
+
+	}
+
 	public static class MustNotDelete extends SystemCategoryException {
 
 		public MustNotDelete(long categoryId) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97548

## What Is Being Fixed

LPD-97548, a subtask of LPD-96309 (system-managed categories), requires that system categories not support subcategories. That constraint was never enforced: a child category could still be added under a system category through the service, the headless taxonomy API, and both the DXP and CMS category UIs.

## How It Is Being Fixed

The service layer (AssetCategoryLocalServiceImpl) now rejects adding or moving a category under a system parent, throwing the new SystemCategoryException.MustNotAddChild. The check is gated by feature flag LPD-86291 and exempt during import, matching the existing rename and delete guards. The headless converter drops the add-category hypermedia action from a system category, so the existing exception mapper returns 403 and the CMS data-set UI hides "Add Subcategory" with no frontend change. The DXP admin categories UI hides the "Add Subcategory" dropdown item for system categories. Service and headless integration tests plus an updated CMS Playwright test cover the behavior.

## PR Check

**pr-check: PASS** — tested on `910a8400cef4ea6f56592b8eac4bff76dc157697`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "910a8400cef4ea6f56592b8eac4bff76dc157697"} -->
