### PR TITLE
LPD-97856 Respect the account locale when validating schedule dates

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ScheduleField.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ScheduleField.tsx
@@ -151,12 +151,11 @@ export default React.forwardRef(function ScheduleField(
 	);
 });
 
-function isPastDate(value: string) {
-	const languageId = Liferay.ThemeDisplay.getBCP47LanguageId();
+export function isPastDate(value: string) {
 	const timeZone = Liferay.ThemeDisplay.getTimeZone();
 
 	const timeZoneDateTime = new Date(
-		new Date().toLocaleString(languageId, {
+		new Date().toLocaleString('en-US', {
 			timeZone,
 		})
 	);

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ScheduleField.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ScheduleField.test.tsx
@@ -8,7 +8,9 @@ import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import ScheduleField from '../../../../src/main/resources/META-INF/resources/js/content_editor/components/ScheduleField';
+import ScheduleField, {
+	isPastDate,
+} from '../../../../src/main/resources/META-INF/resources/js/content_editor/components/ScheduleField';
 
 const DATE_CONFIG = {
 	clayFormat: 'MM/dd/yyyy',
@@ -156,5 +158,37 @@ describe('ScheduleField', () => {
 		await waitFor(() => {
 			expect(screen.queryByText('error')).not.toBeInTheDocument();
 		});
+	});
+});
+
+describe('isPastDate', () => {
+	const originalGetBCP47LanguageId =
+		global.Liferay.ThemeDisplay.getBCP47LanguageId;
+
+	beforeEach(() => {
+		jest.useFakeTimers().setSystemTime(new Date('2026-07-10T08:00:00Z'));
+
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('UTC');
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+
+		global.Liferay.ThemeDisplay.getBCP47LanguageId =
+			originalGetBCP47LanguageId;
+	});
+
+	it('does not flag a future date as past when the account locale swaps the day and month', () => {
+		global.Liferay.ThemeDisplay.getBCP47LanguageId = jest
+			.fn()
+			.mockReturnValue('cs-CZ');
+
+		expect(isPastDate('07/10/2026 09:00 PM')).toBe(false);
+	});
+
+	it('flags an earlier time on the current day as past', () => {
+		expect(isPastDate('07/10/2026 07:00 AM')).toBe(true);
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97856

## What Is Being Fixed

Under an account locale whose date format is not US-style (for example cs_CZ, `DD.MM.YYYY`), the CMS content editor rejected valid future Expiration and Review dates with "the date entered is in the past", while a wrongly ordered US-style date was accepted. The problem also depended on the calendar day: on days 1–12 the current date was shifted forward, and on days 13–31 the past-date check was effectively disabled.

## How It Is Being Fixed

The past-date validation built its "now" reference by reparsing a locale-formatted string with the JavaScript `Date` constructor. That constructor always assumes US month/day ordering and ignores the locale, so a cs_CZ string like "10. 7. 2026" was read as October 7th, pushing "now" months into the future and corrupting the comparison. "Now" is now formatted with a fixed `en-US` pattern so it parses deterministically regardless of the account locale, while the value the user enters keeps being parsed with the locale-aware moment format. A unit test asserts that a future date under a day/month-swapping locale is no longer flagged as past, and fails against the previous implementation.

## PR Check

**pr-check: PASS** — tested on `c23c4892f6665`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c23c4892f6665e1419081551b7c277e18f5a4df4"} -->
