### PR TITLE
LPD-98136 Shrink the Documents & Media Poshi test suite

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
@@ -2440,6 +2440,73 @@ definition {
 		}
 	}
 
+	@description = "This test covers LPS-104957. It ensures that JPG, PNG, and SVG files can be previewed."
+	@priority = 5
+	@refactordone
+	test CanPreviewImageFormats {
+		property portal.acceptance = "true";
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Document_1.jpg",
+			groupName = "Guest",
+			mimeType = "image/jpeg",
+			sourceFileName = "Document_1.jpg");
+
+		DMNavigator.openToEntryInAdmin(
+			dmDocumentTitle = "Document_1.jpg",
+			groupName = "Guest",
+			siteURLKey = "guest");
+
+		AssertVisible(
+			key_dmDocumentFileName = "Document_1.jpg",
+			locator1 = "DocumentsAndMediaDocument#DOCUMENT_DETAILS_IMAGE_PREVIEW");
+
+		DMDocument.expandInfo();
+
+		AssertVisible(locator1 = "DocumentsAndMediaDocument#DOCUMENT_INFO_THUMBNAIL");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Document_1.png",
+			groupName = "Guest",
+			mimeType = "image/png",
+			sourceFileName = "Document_1.png");
+
+		DMNavigator.openToEntryInAdmin(
+			dmDocumentTitle = "Document_1.png",
+			groupName = "Guest",
+			siteURLKey = "guest");
+
+		AssertVisible(
+			key_dmDocumentFileName = "Document_1.png",
+			locator1 = "DocumentsAndMediaDocument#DOCUMENT_DETAILS_IMAGE_PREVIEW");
+
+		DMDocument.expandInfo();
+
+		AssertVisible(locator1 = "DocumentsAndMediaDocument#DOCUMENT_INFO_THUMBNAIL");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Document_1.svg",
+			groupName = "Guest",
+			mimeType = "image/svg+xml",
+			sourceFileName = "Document_1.svg");
+
+		DMNavigator.openToEntryInAdmin(
+			dmDocumentTitle = "Document_1.svg",
+			groupName = "Guest",
+			siteURLKey = "guest");
+
+		AssertVisible(
+			key_dmDocumentFileName = "Document_1.svg",
+			locator1 = "DocumentsAndMediaDocument#DOCUMENT_DETAILS_IMAGE_PREVIEW");
+
+		DMDocument.expandInfo();
+
+		AssertVisible(locator1 = "DocumentsAndMediaDocument#DOCUMENT_INFO_THUMBNAIL");
+	}
+
 	@description = "This ensures that an image can be previewed through the original URL."
 	@priority = 5
 	@refactordone
@@ -2464,33 +2531,6 @@ definition {
 		var key_imageSourceURL = "${portalURL}/documents/${siteId}/0/Document_1";
 
 		WaitForVisible(locator1 = "DocumentsAndMediaDocument#DOCUMENT_VIEWPORT_PREVIEW");
-	}
-
-	@description = "This test covers LPS-104957. It ensures that the JPG file can be previewed."
-	@priority = 5
-	@refactordone
-	test CanPreviewJPG {
-		property portal.acceptance = "true";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.jpg",
-			groupName = "Guest",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		DMNavigator.openToEntryInAdmin(
-			dmDocumentTitle = "Document_1.jpg",
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		AssertVisible(
-			key_dmDocumentFileName = "Document_1.jpg",
-			locator1 = "DocumentsAndMediaDocument#DOCUMENT_DETAILS_IMAGE_PREVIEW");
-
-		DMDocument.expandInfo();
-
-		AssertVisible(locator1 = "DocumentsAndMediaDocument#DOCUMENT_INFO_THUMBNAIL");
 	}
 
 	@description = "This is a use case for LPS-88785."
@@ -2597,33 +2637,6 @@ definition {
 			value2 = ${latestVersionURL});
 	}
 
