### PR TITLE
LPD-97993 Clear the asset entry layoutUuid on display page deletion

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1481,7 +1481,16 @@ public class JournalArticleLocalServiceImpl
 		List<JournalArticle> articles = journalArticlePersistence.findByG_L(
 			groupId, layoutUuid);
 
+		Set<Long> processedResourcePrimKeys = new HashSet<>();
+
 		for (JournalArticle article : articles) {
+			_deleteLayoutArticleReferences(article.getPrimaryKey(), layoutUuid);
+
+			if (processedResourcePrimKeys.add(article.getResourcePrimKey())) {
+				_deleteLayoutArticleReferences(
+					article.getResourcePrimKey(), layoutUuid);
+			}
+
 			article.setLayoutUuid(StringPool.BLANK);
 
 			journalArticlePersistence.update(article);
@@ -7909,6 +7918,23 @@ public class JournalArticleLocalServiceImpl
 		finally {
 			serviceContext.setIndexingEnabled(indexingEnabled);
 		}
+	}
+
+	private void _deleteLayoutArticleReferences(
+		long classPK, String layoutUuid) {
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			JournalArticle.class.getName(), classPK);
+
+		if ((assetEntry == null) ||
+			!Objects.equals(layoutUuid, assetEntry.getLayoutUuid())) {
+
+			return;
+		}
+
+		assetEntry.setLayoutUuid(StringPool.BLANK);
+
+		_assetEntryLocalService.updateAssetEntry(assetEntry);
 	}
 
 	private boolean _equals(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -66,6 +66,7 @@ import com.liferay.journal.util.comparator.ArticleVersionComparator;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -1334,6 +1335,44 @@ public class JournalArticleLocalServiceTest {
 				Assert.assertEquals(StringPool.BLANK, entry.getValue());
 			}
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-97993")
+	public void testDeleteLayoutArticleReferences() throws Exception {
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		journalArticle = _journalArticleLocalService.updateArticle(
+			journalArticle.getUserId(), journalArticle.getGroupId(),
+			journalArticle.getFolderId(), journalArticle.getArticleId(),
+			journalArticle.getVersion(), journalArticle.getTitleMap(),
+			journalArticle.getDescriptionMap(), journalArticle.getContent(),
+			layout.getUuid(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		AssetEntry assetEntry = _assetEntryLocalService.getEntry(
+			JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey());
+
+		Assert.assertEquals(layout.getUuid(), assetEntry.getLayoutUuid());
+
+		_journalArticleLocalService.deleteLayoutArticleReferences(
+			_group.getGroupId(), layout.getUuid());
+
+		journalArticle = _journalArticleLocalService.getArticle(
+			journalArticle.getGroupId(), journalArticle.getArticleId());
+
+		Assert.assertEquals(StringPool.BLANK, journalArticle.getLayoutUuid());
+
+		assetEntry = _assetEntryLocalService.getEntry(
+			JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey());
+
+		Assert.assertEquals(StringPool.BLANK, assetEntry.getLayoutUuid());
 	}
 
 	@Test(expected = DuplicateArticleIdException.class)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97993

## What is this trying to solve?

When a layout set as the legacy display page of a web content article is deleted, the layoutUuid is cleared on the JournalArticle records but the corresponding AssetEntry keeps the stale value. The inconsistency later causes a java.lang.StackOverflowError during search suggestion retrieval, because URL generation loops on an asset pointing to a nonexistent layout.

## How am I fixing it?

JournalArticleLocalServiceImpl#deleteLayoutArticleReferences, invoked by the journal LayoutModelListener when a layout is deleted, now also clears the layoutUuid on the article's asset entries — both the main entry keyed by resourcePrimKey and a possible draft entry keyed by the article id — guarded so it only touches an entry whose layoutUuid matches the deleted layout. Journal is the only writer of a real layoutUuid into AssetEntry, so the fix lives next to the existing article-side cleanup and stays group-scoped, which avoids the cross-group UUID collisions a global asset-side cleanup would risk with staging.

## How can you verify that it works?

Run the new integration test, which creates a layout, sets it as an article's display page, deletes the layout, and asserts the layoutUuid is cleared on both the JournalArticle and the AssetEntry:

```
cd modules/apps/journal/journal-test && gradlew testIntegration --tests JournalArticleLocalServiceTest.testDeleteLayoutArticleReferences
```

## PR Check

**pr-check: PASS** — tested on `f0cf3a1435b63413dc27975338c12e13dc57acf8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f0cf3a1435b63413dc27975338c12e13dc57acf8"} -->
