### PR TITLE
LPD-97452 Revert wiring the e2e-cms-dxp tests into the cms suite

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/config.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/config.ts
@@ -4,7 +4,6 @@
  */
 
 export const config = {
-	dependencies: ['site-cms-site.main'],
 	name: 'e2e-cms-dxp.main',
 	testDir: 'tests/e2e-cms-dxp/main',
 };

--- a/test.properties
+++ b/test.properties
@@ -3017,7 +3017,6 @@
     modules.includes[js-unit][cms]=apps/site/site-cms-site-initializer
 
     playwright.projects.includes[playwright-js-tomcat101-*][cms]=\
-        e2e-cms-dxp.main,\
         site-cms-site-initializer.main,\
         site-cms-site-initializer.permissions,\
         site-cms-site-initializer.structure-builder


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97452
https://liferay.atlassian.net/browse/LPD-97631

## What Is Being Fixed

The e2e-cms-dxp Playwright tests were wired into the cms suite across two changes: LPD-97452 added `e2e-cms-dxp.main` to the cms project includes in `test.properties`, and LPD-97625/LPD-97631 added a `site-cms-site.main` dependency to `e2e-cms-dxp/main/config.ts` to provision the CMS environment. That wiring is being backed out.

## How It Is Being Fixed

Two reverts. The first removes `e2e-cms-dxp.main` from the `playwright.projects.includes[...][cms]` list in `test.properties`, so the suite no longer runs the consolidated project. The second removes the `dependencies: ['site-cms-site.main']` entry from `e2e-cms-dxp/main/config.ts`. The LPD-97452 test consolidation itself (the single-project folder structure) is intentionally kept.

## Why Are There No Tests?

This PR only reverts test-suite wiring (a `test.properties` include and a Playwright project dependency). No product code changes, so no test coverage applies.

## PR Check

**pr-check: PASS** — tested on `792b3ee6fa57bfe587a8c72c23cdae94d56e07f8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "792b3ee6fa57bfe587a8c72c23cdae94d56e07f8"} -->
