### PR TITLE
LPD-98211 Clear thread-locals so the upgrade test reads fresh groups

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.model.Group;
@@ -163,6 +164,8 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 
 			_entityCache.clearCache();
 			_multiVMPool.clear();
+
+			CentralizedThreadLocal.clearLongLivedCentralizedThreadLocals();
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98211

## What Is Being Fixed

`TrashEntriesMaxAgeUpgradeProcessTest.testUpgrade` fails deterministically with `expected:<43200> but was:<null>`. LPD-91035 rewrote the depot upgrade to backfill `Group_.typeSettings` through raw JDBC, and that write reaches and commits to the database correctly. However, the test thread still holds the pre-upgrade `Group` in a long-lived thread-local (the Hibernate session), so `GroupLocalService.fetchGroup` keeps returning the stale entity. LPD-97244 tried to address this by clearing the entity cache, but `EntityCache.clearCache()` and `MultiVMPool.clear()` only evict the portal and multi-VM caches, not the thread-local, so the same failure survived into the 2026-07-13 run.

## How It Is Being Fixed

The test's `_upgrade()` helper now also calls `CentralizedThreadLocal.clearLongLivedCentralizedThreadLocals()` after the existing cache clears, so the next `fetchGroup` opens a fresh session and reads the value the upgrade actually wrote. This was confirmed by observing that a read on a separate thread already returned the correct value while the test thread returned null. `Group` is change-tracking-enabled, which is why sibling upgrade tests on non-change-tracking entities are unaffected.

## Why Are There No Tests?

This change only modifies an existing integration test to correct a false failure; there is no production code change, so no additional tests are warranted.

## PR Check

**pr-check: PASS** — tested on `3460b71f3ffc221a642769544c7d3b73364c3e13`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "3460b71f3ffc221a642769544c7d3b73364c3e13"} -->
