### PR TITLE
LPD-97728 Stabilize two journal-web translation Playwright tests

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -285,7 +285,7 @@ baseTest(
 	}
 );
 
-baseTest(
+ckeditor5Test(
 	'Check that upload field is marked as translated',
 	{
 		tag: '@LPD-66008',

--- a/modules/test/playwright/tests/journal-web/main/translation.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/translation.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {siteSettingsPagesTest} from '../../../fixtures/siteSettingsPagesTest';
+import {changeManagementToolbarView} from '../../../utils/changeManagementToolbarView';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getGlobalSiteId from '../../../utils/getGlobalSiteId';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
@@ -53,6 +54,8 @@ test(
 			});
 
 			await journalPage.goto(site.friendlyUrlPath);
+
+			await changeManagementToolbarView(page, 'List');
 
 			await clickAndExpectToBeVisible({
 				autoClick: true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97728

## What Is Being Fixed

Two journal-web Playwright tests were failing.

*Check that upload field is marked as translated* (`journalArticle.spec.ts`) failed locally. It drives the content editor through markup that only exists when the newer inline editor is enabled, so on a bundle where that editor is off the editable never appears and the interaction times out.

*Stored script payload sanitized in the translation editor and processes list* (`translation.spec.ts`) failed in CI. The row-actions button it clicks only carries the `Actions for X` label in the descriptive list view. When an earlier test in the shard left the journal admin list in the table view (a per-user preference that persists across sites), the button is labeled differently and the click times out.

## How It Is Being Fixed

The upload-field test now runs under the `ckeditor5Test` wrapper, which pins the `LPD-11235` feature flag off so the test always exercises the inline-editor markup it targets, matching the CI default.

The sanitization test now forces the journal admin list into the List (descriptive) view before opening the row actions, removing its dependency on the ambient per-user display-style preference that a previous test can leave in a different state.

## PR Check

**pr-check: PASS** — tested on `5ed2ae88e33d452f487464726f4d2c209878f4dc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "5ed2ae88e33d452f487464726f4d2c209878f4dc"} -->
