### PR TITLE
LPD-97710 Register orphaned Playwright projects in test.properties

### DIFF
--- a/modules/apps/asset/asset-publisher-web/test.properties
+++ b/modules/apps/asset/asset-publisher-web/test.properties
@@ -12,7 +12,8 @@ modules.includes.required.test.batch.class.names.includes[modules-unit][relevant
     **/asset-publisher-test/**/*Test.java
 
 playwright.projects.includes[playwright-js-tomcat101-postgresql163][relevant][asset-publisher-web-playwright-rule]=\
-    asset-publisher-web.main
+    asset-publisher-web.main,\
+    asset-publisher-web.related-assets
 
 relevant.rule.names=\
     asset-publisher-web-java-rule,\

--- a/modules/apps/message-boards/message-boards-web/test.properties
+++ b/modules/apps/message-boards/message-boards-web/test.properties
@@ -2,7 +2,8 @@ modified.files.includes[relevant][message-boards-web-functional-rule]=**
 modified.files.includes[relevant][message-boards-web-playwright-rule]=**
 
 playwright.projects.includes[playwright-js-tomcat101-postgresql163][relevant][message-boards-web-playwright-rule]=\
-    message-boards-web.main
+    message-boards-web.main,\
+    message-boards-web.pagination
 
 relevant.rule.names=\
     message-boards-web-functional-rule,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97710

## What Is Being Fixed

Two Playwright projects created by earlier Poshi to Playwright migrations were imported in playwright.config.ts but never added to a module test.properties playwright.projects.includes rule, so CI and Testray silently skipped their specs even though the corresponding Poshi sources were already deleted. The affected projects are asset-publisher-web.related-assets (from LPD-96964, Related Assets Widget) and message-boards-web.pagination (from LPD-97205, Message Boards). Each module already registered its .main project, which masked the gap. This is the same class of gap fixed for translation-web in LPD-97597.

## How It Is Being Fixed

Each orphaned project name is appended to the existing playwright.projects.includes rule in its module test.properties, next to the already-registered .main project: asset-publisher-web.related-assets in modules/apps/asset/asset-publisher-web/test.properties and message-boards-web.pagination in modules/apps/message-boards/message-boards-web/test.properties. No other changes are needed because the module rules and the batch already exist.

## Why Are There No Tests?

This is a CI test-registration change to test.properties only, with no product or test code. It enables already-migrated Playwright specs to run in CI, so there is nothing to unit test.

## PR Check

**pr-check: PASS** — tested on `b529c1e7a36cc8267650c542060c11bcbc4bd178`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "b529c1e7a36cc8267650c542060c11bcbc4bd178"} -->
