### PR TITLE
LPD-97732 Fix flaky Create AI Image instance-settings test

### DIFF
--- a/modules/test/playwright/tests/document-library-web/main/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/dmAICreator.spec.ts
@@ -48,11 +48,17 @@ test(
 	}) => {
 		await aiCreatorInstanceSettingsPage.disableDalleCreateImages();
 
-		await documentLibraryPage.goto(site.friendlyUrlPath);
-		await documentLibraryPage.openNewButton();
-		await expect(
-			page.getByRole('menuitem', {name: 'Create AI Image'})
-		).not.toBeVisible();
+		await expect(async () => {
+			await documentLibraryPage.goto(site.friendlyUrlPath);
+			await documentLibraryPage.openNewButton();
+
+			await expect(
+				page.getByRole('menuitem', {exact: true, name: 'Folder'})
+			).toBeVisible({timeout: 3000});
+			await expect(
+				page.getByRole('menuitem', {name: 'Create AI Image'})
+			).toBeHidden();
+		}).toPass();
 
 		await aiCreatorInstanceSettingsPage.enableDalleCreateImages();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97732

## What Is Being Fixed

The Playwright test "Create AI Image option is hidden when disabled from Instance Settings" (`@LPD-6717`, `@LPD-6691`, `dmAICreator.spec.ts`) was flaky in CI, failing with a 15s timeout on `expect(getByRole('menuitem', {name: 'Create AI Image'})).not.toBeVisible()` — the option stayed visible after DALL-E was disabled.

## How It Is Being Fixed

The test disables DALL-E from Instance Settings and then immediately navigates to the document library and asserts the "Create AI Image" option is gone. The "New" menu is rendered server-side and reads the DALL-E company configuration, whose invalidation is eventually consistent, so a loaded CI box occasionally rendered the menu from the stale, still-enabled configuration and the option remained visible for the whole timeout. Because the menu is static once rendered, re-opening the dropdown could not recover it. The test now reloads the document library until the freshly rendered menu reflects the disabled setting, anchoring on the always-present "Folder" item so the absence assertion cannot pass before the menu opens.

## Why Are There No Tests?

This change only modifies an existing Playwright test to remove flakiness; the test itself is the change under review. It was validated with `--repeat-each=10 --workers=1` (10/10 green).

## PR Check

**pr-check: PASS** — tested on `fc0fa41edfc637db550f61a7d432ba3bec5122ea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "fc0fa41edfc637db550f61a7d432ba3bec5122ea"} -->