-	@description = "This test covers LPS-104957. It ensures that the PNG file can be previewed."
-	@priority = 5
-	@refactordone
-	test CanPreviewPNG {
-		property portal.acceptance = "true";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.png",
-			groupName = "Guest",
-			mimeType = "image/png",
-			sourceFileName = "Document_1.png");
-
-		DMNavigator.openToEntryInAdmin(
-			dmDocumentTitle = "Document_1.png",
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		AssertVisible(
-			key_dmDocumentFileName = "Document_1.png",
-			locator1 = "DocumentsAndMediaDocument#DOCUMENT_DETAILS_IMAGE_PREVIEW");
-
-		DMDocument.expandInfo();
-
-		AssertVisible(locator1 = "DocumentsAndMediaDocument#DOCUMENT_INFO_THUMBNAIL");
-	}
-
 	@description = "This ensures that users can preview a version entry from the Version History page."
 	@priority = 5
 	test CanPreviewSpecifiedFileVersionFromVersionPage {
@@ -2660,33 +2673,6 @@ definition {
 		DMDocument.viewCP(
 			dmDocumentTitle = "Document Version 1.9 (Version 1.9)",
 			previewImage = "Document_1.jpg");
-	}
-
-	@description = "This ensures that the SVG file can be previewed."
-	@priority = 5
-	@refactordone
-	test CanPreviewSVG {
-		property portal.acceptance = "true";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.svg",
-			groupName = "Guest",
-			mimeType = "image/svg+xml",
-			sourceFileName = "Document_1.svg");
-
-		DMNavigator.openToEntryInAdmin(
-			dmDocumentTitle = "Document_1.svg",
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		AssertVisible(
-			key_dmDocumentFileName = "Document_1.svg",
-			locator1 = "DocumentsAndMediaDocument#DOCUMENT_DETAILS_IMAGE_PREVIEW");
-
-		DMDocument.expandInfo();
-
-		AssertVisible(locator1 = "DocumentsAndMediaDocument#DOCUMENT_INFO_THUMBNAIL");
 	}
 
 	@description = "This test ensures that a document with special characters in its title can be published successfully."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
@@ -328,42 +328,6 @@ definition {
 		DMDocument.viewCategories(categoryNameList = "category");
 	}
 
-	@description = "This test ensures that Users can copy multiple documents at the same time."
-	@priority = 5
-	test CanBulkCopyFiles {
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		for (var entryCount : list "1,2,3") {
-			JSONDocument.addFileWithUploadedFile(
-				dmDocumentDescription = "DM Document Description",
-				dmDocumentTitle = "Document_${entryCount}.jpg",
-				groupName = "Guest",
-				mimeType = "image/jpeg",
-				sourceFileName = "Document_${entryCount}.jpg");
-		}
-
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
-
-		DMFolder.deleteCP(dmFolderName = "Provided by Liferay");
-
-		PortletEntry.selectAll();
-
-		DMNavigator.gotoItemViaManagementBar(
-			item = "dropdownMenu",
-			menuItem = "Copy To");
-
-		DMDocument.copy(
-			bulkCopy = "true",
-			homeFolder = "true",
-			siteName = "Site Name");
-
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
-
-		for (var entryCount : list "1,2,3") {
-			LexiconEntry.viewEntryName(rowEntry = "Document_${entryCount}.jpg");
-		}
-	}
-
 	@description = "This test ensures that document permissions can be copied over correctly."
 	@priority = 4
 	test CanBulkCopyFilesPermission {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFolder.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFolder.testcase
@@ -61,24 +61,6 @@ definition {
 			dmDocumentTitle = "Document_1.doc");
 
 		DMDocument.viewPG(dmDocumentTitle = "Document_1.doc");
-	}
-
-	@priority = 4
-	@refactordone
-	test CanAddImageInFolder {
-		property custom.properties = "dl.actions.visible=true";
-		property portal.acceptance = "true";
-
-		JSONFolder.addFolder(
-			dmFolderDescription = "DM Folder Description",
-			dmFolderName = "DM Folder Name",
-			groupName = "Guest");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		LexiconEntry.changeDisplayStyle(displayStyle = "list");
-
-		DMNavigator.gotoFolder(dmFolderName = "DM Folder Name");
 
 		DMDocument.addPG(
 			dmDocumentDescription = "DM Image Description",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFriendlyURL.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFriendlyURL.testcase
@@ -463,49 +463,4 @@ definition {
 			image = "Document_1");
 	}
 
-	@description = "This ensures that the friendlyURL can be used when a user accesses a document template."
-	@priority = 4
-	test CanViewImageWithTemplate {
-		var portalURL = PropsUtil.get("portal.url");
-
-		JSONLayoutpagetemplate.addDisplayPageTemplateEntry(
-			contentType = "Document",
-			displayPageTemplateEntryName = "Display Page Template Name",
-			groupName = "Site Name",
-			subType = "Basic Document");
-
-		DisplayPageTemplate.addFragment(
-			collectionName = "Content Display",
-			displayPageName = "Display Page Template Name",
-			fragmentName = "Display Page Content",
-			siteURLKey = "site-name");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1",
-			groupName = "Site Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		DisplayPageTemplate.selectDisplayPageTemplateForAsset(
-			assetType = "Document",
-			entryTitle = "Document_1",
-			groupName = "Site Name",
-			pageName = "Display Page Template Name",
-			siteURLKey = "site-name");
-
-		Button.clickPublish();
-
-		DMNavigator.openToEditEntryInSite(
-			dmDocumentTitle = "Document_1",
-			groupName = "Site Name",
-			siteURLKey = "site-name");
-
-		DMDocument.editFriendlyURL(friendlyURLEdit = "document_1_edit");
-
-		Navigator.openSpecificURL(url = "${portalURL}/web/site-name/d/document_1_edit");
-
-		ContentPages.viewFragmentBackgroundImage(image = "Document_1.jpg");
-	}
-
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalization.testcase
@@ -52,9 +52,9 @@ definition {
 			fileExtension = ".txt");
 	}
 
