### PR TITLE
LPD-98201 Add feature flags for e2e-cms-dxp Playwright project

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/env/portal-ext.properties
@@ -1,0 +1,3 @@
+feature.flag.LPD-11235=false
+feature.flag.LPD-17564=true
+feature.flag.LPD-34594=true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98201

## What Is Being Fixed

Several e2e-cms-dxp Playwright tests were failing because the project ran
without the feature flags the CMS scenarios depend on. Without them the CMS
site is not provisioned and the CMS-specific behavior under test is disabled,
so the tests could not reach a valid state.

## How It Is Being Fixed

Adds an `env/portal-ext.properties` for the `e2e-cms-dxp/main` project that
sets the required feature flags (`LPD-11235=false`, `LPD-17564=true`,
`LPD-34594=true`). This mirrors the configuration already used by the sibling
CMS project `site-cms-site-initializer/main`, so the runtime matches what the
CMS tests expect.

## Why Are There No Tests?

This change is Playwright test infrastructure — it only adds feature-flag
configuration that enables the existing e2e-cms-dxp tests to run. There is no
product code to cover with new tests.

## PR Check

**pr-check: PASS** — tested on `b88d452053204cb70948a2940c45e029e8099904`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "b88d452053204cb70948a2940c45e029e8099904"} -->
