### PR TITLE
LPD-98091 Register migrated Playwright projects in the scoped run

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -3177,21 +3177,27 @@
     #
 
     content.management.playwright.projects=\
+        ai-creator-openai-web.main,\
         announcements-web.main,\
         asset-categories-admin-web.main,\
         asset-publisher-web.main,\
+        asset-publisher-web.related-assets,\
         asset-tags-admin-web.main,\
         blogs-web.main,\
         content-dashboard-web.main,\
+        depot-web.main,\
         document-library-web.main,\
         item-selector-taglib.main,\
         journal-web.main,\
         knowledge-base-web.main,\
         locked-items-web.main,\
         message-boards-web.main,\
+        message-boards-web.pagination,\
         notifications-web.main,\
         questions-web.main,\
         site-cms-site-initializer.main,\
+        translation-web.main,\
+        trash-web.main,\
         wiki-web.main
 
     content.management.testing.modules=\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98091

## What Is Being Fixed

The Content Management scoped Playwright run executes only the projects listed in the content.management.playwright.projects property in test.properties. Several projects migrated from Poshi were registered in playwright.config.ts and in their module test.properties, but were never added to this list, so they run only in the full acceptance build and are absent from the CM scoped run — under-reporting our team's Playwright coverage.

## How It Is Being Fixed

Adds the six affected Content Management Playwright projects to content.management.playwright.projects, keeping the list alphabetical: ai-creator-openai-web.main, asset-publisher-web.related-assets, depot-web.main, message-boards-web.pagination, translation-web.main, and trash-web.main. The batch include properties playwright.projects.includes[playwright-js-tomcat101-*][content-management] and [content-management-playwright] both dereference this variable, so no other change is needed for the scoped run to execute them.

## Why Are There No Tests?

The change only registers existing Playwright projects in the CI scoped-run list. There is no product code to exercise, and the registered projects are themselves the tests; PQL validation of test.properties passes in pr-check.

## PR Check

**pr-check: PASS** — tested on `3cdaec1a7526ea747f61debb6260c3fdaf53f0cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "3cdaec1a7526ea747f61debb6260c3fdaf53f0cf"} -->