-	@description = "This test ensures that a Japanese file can be downloaded by file name."
+	@description = "This test ensures that a Japanese file can be downloaded by file name or by title."
 	@priority = 4
-	test CanDownloadJapaneseFileByFileName {
+	test CanDownloadJapaneseFileByFileNameOrTitle {
 		var portalURL = PropsUtil.get("portal.url");
 		var siteId = JSONGroupAPI._getGroupIdByName(
 			groupName = "Guest",
@@ -74,22 +74,6 @@ definition {
 		AssertTextNotPresent(value1 = "The requested resource could not be found.");
 
 		DMDocument.assertFileNameFromTempFolder(fileName = "これは文書です.txt");
-	}
-
-	@description = "This test ensures that a Japanese file can be downloaded by title."
-	@priority = 4
-	test CanDownloadJapaneseFileByTitle {
-		var portalURL = PropsUtil.get("portal.url");
-		var siteId = JSONGroupAPI._getGroupIdByName(
-			groupName = "Guest",
-			site = "true");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM文書記述",
-			dmDocumentTitle = "これは文書です",
-			groupName = "Guest",
-			mimeType = "image/jpeg",
-			sourceFileName = "これは文書です.txt");
 
 		Navigator.openSpecificURL(url = "${portalURL}/documents/${siteId}/0/これは文書です");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMMediaGallery.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMMediaGallery.testcase
@@ -258,6 +258,12 @@ definition {
 		SearchResults.viewSearchResults(
 			searchAssetTitle = "DM Document Title",
 			searchAssetType = "Document");
+
+		Navigator.gotoPage(pageName = "Media Gallery Page");
+
+		SearchPage.searchEmbedded(searchTerm = "asdf");
+
+		SearchResults.viewNoSearchResults(searchTerm = "asdf");
 	}
 
 	@description = "This test covers LPS-153892. It ensures that the external video shortcuts can be rendered."
@@ -382,23 +388,6 @@ definition {
 		DMDocument.viewPGViaMG(
 			mgDocumentTitle = "DM Document Title",
 			mgVideoPreview = "true");
-	}
-
-	@priority = 3
-	@refactordone
-	test DocumentWillNotAppearIfSearchQueryIsIrrelevant {
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Guest",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		Navigator.gotoPage(pageName = "Media Gallery Page");
-
-		SearchPage.searchEmbedded(searchTerm = "asdf");
-
-		SearchResults.viewNoSearchResults(searchTerm = "asdf");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
@@ -2254,9 +2254,9 @@ definition {
 		AssertElementNotPresent(locator1 = "Button#PERMISSIONS");
 	}
 
-	@description = "This is a test for LPS-136850. It checks that a site member cannot update a folder without permissions."
+	@description = "This is a test for LPS-136850 and LPS-136844. It checks that a site member cannot update a folder or its permissions without permissions."
 	@priority = 3
-	test SiteMemberCannotUpdateFolder {
+	test SiteMemberCannotUpdateFolderOrFolderPermissions {
 		JSONUser.addUser(
 			userEmailAddress = "userea@liferay.com",
 			userFirstName = "userfn",
@@ -2301,65 +2301,15 @@ definition {
 			card = "DM Folder Name",
 			item = "Edit");
 
+		LexiconCard.viewMenuItemNotPresent(
+			card = "DM Folder Name",
+			item = "Permissions");
+
 		DMNavigator.gotoFolder(dmFolderName = "DM Folder Name");
 
 		DMDocument.gotoMenuItemViaInfoPanel();
 
 		MenuItem.viewNotPresent(menuItem = "Edit");
-	}
-
-	@description = "This is a test for LPS-136844. It checks that a site member cannot update the permissions of a folder without permissions."
-	@priority = 3
-	test SiteMemberCannotUpdateFolderPermissions {
-		JSONUser.addUser(
-			userEmailAddress = "userea@liferay.com",
-			userFirstName = "userfn",
-			userLastName = "userln",
-			userScreenName = "usersn");
-
-		JSONUser.setFirstPassword(
-			agreeToTermsAndAnswerReminderQuery = "true",
-			requireReset = "false",
-			userEmailAddress = "userea@liferay.com");
-
-		JSONUser.addUserToSite(
-			groupName = "Guest",
-			userEmailAddress = "userea@liferay.com");
-
-		JSONLayout.addPublicLayout(
-			groupName = "Guest",
-			layoutName = "Documents and Media Page");
-
-		JSONLayout.addWidgetToPublicLayout(
-			column = 1,
-			groupName = "Guest",
-			layoutName = "Documents and Media Page",
-			widgetName = "Documents and Media");
-
-		JSONFolder.addFolder(
-			dmFolderDescription = "DM Folder Description",
-			dmFolderName = "DM Folder Name",
-			groupName = "Guest");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		DMDocument.enableActionsMenuOnPortlet();
-
-		User.logoutAndLoginPG(
-			userLoginEmailAddress = "userea@liferay.com",
-			userLoginFullName = "userfn userln");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		LexiconCard.viewMenuItemNotPresent(
-			card = "DM Folder Name",
-			item = "Permissions");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		DMNavigator.gotoFolder(dmFolderName = "DM Folder Name");
-
-		DMDocument.gotoMenuItemViaInfoPanel();
 
 		MenuItem.viewNotPresent(menuItem = "Permissions");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMSearch.testcase
@@ -319,28 +319,6 @@ definition {
 			searchAssetType = "Document");
 	}
 
-	@priority = 4
-	@refactordone
-	test CanSearchForDocumentThroughContent {
-		property portal.acceptance = "true";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Guest",
-			mimeType = "application/msword",
-			sourceFileName = "Document_1.doc");
-
-		Navigator.gotoPage(pageName = "Documents and Media Page");
-
-		SearchPage.searchEmbedded(searchTerm = "This is a *.doc file.");
-
-		SearchResults.viewSearchResults(
-			searchAssetSummary = "This is a *.doc file.",
-			searchAssetTitle = "DM Document Title",
-			searchAssetType = "Document");
-	}
-
 	@description = "This test covers LPS-129887. It ensures that the user can search for documents using file name."
 	@priority = 5
 	@refactordone
@@ -367,7 +345,7 @@ definition {
 
 	@priority = 4
 	@refactordone
-	test CanSearchForDocumentThroughTitle {
+	test CanSearchForDocumentThroughTitleAndContent {
 		property portal.acceptance = "true";
 
 		JSONDocument.addFileWithUploadedFile(
@@ -382,6 +360,15 @@ definition {
 		SearchPage.searchEmbedded(searchTerm = "DM Document Title");
 
 		SearchResults.viewSearchResults(
+			searchAssetTitle = "DM Document Title",
+			searchAssetType = "Document");
+
+		Navigator.gotoPage(pageName = "Documents and Media Page");
+
+		SearchPage.searchEmbedded(searchTerm = "This is a *.doc file.");
+
+		SearchResults.viewSearchResults(
+			searchAssetSummary = "This is a *.doc file.",
 			searchAssetTitle = "DM Document Title",
 			searchAssetType = "Document");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/externalvideoshortcut/DMVideoShortcut.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/externalvideoshortcut/DMVideoShortcut.testcase
@@ -332,36 +332,6 @@ definition {
 			locator1 = "BlogsEntry#CONTENT_VIDEO");
 	}
 
-	@description = "This test ensures that a user is able to embed an external video in web content."
-	@priority = 4
-	@refactordone
-	test CanAddWCWithEmbeddedVideo {
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
-
-		VideoShortcut.addCP(
-			videoShortcutTitle = "Test YouTube Video Name",
-			videoURL = "https://www.youtube.com/watch?v=HOdbzGCI5ME");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-		WebContentNavigator.gotoAddCP();
-
-		WebContent.addCP(
-			embedVideo = "true",
-			navTab = "Documents and Media",
-			videoShortcutTitle = "Test YouTube Video Name",
-			webContentContent = "WC WebContent Content",
-			webContentTitle = "WC WebContent Title");
-
-		WebContent.publishWithPermissions();
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-		WebContent.viewVideoPreview(
-			service = "https://www.youtube.com",
-			webContentTitle = "WC WebContent Title");
-	}
-
 	@description = "This test ensures that a YouTube video added via item selector can be embedded when adding a WC."
 	@priority = 5
 	@refactordone


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98136

## What Is Being Fixed

The Documents & Media Poshi test suite carries overlapping tests that duplicate coverage across the component, inflating the suite ahead of its migration to Playwright. Consolidating the overlaps first keeps the migration smaller and avoids porting redundant tests.

## How It Is Being Fixed

Every multi-test `.testcase` file in the "Documents and Media" Testray component was reviewed for genuinely overlapping tests — tests that share the same setup and UI surface and differ only in a final assertion, or whose assertions are already fully covered by another test. Nine such overlaps were merged, one commit per merge group: three image-preview format tests fold into `CanPreviewImageFormats`; the redundant `CanBulkCopyFiles` is dropped in favor of `BulkCopyDoesNotFactorInDocumentStatus`; the folder and folder-permission checks combine into `SiteMemberCannotUpdateFolderOrFolderPermissions`; the add-image variant folds into `CanAddDocumentInFolder`; the web-content embedded-video test folds into its move-to-folder superset; the irrelevant-query negative search folds into `CanSearchForDocumentInFolder`; the title and content searches combine into `CanSearchForDocumentThroughTitleAndContent`; the download-by-title variant folds into `CanDownloadJapaneseFileByFileNameOrTitle`; and the templated-image test folds into `CanAccessDisplayPageWithOldFriendlyURL`.

Merges were kept deliberately conservative. Tests with differing property overrides, distinct system-setting or limit configurations, opposite assertions on shared setup, or distinct field-type and UI code paths were left untouched. Merges that would place two identically named documents in the same folder were rejected, since Liferay forbids duplicate names in a folder. The net effect is ten fewer tests across eight files, with no loss of assertion coverage.

## Why Are There No Tests?

This change consolidates existing Poshi tests rather than adding product code, so no new tests are warranted; it reduces the test count while preserving coverage.

## PR Check

**pr-check: PASS** — tested on `f87f46ddee6aa478ba223f2f00a8f6762fd9f836`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "f87f46ddee6aa478ba223f2f00a8f6762fd9f836"} -->
