### PR TITLE
LPD-97712 Fix flaky Add Subcategory categorization test

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -600,15 +600,18 @@ test.describe('Subcategory tests', () => {
 
 			await editCategoryPage.clickSave();
 
-			await categoriesPage.assertBreadcrumbItemText(1, vocabularyName);
+			await expect(async () => {
+				await categoriesPage.gotoSubcategories(
+					categoryId,
+					categoryName,
+					vocabularyId,
+					vocabularyName
+				);
 
-			await expect(categoriesPage.getItem('1')).toBeVisible();
-
-			await categoriesPage.getItem('1').click();
-
-			await categoriesPage.assertBreadcrumbItemText(2, categoryName);
-
-			await expect(categoriesPage.getItem(subcategoryName)).toBeVisible();
+				await expect(
+					categoriesPage.getItem(subcategoryName)
+				).toBeVisible({timeout: 5000});
+			}).toPass();
 		}
 	);
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97712

## What Is Being Fixed

The Playwright test "Subcategories can be created within a Category from the dropdown actions" (`@LPD-54221`, `categories.spec.ts`) was flaky, failing roughly 40% of runs with a 90s timeout waiting for `.breadcrumb-bar` `.breadcrumb-item` `nth(2)` to be visible.

## How It Is Being Fixed

After saving a subcategory from the dropdown action the UI already sits inside the category, but the test navigated with an ambiguous `getItem('1')` row click and a positional breadcrumb assertion. That click sometimes drilled one level deeper into the subcategory, growing the breadcrumb past three levels, at which point ClayBreadcrumb collapses the trail behind a toggle and the positional `.breadcrumb-item.nth(2)` no longer existed, so the assertion timed out. The categorization list is also search-backed and occasionally lags behind a newly created subcategory. The test now navigates deterministically into the category with `gotoSubcategories` and retries until the subcategory appears.

## Why Are There No Tests?

This change only modifies an existing Playwright test to remove flakiness; the test itself is the change under review. It was validated with `--repeat-each=10 --workers=1` across two rounds (20/20 green) where the original failed roughly 40% of the time.

## PR Check

**pr-check: PASS** — tested on `7f20d8d76332e26d750298021f431e36951d85d4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "7f20d8d76332e26d750298021f431e36951d85d4"} -->
