### PR TITLE
LPD-97734 Fix flaky Asset Publisher Playwright tests

### DIFF
--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
@@ -46,6 +46,8 @@ export class AssetPublisherPage {
 	}
 
 	async changeAssetSelection(type: 'Collection' | 'Dynamic' | 'Manual') {
+		await this.openAssetSelectionTab();
+
 		await this.configurationIframe.getByLabel(type).click();
 
 		await waitForAlert(

--- a/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
@@ -236,12 +236,16 @@ test(
 
 		// Create a space and connect it to the site
 
-		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-			externalReferenceCode: getRandomString(),
-			name: `Space ${getRandomString()}`,
-			settings: {},
-			type: 'Space',
-		});
+		let space;
+
+		await expect(async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				externalReferenceCode: getRandomString(),
+				name: `Space ${getRandomString()}`,
+				settings: {},
+				type: 'Space',
+			});
+		}).toPass();
 
 		await apiHelpers.headlessAssetLibrary.connectSite(
 			space.externalReferenceCode,
@@ -333,28 +337,34 @@ test(
 
 		await pageEditorPage.publishPage();
 
-		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
-
 		const titleLocator = page
-			.locator(`[data-analytics-asset-title="${title}"]`)
+			.locator(
+				`[data-analytics-asset-title="${title}"][data-analytics-asset-type]`
+			)
 			.first();
 
-		await expect(titleLocator).toBeVisible();
+		await expect(async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+			);
 
-		await expect(titleLocator).toHaveAttribute(
-			'data-analytics-asset-type',
-			'object-entry'
-		);
+			await expect(titleLocator).toBeVisible({timeout: 3000});
 
-		await expect(titleLocator).toHaveAttribute(
-			'data-analytics-external-reference-code',
-			/.+/
-		);
+			await expect(titleLocator).toHaveAttribute(
+				'data-analytics-asset-type',
+				'object-entry'
+			);
 
-		await expect(titleLocator).toHaveAttribute(
-			'data-analytics-object-definition-name',
-			'cms-basic-web-content'
-		);
+			await expect(titleLocator).toHaveAttribute(
+				'data-analytics-external-reference-code',
+				/.+/
+			);
+
+			await expect(titleLocator).toHaveAttribute(
+				'data-analytics-object-definition-name',
+				'cms-basic-web-content'
+			);
+		}).toPass();
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97734

## What Is Being Fixed

Four Asset Publisher Playwright tests were flaky in CI: "Create manual collection from asset publisher configuration", "Create dynamic collection from asset publisher configuration" and "Add file to documents and media through asset publisher" (`@LPD-32724`, `@LPD-33784`), plus "Emits object entry analytics attributes for CMS basic web content" (`@LPD-93309`).

## How It Is Being Fixed

The three configuration tests change the asset selection through `AssetPublisherPage.changeAssetSelection`, which clicked the Dynamic/Manual radio without first opening the "Asset Selection" tab. That radio lives on the legacy portlet configuration's Asset Selection tab, so the click only worked when that tab happened to be active on open; on a loaded CI box a different tab was active, leaving the radio present but hidden until the test timed out. The helper now opens the Asset Selection tab before clicking the radio.

The analytics test failed at its first step: creating a Space asset library through the headless API returned a 400 `UnsupportedOperationException` because the `LPD-17564` feature flag enabled by the fixture had not propagated server-side by the time the immediately-following flag-gated request fired; it now retries the creation until the flag is active. Its final assertion also selected the rendered entry with a plain `data-analytics-asset-title` locator, which the Asset Publisher applies to several nodes while only one carries the analytics type attributes, so `first()` could pick a node without them; the locator now requires `data-analytics-asset-type`, and the published page is reloaded until that element renders to account for the search-backed collection lag.

## Why Are There No Tests?

This change only modifies existing Playwright tests and their shared page object to remove flakiness. The configuration tests were validated with `--repeat-each` (9/9) and the analytics test with `--repeat-each=8 --workers=1` (8/8) against a clean bundle.

## PR Check

**pr-check: PASS** — tested on `e05a56aa1587896e7a5130aa35b8511f54bb7b31`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e05a56aa1587896e7a5130aa35b8511f54bb7b31"} -->
