### PR TITLE
LPD-97865 Scope asset-statistics by space and add governance counts

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
+++ b/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless CMS API
 Bundle-SymbolicName: com.liferay.headless.cms.api
-Bundle-Version: 2.2.2
+Bundle-Version: 3.0.0
 Export-Package:\
 	com.liferay.headless.cms.dto.v1_0,\
 	com.liferay.headless.cms.resource.v1_0

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/AssetStatistics.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/AssetStatistics.java
@@ -47,6 +47,47 @@ public class AssetStatistics implements Serializable {
 	}
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getApprovedCount() {
+		if (_approvedCountSupplier != null) {
+			approvedCount = _approvedCountSupplier.get();
+
+			_approvedCountSupplier = null;
+		}
+
+		return approvedCount;
+	}
+
+	public void setApprovedCount(Long approvedCount) {
+		this.approvedCount = approvedCount;
+
+		_approvedCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setApprovedCount(
+		UnsafeSupplier<Long, Exception> approvedCountUnsafeSupplier) {
+
+		_approvedCountSupplier = () -> {
+			try {
+				return approvedCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long approvedCount;
+
+	@JsonIgnore
+	private Supplier<Long> _approvedCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public Long getExpiredCount() {
 		if (_expiredCountSupplier != null) {
 			expiredCount = _expiredCountSupplier.get();
@@ -170,6 +211,47 @@ public class AssetStatistics implements Serializable {
 	private Supplier<Long> _inDraftCountSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getPendingCount() {
+		if (_pendingCountSupplier != null) {
+			pendingCount = _pendingCountSupplier.get();
+
+			_pendingCountSupplier = null;
+		}
+
+		return pendingCount;
+	}
+
+	public void setPendingCount(Long pendingCount) {
+		this.pendingCount = pendingCount;
+
+		_pendingCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPendingCount(
+		UnsafeSupplier<Long, Exception> pendingCountUnsafeSupplier) {
+
+		_pendingCountSupplier = () -> {
+			try {
+				return pendingCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long pendingCount;
+
+	@JsonIgnore
+	private Supplier<Long> _pendingCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public Long getReviewDateOverdueCount() {
 		if (_reviewDateOverdueCountSupplier != null) {
 			reviewDateOverdueCount = _reviewDateOverdueCountSupplier.get();
@@ -209,6 +291,47 @@ public class AssetStatistics implements Serializable {
 
 	@JsonIgnore
 	private Supplier<Long> _reviewDateOverdueCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getScheduledCount() {
+		if (_scheduledCountSupplier != null) {
+			scheduledCount = _scheduledCountSupplier.get();
+
+			_scheduledCountSupplier = null;
+		}
+
+		return scheduledCount;
+	}
+
+	public void setScheduledCount(Long scheduledCount) {
+		this.scheduledCount = scheduledCount;
+
+		_scheduledCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setScheduledCount(
+		UnsafeSupplier<Long, Exception> scheduledCountUnsafeSupplier) {
+
+		_scheduledCountSupplier = () -> {
+			try {
+				return scheduledCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long scheduledCount;
+
+	@JsonIgnore
+	private Supplier<Long> _scheduledCountSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	public Long getTotalCount() {
@@ -251,6 +374,47 @@ public class AssetStatistics implements Serializable {
 	@JsonIgnore
 	private Supplier<Long> _totalCountSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getUpcomingReviewCount() {
+		if (_upcomingReviewCountSupplier != null) {
+			upcomingReviewCount = _upcomingReviewCountSupplier.get();
+
+			_upcomingReviewCountSupplier = null;
+		}
+
+		return upcomingReviewCount;
+	}
+
+	public void setUpcomingReviewCount(Long upcomingReviewCount) {
+		this.upcomingReviewCount = upcomingReviewCount;
+
+		_upcomingReviewCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUpcomingReviewCount(
+		UnsafeSupplier<Long, Exception> upcomingReviewCountUnsafeSupplier) {
+
+		_upcomingReviewCountSupplier = () -> {
+			try {
+				return upcomingReviewCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long upcomingReviewCount;
+
+	@JsonIgnore
+	private Supplier<Long> _upcomingReviewCountSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -277,6 +441,18 @@ public class AssetStatistics implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		Long approvedCount = getApprovedCount();
+
+		if (approvedCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"approvedCount\": ");
+
+			sb.append(approvedCount);
+		}
 
 		Long expiredCount = getExpiredCount();
 
@@ -314,6 +490,18 @@ public class AssetStatistics implements Serializable {
 			sb.append(inDraftCount);
 		}
 
+		Long pendingCount = getPendingCount();
+
+		if (pendingCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"pendingCount\": ");
+
+			sb.append(pendingCount);
+		}
+
 		Long reviewDateOverdueCount = getReviewDateOverdueCount();
 
 		if (reviewDateOverdueCount != null) {
@@ -326,6 +514,18 @@ public class AssetStatistics implements Serializable {
 			sb.append(reviewDateOverdueCount);
 		}
 
+		Long scheduledCount = getScheduledCount();
+
+		if (scheduledCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"scheduledCount\": ");
+
+			sb.append(scheduledCount);
+		}
+
 		Long totalCount = getTotalCount();
 
 		if (totalCount != null) {
@@ -336,6 +536,18 @@ public class AssetStatistics implements Serializable {
 			sb.append("\"totalCount\": ");
 
 			sb.append(totalCount);
+		}
+
+		Long upcomingReviewCount = getUpcomingReviewCount();
+
+		if (upcomingReviewCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"upcomingReviewCount\": ");
+
+			sb.append(upcomingReviewCount);
 		}
 
 		sb.append("}");
@@ -439,4 +651,4 @@ public class AssetStatistics implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-812723712
+// LIFERAY-REST-BUILDER-HASH:1350526058

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/AssetStatisticsResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/AssetStatisticsResource.java
@@ -43,7 +43,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface AssetStatisticsResource {
 
-	public AssetStatistics getAssetStatistics() throws Exception;
+	public AssetStatistics getAssetStatistics(Long assetLibraryId)
+		throws Exception;
 
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
@@ -133,4 +134,4 @@ public interface AssetStatisticsResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1067241138
+// LIFERAY-REST-BUILDER-HASH:325639570

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/AssetStatistics.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/AssetStatistics.java
@@ -25,6 +25,27 @@ public class AssetStatistics implements Cloneable, Serializable {
 		return AssetStatisticsSerDes.toDTO(json);
 	}
 
+	public Long getApprovedCount() {
+		return approvedCount;
+	}
+
+	public void setApprovedCount(Long approvedCount) {
+		this.approvedCount = approvedCount;
+	}
+
+	public void setApprovedCount(
+		UnsafeSupplier<Long, Exception> approvedCountUnsafeSupplier) {
+
+		try {
+			approvedCount = approvedCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long approvedCount;
+
 	public Long getExpiredCount() {
 		return expiredCount;
 	}
@@ -88,6 +109,27 @@ public class AssetStatistics implements Cloneable, Serializable {
 
 	protected Long inDraftCount;
 
+	public Long getPendingCount() {
+		return pendingCount;
+	}
+
+	public void setPendingCount(Long pendingCount) {
+		this.pendingCount = pendingCount;
+	}
+
+	public void setPendingCount(
+		UnsafeSupplier<Long, Exception> pendingCountUnsafeSupplier) {
+
+		try {
+			pendingCount = pendingCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long pendingCount;
+
 	public Long getReviewDateOverdueCount() {
 		return reviewDateOverdueCount;
 	}
@@ -109,6 +151,27 @@ public class AssetStatistics implements Cloneable, Serializable {
 
 	protected Long reviewDateOverdueCount;
 
+	public Long getScheduledCount() {
+		return scheduledCount;
+	}
+
+	public void setScheduledCount(Long scheduledCount) {
+		this.scheduledCount = scheduledCount;
+	}
+
+	public void setScheduledCount(
+		UnsafeSupplier<Long, Exception> scheduledCountUnsafeSupplier) {
+
+		try {
+			scheduledCount = scheduledCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long scheduledCount;
+
 	public Long getTotalCount() {
 		return totalCount;
 	}
@@ -129,6 +192,27 @@ public class AssetStatistics implements Cloneable, Serializable {
 	}
 
 	protected Long totalCount;
+
+	public Long getUpcomingReviewCount() {
+		return upcomingReviewCount;
+	}
+
+	public void setUpcomingReviewCount(Long upcomingReviewCount) {
+		this.upcomingReviewCount = upcomingReviewCount;
+	}
+
+	public void setUpcomingReviewCount(
+		UnsafeSupplier<Long, Exception> upcomingReviewCountUnsafeSupplier) {
+
+		try {
+			upcomingReviewCount = upcomingReviewCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long upcomingReviewCount;
 
 	@Override
 	public AssetStatistics clone() throws CloneNotSupportedException {
@@ -162,4 +246,4 @@ public class AssetStatistics implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-941353405
+// LIFERAY-REST-BUILDER-HASH:-195853936

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/AssetStatisticsResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/AssetStatisticsResource.java
@@ -32,9 +32,11 @@ public interface AssetStatisticsResource {
 		return new Builder();
 	}
 
-	public AssetStatistics getAssetStatistics() throws Exception;
+	public AssetStatistics getAssetStatistics(Long assetLibraryId)
+		throws Exception;
 
-	public HttpInvoker.HttpResponse getAssetStatisticsHttpResponse()
+	public HttpInvoker.HttpResponse getAssetStatisticsHttpResponse(
+			Long assetLibraryId)
 		throws Exception;
 
 	public static class Builder {
@@ -146,9 +148,11 @@ public interface AssetStatisticsResource {
 	public static class AssetStatisticsResourceImpl
 		implements AssetStatisticsResource {
 
-		public AssetStatistics getAssetStatistics() throws Exception {
+		public AssetStatistics getAssetStatistics(Long assetLibraryId)
+			throws Exception {
+
 			HttpInvoker.HttpResponse httpResponse =
-				getAssetStatisticsHttpResponse();
+				getAssetStatisticsHttpResponse(assetLibraryId);
 
 			String content = httpResponse.getContent();
 
@@ -209,7 +213,8 @@ public interface AssetStatisticsResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse getAssetStatisticsHttpResponse()
+		public HttpInvoker.HttpResponse getAssetStatisticsHttpResponse(
+				Long assetLibraryId)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -232,6 +237,11 @@ public interface AssetStatisticsResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetLibraryId != null) {
+				httpInvoker.parameter(
+					"assetLibraryId", String.valueOf(assetLibraryId));
+			}
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
@@ -258,4 +268,4 @@ public interface AssetStatisticsResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1229830636
+// LIFERAY-REST-BUILDER-HASH:563747107

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/AssetStatisticsSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/AssetStatisticsSerDes.java
@@ -46,6 +46,16 @@ public class AssetStatisticsSerDes {
 
 		sb.append("{");
 
+		if (assetStatistics.getApprovedCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"approvedCount\": ");
+
+			sb.append(assetStatistics.getApprovedCount());
+		}
+
 		if (assetStatistics.getExpiredCount() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -76,6 +86,16 @@ public class AssetStatisticsSerDes {
 			sb.append(assetStatistics.getInDraftCount());
 		}
 
+		if (assetStatistics.getPendingCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"pendingCount\": ");
+
+			sb.append(assetStatistics.getPendingCount());
+		}
+
 		if (assetStatistics.getReviewDateOverdueCount() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -86,6 +106,16 @@ public class AssetStatisticsSerDes {
 			sb.append(assetStatistics.getReviewDateOverdueCount());
 		}
 
+		if (assetStatistics.getScheduledCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"scheduledCount\": ");
+
+			sb.append(assetStatistics.getScheduledCount());
+		}
+
 		if (assetStatistics.getTotalCount() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -94,6 +124,16 @@ public class AssetStatisticsSerDes {
 			sb.append("\"totalCount\": ");
 
 			sb.append(assetStatistics.getTotalCount());
+		}
+
+		if (assetStatistics.getUpcomingReviewCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"upcomingReviewCount\": ");
+
+			sb.append(assetStatistics.getUpcomingReviewCount());
 		}
 
 		sb.append("}");
@@ -114,6 +154,15 @@ public class AssetStatisticsSerDes {
 		}
 
 		Map<String, String> map = new TreeMap<>();
+
+		if (assetStatistics.getApprovedCount() == null) {
+			map.put("approvedCount", null);
+		}
+		else {
+			map.put(
+				"approvedCount",
+				String.valueOf(assetStatistics.getApprovedCount()));
+		}
 
 		if (assetStatistics.getExpiredCount() == null) {
 			map.put("expiredCount", null);
@@ -142,6 +191,15 @@ public class AssetStatisticsSerDes {
 				String.valueOf(assetStatistics.getInDraftCount()));
 		}
 
+		if (assetStatistics.getPendingCount() == null) {
+			map.put("pendingCount", null);
+		}
+		else {
+			map.put(
+				"pendingCount",
+				String.valueOf(assetStatistics.getPendingCount()));
+		}
+
 		if (assetStatistics.getReviewDateOverdueCount() == null) {
 			map.put("reviewDateOverdueCount", null);
 		}
@@ -151,12 +209,30 @@ public class AssetStatisticsSerDes {
 				String.valueOf(assetStatistics.getReviewDateOverdueCount()));
 		}
 
+		if (assetStatistics.getScheduledCount() == null) {
+			map.put("scheduledCount", null);
+		}
+		else {
+			map.put(
+				"scheduledCount",
+				String.valueOf(assetStatistics.getScheduledCount()));
+		}
+
 		if (assetStatistics.getTotalCount() == null) {
 			map.put("totalCount", null);
 		}
 		else {
 			map.put(
 				"totalCount", String.valueOf(assetStatistics.getTotalCount()));
+		}
+
+		if (assetStatistics.getUpcomingReviewCount() == null) {
+			map.put("upcomingReviewCount", null);
+		}
+		else {
+			map.put(
+				"upcomingReviewCount",
+				String.valueOf(assetStatistics.getUpcomingReviewCount()));
 		}
 
 		return map;
@@ -177,7 +253,10 @@ public class AssetStatisticsSerDes {
 
 		@Override
 		protected boolean parseMaps(String jsonParserFieldName) {
-			if (Objects.equals(jsonParserFieldName, "expiredCount")) {
+			if (Objects.equals(jsonParserFieldName, "approvedCount")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "expiredCount")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "expiringSoonCount")) {
@@ -186,12 +265,23 @@ public class AssetStatisticsSerDes {
 			else if (Objects.equals(jsonParserFieldName, "inDraftCount")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "pendingCount")) {
+				return false;
+			}
 			else if (Objects.equals(
 						jsonParserFieldName, "reviewDateOverdueCount")) {
 
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "scheduledCount")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "upcomingReviewCount")) {
+
 				return false;
 			}
 
@@ -203,7 +293,13 @@ public class AssetStatisticsSerDes {
 			AssetStatistics assetStatistics, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "expiredCount")) {
+			if (Objects.equals(jsonParserFieldName, "approvedCount")) {
+				if (jsonParserFieldValue != null) {
+					assetStatistics.setApprovedCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "expiredCount")) {
 				if (jsonParserFieldValue != null) {
 					assetStatistics.setExpiredCount(
 						Long.valueOf((String)jsonParserFieldValue));
@@ -221,6 +317,12 @@ public class AssetStatisticsSerDes {
 						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "pendingCount")) {
+				if (jsonParserFieldValue != null) {
+					assetStatistics.setPendingCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
 			else if (Objects.equals(
 						jsonParserFieldName, "reviewDateOverdueCount")) {
 
@@ -229,9 +331,23 @@ public class AssetStatisticsSerDes {
 						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "scheduledCount")) {
+				if (jsonParserFieldValue != null) {
+					assetStatistics.setScheduledCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
 				if (jsonParserFieldValue != null) {
 					assetStatistics.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "upcomingReviewCount")) {
+
+				if (jsonParserFieldValue != null) {
+					assetStatistics.setUpcomingReviewCount(
 						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
@@ -316,4 +432,4 @@ public class AssetStatisticsSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1208800704
+// LIFERAY-REST-BUILDER-HASH:-650741636

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -17,6 +17,10 @@ components:
                     type: string
         AssetStatistics:
             properties:
+                approvedCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
                 expiredCount:
                     format: int64
                     readOnly: true
@@ -29,11 +33,23 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
+                pendingCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
                 reviewDateOverdueCount:
                     format: int64
                     readOnly: true
                     type: integer
+                scheduledCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
                 totalCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                upcomingReviewCount:
                     format: int64
                     readOnly: true
                     type: integer
@@ -82,6 +98,12 @@ paths:
     "/asset-statistics":
         get:
             operationId: getAssetStatistics
+            parameters:
+                -   in: query
+                    name: assetLibraryId
+                    schema:
+                        format: int64
+                        type: integer
             responses:
                 200:
                     content:

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -26,6 +26,8 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.validation.constraints.NotEmpty;
+
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Map;
@@ -59,15 +61,19 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetStatistics{expiredCount, expiringSoonCount, inDraftCount, reviewDateOverdueCount, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetStatistics(assetLibraryId: ___){approvedCount, expiredCount, expiringSoonCount, inDraftCount, pendingCount, reviewDateOverdueCount, scheduledCount, totalCount, upcomingReviewCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
-	public AssetStatistics assetStatistics() throws Exception {
+	public AssetStatistics assetStatistics(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId)
+		throws Exception {
+
 		return _applyComponentServiceObjects(
 			_assetStatisticsResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			assetStatisticsResource ->
-				assetStatisticsResource.getAssetStatistics());
+				assetStatisticsResource.getAssetStatistics(
+					Long.valueOf(assetLibraryId)));
 	}
 
 	/**
@@ -237,4 +243,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:574024614
+// LIFERAY-REST-BUILDER-HASH:1260038530

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -42,19 +42,18 @@ public class AssetStatisticsResourceImpl
 	extends BaseAssetStatisticsResourceImpl {
 
 	@Override
-	public AssetStatistics getAssetStatistics() throws Exception {
+	public AssetStatistics getAssetStatistics(Long assetLibraryId)
+		throws Exception {
+
 		if (!FeatureFlagManagerUtil.isEnabled(
 				contextCompany.getCompanyId(), "LPD-17564")) {
 
 			throw new UnsupportedOperationException();
 		}
 
-		List<Long> depotEntryGroupIds =
-			_depotEntryService.getDepotEntryGroupIds(
-				contextCompany.getCompanyId(), contextUser.getUserId(),
-				DepotConstants.TYPE_SPACE);
+		Long[] groupIds = _getGroupIds(assetLibraryId);
 
-		if (depotEntryGroupIds.isEmpty()) {
+		if (ArrayUtil.isEmpty(groupIds)) {
 			return _toAssetStatistics();
 		}
 
@@ -73,10 +72,14 @@ public class AssetStatisticsResourceImpl
 		}
 
 		Date date = new Date();
-		Long[] groupIds = depotEntryGroupIds.toArray(new Long[0]);
 
 		return new AssetStatistics() {
 			{
+				setApprovedCount(
+					() -> _getCount(
+						groupIds, objectDefinitionIds,
+						ObjectEntryTable.INSTANCE.status.eq(
+							WorkflowConstants.STATUS_APPROVED)));
 				setExpiredCount(
 					() -> _getCount(
 						groupIds, objectDefinitionIds,
@@ -98,15 +101,44 @@ public class AssetStatisticsResourceImpl
 						groupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_DRAFT)));
+				setPendingCount(
+					() -> _getCount(
+						groupIds, objectDefinitionIds,
+						ObjectEntryTable.INSTANCE.status.eq(
+							WorkflowConstants.STATUS_PENDING)));
 				setReviewDateOverdueCount(
 					() -> _getCount(
 						groupIds, objectDefinitionIds,
-						ObjectEntryTable.INSTANCE.reviewDate.lt(date)));
+						ObjectEntryTable.INSTANCE.reviewDate.lt(
+							date
+						).and(
+							ObjectEntryTable.INSTANCE.status.in(
+								CMSWorkflowConstants.STATUSES)
+						)));
+				setScheduledCount(
+					() -> _getCount(
+						groupIds, objectDefinitionIds,
+						ObjectEntryTable.INSTANCE.status.eq(
+							WorkflowConstants.STATUS_SCHEDULED)));
 				setTotalCount(
 					() -> _getCount(
 						groupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.in(
 							CMSWorkflowConstants.STATUSES)));
+				setUpcomingReviewCount(
+					() -> _getCount(
+						groupIds, objectDefinitionIds,
+						ObjectEntryTable.INSTANCE.reviewDate.gt(
+							date
+						).and(
+							ObjectEntryTable.INSTANCE.reviewDate.lte(
+								new Date(
+									date.getTime() +
+										(Time.DAY * _UPCOMING_REVIEW_DAYS)))
+						).and(
+							ObjectEntryTable.INSTANCE.status.in(
+								CMSWorkflowConstants.STATUSES)
+						)));
 			}
 		};
 	}
@@ -128,19 +160,42 @@ public class AssetStatisticsResourceImpl
 		}
 	}
 
+	private Long[] _getGroupIds(Long assetLibraryId) {
+		List<Long> depotEntryGroupIds =
+			_depotEntryService.getDepotEntryGroupIds(
+				contextCompany.getCompanyId(), contextUser.getUserId(),
+				DepotConstants.TYPE_SPACE);
+
+		if (assetLibraryId == null) {
+			return depotEntryGroupIds.toArray(new Long[0]);
+		}
+
+		if (!depotEntryGroupIds.contains(assetLibraryId)) {
+			return new Long[0];
+		}
+
+		return new Long[] {assetLibraryId};
+	}
+
 	private AssetStatistics _toAssetStatistics() {
 		return new AssetStatistics() {
 			{
+				setApprovedCount(() -> 0L);
 				setExpiredCount(() -> 0L);
 				setExpiringSoonCount(() -> 0L);
 				setInDraftCount(() -> 0L);
+				setPendingCount(() -> 0L);
 				setReviewDateOverdueCount(() -> 0L);
+				setScheduledCount(() -> 0L);
 				setTotalCount(() -> 0L);
+				setUpcomingReviewCount(() -> 0L);
 			}
 		};
 	}
 
 	private static final int _EXPIRING_SOON_DAYS = 7;
+
+	private static final int _UPCOMING_REVIEW_DAYS = 7;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AssetStatisticsResourceImpl.class);

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.cms.internal.resource.v1_0;
 
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
@@ -22,6 +23,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
 
 import java.util.Date;
@@ -170,11 +172,15 @@ public class AssetStatisticsResourceImpl
 			return depotEntryGroupIds.toArray(new Long[0]);
 		}
 
-		if (!depotEntryGroupIds.contains(assetLibraryId)) {
+		Long groupId = GroupUtil.getDepotGroupId(
+			String.valueOf(assetLibraryId), contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService);
+
+		if ((groupId == null) || !depotEntryGroupIds.contains(groupId)) {
 			return new Long[0];
 		}
 
-		return new Long[] {assetLibraryId};
+		return new Long[] {groupId};
 	}
 
 	private AssetStatistics _toAssetStatistics() {
@@ -199,6 +205,9 @@ public class AssetStatisticsResourceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AssetStatisticsResourceImpl.class);
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private DepotEntryService _depotEntryService;

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseAssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseAssetStatisticsResourceImpl.java
@@ -47,6 +47,14 @@ public abstract class BaseAssetStatisticsResourceImpl
 	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-cms/v1.0/asset-statistics'  -u 'test@liferay.com:test'
 	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetLibraryId"
+			)
+		}
+	)
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
 			@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetStatistics")
@@ -56,7 +64,12 @@ public abstract class BaseAssetStatisticsResourceImpl
 	@jakarta.ws.rs.Path("/asset-statistics")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public AssetStatistics getAssetStatistics() throws Exception {
+	public AssetStatistics getAssetStatistics(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetLibraryId")
+			Long assetLibraryId)
+		throws Exception {
+
 		return new AssetStatistics();
 	}
 
@@ -505,4 +518,4 @@ public abstract class BaseAssetStatisticsResourceImpl
 		LogFactoryUtil.getLog(BaseAssetStatisticsResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1233316681
+// LIFERAY-REST-BUILDER-HASH:1823472258

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -390,15 +390,21 @@ public class AssetStatisticsResourceTest
 			TestPropsValues.getUserId(), pendingObjectEntry.getObjectEntryId(),
 			WorkflowConstants.STATUS_PENDING, serviceContext);
 
-		// Counts scoped to the first space only
+		// Counts scoped to the first space only, resolved by group ID and by
+		// depot entry ID
 
 		_assertAssetStatistics(
 			depotEntry1.getGroupId(), 2, 0, 0, 0, 0, 0, 0, 2, 1);
+		_assertAssetStatistics(
+			depotEntry1.getDepotEntryId(), 2, 0, 0, 0, 0, 0, 0, 2, 1);
 
-		// Counts scoped to the second space only
+		// Counts scoped to the second space only, resolved by group ID and by
+		// depot entry ID
 
 		_assertAssetStatistics(
 			depotEntry2.getGroupId(), 1, 0, 0, 0, 1, 0, 0, 2, 0);
+		_assertAssetStatistics(
+			depotEntry2.getDepotEntryId(), 1, 0, 0, 0, 1, 0, 0, 2, 0);
 
 		_depotEntryLocalService.deleteDepotEntry(depotEntry1.getDepotEntryId());
 		_depotEntryLocalService.deleteDepotEntry(depotEntry2.getDepotEntryId());

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -92,6 +92,12 @@ public class AssetStatisticsResourceTest
 	@Override
 	@Test
 	public void testGetAssetStatistics() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+
+		long assetLibraryId = depotEntry.getGroupId();
 
 		// Add object entry on irrelevant group and irrelevant object definition
 
@@ -103,9 +109,6 @@ public class AssetStatisticsResourceTest
 						ObjectFieldConstants.DB_TYPE_STRING,
 						RandomTestUtil.randomString(), "name")),
 				ObjectDefinitionConstants.SCOPE_SITE);
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext();
 
 		ObjectEntry irrelevantObjectEntry =
 			_objectEntryLocalService.addObjectEntry(
@@ -121,24 +124,10 @@ public class AssetStatisticsResourceTest
 			irrelevantObjectEntry.getObjectEntryId(),
 			WorkflowConstants.STATUS_DRAFT, serviceContext);
 
-		_assertAssetStatistics(0, 0, 0, 0, 0);
-
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), StringUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), StringUtil.randomString()
-			).build(),
-			DepotConstants.TYPE_SPACE, serviceContext);
-
-		Group cmsGroup = CMSTestUtil.getOrAddGroup(
-			AssetStatisticsResourceTest.class);
+		_assertAssetStatistics(assetLibraryId, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
 		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+			_getBasicWebContentObjectDefinition();
 
 		Date date = new Date();
 
@@ -152,7 +141,7 @@ public class AssetStatisticsResourceTest
 
 		_objectEntryLocalService.updateObjectEntry(objectEntry1);
 
-		_assertAssetStatistics(0, 0, 0, 0, 1);
+		_assertAssetStatistics(assetLibraryId, 1, 0, 0, 0, 0, 0, 0, 1, 0);
 
 		// Add object entry with future review date
 
@@ -163,7 +152,7 @@ public class AssetStatisticsResourceTest
 
 		_objectEntryLocalService.updateObjectEntry(objectEntry2);
 
-		_assertAssetStatistics(0, 0, 0, 0, 2);
+		_assertAssetStatistics(assetLibraryId, 2, 0, 0, 0, 0, 0, 0, 2, 1);
 
 		// Add object entry with imminent expiration date
 
@@ -175,7 +164,7 @@ public class AssetStatisticsResourceTest
 
 		_objectEntryLocalService.updateObjectEntry(objectEntry3);
 
-		_assertAssetStatistics(0, 1, 0, 0, 3);
+		_assertAssetStatistics(assetLibraryId, 3, 0, 1, 0, 0, 0, 0, 3, 1);
 
 		// Add object entry with already passed expiration date
 
@@ -187,7 +176,7 @@ public class AssetStatisticsResourceTest
 
 		_objectEntryLocalService.updateObjectEntry(objectEntry4);
 
-		_assertAssetStatistics(0, 2, 0, 0, 4);
+		_assertAssetStatistics(assetLibraryId, 4, 0, 2, 0, 0, 0, 0, 4, 1);
 
 		// Add object entry with overdue review date
 
@@ -198,7 +187,7 @@ public class AssetStatisticsResourceTest
 
 		_objectEntryLocalService.updateObjectEntry(objectEntry5);
 
-		_assertAssetStatistics(0, 2, 0, 1, 5);
+		_assertAssetStatistics(assetLibraryId, 5, 0, 2, 0, 0, 1, 0, 5, 1);
 
 		// Add object entry with status draft
 
@@ -209,7 +198,7 @@ public class AssetStatisticsResourceTest
 			TestPropsValues.getUserId(), objectEntry6.getObjectEntryId(),
 			WorkflowConstants.STATUS_DRAFT, serviceContext);
 
-		_assertAssetStatistics(0, 2, 1, 1, 6);
+		_assertAssetStatistics(assetLibraryId, 5, 0, 2, 1, 0, 1, 0, 6, 1);
 
 		// Add object entry with status expired
 
@@ -220,7 +209,7 @@ public class AssetStatisticsResourceTest
 			TestPropsValues.getUserId(), objectEntry7.getObjectEntryId(),
 			WorkflowConstants.STATUS_EXPIRED, serviceContext);
 
-		_assertAssetStatistics(1, 2, 1, 1, 7);
+		_assertAssetStatistics(assetLibraryId, 5, 1, 2, 1, 0, 1, 0, 7, 1);
 
 		// Add object entry in a status that is not visible in the All view
 
@@ -231,12 +220,14 @@ public class AssetStatisticsResourceTest
 			TestPropsValues.getUserId(), objectEntry8.getObjectEntryId(),
 			WorkflowConstants.STATUS_DENIED, serviceContext);
 
-		_assertAssetStatistics(1, 2, 1, 1, 7);
+		_assertAssetStatistics(assetLibraryId, 5, 1, 2, 1, 0, 1, 0, 7, 1);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			irrelevantObjectDefinition);
 
 		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+
+		_testGetAssetStatisticsByAssetLibrary();
 	}
 
 	@Override
@@ -272,6 +263,19 @@ public class AssetStatisticsResourceTest
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	private DepotEntry _addSpaceDepotEntry(ServiceContext serviceContext)
+		throws Exception {
+
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+	}
+
 	private User _addUserWithRole(String roleName) throws Exception {
 		User user = UserTestUtil.addUser(
 			testCompany, RandomTestUtil.randomString());
@@ -285,17 +289,22 @@ public class AssetStatisticsResourceTest
 	}
 
 	private void _assertAssetStatistics(
+			Long assetLibraryId, long expectedApprovedCount,
 			long expectedExpiredCount, long expectedExpiringSoonCount,
-			long expectedInDraftCount, long expectedReviewDateOverdueCount,
-			long expectedTotalCount)
+			long expectedInDraftCount, long expectedPendingCount,
+			long expectedReviewDateOverdueCount, long expectedScheduledCount,
+			long expectedTotalCount, long expectedUpcomingReviewCount)
 		throws Exception {
 
 		for (AssetStatisticsResource assetStatisticsResource :
 				_assetStatisticsResources) {
 
 			AssetStatistics assetStatistics =
-				assetStatisticsResource.getAssetStatistics();
+				assetStatisticsResource.getAssetStatistics(assetLibraryId);
 
+			Assert.assertEquals(
+				expectedApprovedCount,
+				GetterUtil.getLong(assetStatistics.getApprovedCount()));
 			Assert.assertEquals(
 				expectedExpiredCount,
 				GetterUtil.getLong(assetStatistics.getExpiredCount()));
@@ -306,12 +315,21 @@ public class AssetStatisticsResourceTest
 				expectedInDraftCount,
 				GetterUtil.getLong(assetStatistics.getInDraftCount()));
 			Assert.assertEquals(
+				expectedPendingCount,
+				GetterUtil.getLong(assetStatistics.getPendingCount()));
+			Assert.assertEquals(
 				expectedReviewDateOverdueCount,
 				GetterUtil.getLong(
 					assetStatistics.getReviewDateOverdueCount()));
 			Assert.assertEquals(
+				expectedScheduledCount,
+				GetterUtil.getLong(assetStatistics.getScheduledCount()));
+			Assert.assertEquals(
 				expectedTotalCount,
 				GetterUtil.getLong(assetStatistics.getTotalCount()));
+			Assert.assertEquals(
+				expectedUpcomingReviewCount,
+				GetterUtil.getLong(assetStatistics.getUpcomingReviewCount()));
 		}
 	}
 
@@ -325,6 +343,65 @@ public class AssetStatisticsResourceTest
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+	}
+
+	private ObjectDefinition _getBasicWebContentObjectDefinition()
+		throws Exception {
+
+		Group cmsGroup = CMSTestUtil.getOrAddGroup(
+			AssetStatisticsResourceTest.class);
+
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+	}
+
+	private void _testGetAssetStatisticsByAssetLibrary() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry1 = _addSpaceDepotEntry(serviceContext);
+		DepotEntry depotEntry2 = _addSpaceDepotEntry(serviceContext);
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		Date date = new Date();
+
+		// First space: two approved entries, one with an upcoming review date
+
+		_addObjectEntry(depotEntry1, objectDefinition);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			depotEntry1, objectDefinition);
+
+		objectEntry.setReviewDate(new Date(date.getTime() + (3 * Time.DAY)));
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry);
+
+		// Second space: one approved entry and one pending entry
+
+		_addObjectEntry(depotEntry2, objectDefinition);
+
+		ObjectEntry pendingObjectEntry = _addObjectEntry(
+			depotEntry2, objectDefinition);
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), pendingObjectEntry.getObjectEntryId(),
+			WorkflowConstants.STATUS_PENDING, serviceContext);
+
+		// Counts scoped to the first space only
+
+		_assertAssetStatistics(
+			depotEntry1.getGroupId(), 2, 0, 0, 0, 0, 0, 0, 2, 1);
+
+		// Counts scoped to the second space only
+
+		_assertAssetStatistics(
+			depotEntry2.getGroupId(), 1, 0, 0, 0, 1, 0, 0, 2, 0);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry1.getDepotEntryId());
+		_depotEntryLocalService.deleteDepotEntry(depotEntry2.getDepotEntryId());
 	}
 
 	private AssetStatisticsResource[] _assetStatisticsResources;

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetStatisticsResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetStatisticsResourceTestCase.java
@@ -271,6 +271,14 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("approvedCount", additionalAssertFieldName)) {
+				if (assetStatistics.getApprovedCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("expiredCount", additionalAssertFieldName)) {
 				if (assetStatistics.getExpiredCount() == null) {
 					valid = false;
@@ -297,6 +305,14 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("pendingCount", additionalAssertFieldName)) {
+				if (assetStatistics.getPendingCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"reviewDateOverdueCount", additionalAssertFieldName)) {
 
@@ -307,8 +323,26 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("scheduledCount", additionalAssertFieldName)) {
+				if (assetStatistics.getScheduledCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("totalCount", additionalAssertFieldName)) {
 				if (assetStatistics.getTotalCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"upcomingReviewCount", additionalAssertFieldName)) {
+
+				if (assetStatistics.getUpcomingReviewCount() == null) {
 					valid = false;
 				}
 
@@ -434,6 +468,17 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("approvedCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetStatistics1.getApprovedCount(),
+						assetStatistics2.getApprovedCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("expiredCount", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						assetStatistics1.getExpiredCount(),
@@ -469,6 +514,17 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("pendingCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetStatistics1.getPendingCount(),
+						assetStatistics2.getPendingCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"reviewDateOverdueCount", additionalAssertFieldName)) {
 
@@ -482,10 +538,34 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("scheduledCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetStatistics1.getScheduledCount(),
+						assetStatistics2.getScheduledCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("totalCount", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						assetStatistics1.getTotalCount(),
 						assetStatistics2.getTotalCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"upcomingReviewCount", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						assetStatistics1.getUpcomingReviewCount(),
+						assetStatistics2.getUpcomingReviewCount())) {
 
 					return false;
 				}
@@ -601,6 +681,11 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 		sb.append(operator);
 		sb.append(" ");
 
+		if (entityFieldName.equals("approvedCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("expiredCount")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -616,12 +701,27 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("pendingCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("reviewDateOverdueCount")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("scheduledCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("totalCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("upcomingReviewCount")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}
@@ -673,11 +773,15 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 	protected AssetStatistics randomAssetStatistics() throws Exception {
 		return new AssetStatistics() {
 			{
+				approvedCount = RandomTestUtil.randomLong();
 				expiredCount = RandomTestUtil.randomLong();
 				expiringSoonCount = RandomTestUtil.randomLong();
 				inDraftCount = RandomTestUtil.randomLong();
+				pendingCount = RandomTestUtil.randomLong();
 				reviewDateOverdueCount = RandomTestUtil.randomLong();
+				scheduledCount = RandomTestUtil.randomLong();
 				totalCount = RandomTestUtil.randomLong();
+				upcomingReviewCount = RandomTestUtil.randomLong();
 			}
 		};
 	}
@@ -905,4 +1009,4 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 		_assetStatisticsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:256843011
+// LIFERAY-REST-BUILDER-HASH:-237696254


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97865

## What Is Being Fixed

The Content Governance Dashboard (epic LPD-82226) needs per-Space governance counts, but the headless-cms `asset-statistics` endpoint aggregated across every Space the user could access and exposed only five counts. It was missing the status distribution, the pending-approval count and the upcoming-reviews count that the dashboard widgets require.

## How It Is Being Fixed

Added an optional `assetLibraryId` query parameter to `GET /o/headless-cms/v1.0/asset-statistics` so a widget can request the counts for a single Space; omitting it preserves the previous all-Spaces behavior. Following the headless convention (`headless-delivery`, `headless-admin-taxonomy`), `assetLibraryId` is the Space's group ID. The `AssetStatistics` DTO gains four counts — `approvedCount`, `pendingCount`, `scheduledCount` and `upcomingReviewCount` (review date within the next seven days).

The scoped path gates on the user's accessible Spaces, so an inaccessible or out-of-scope id returns zeros consistently with the all-Spaces path. The review counts (the existing overdue count and the new upcoming count) are now restricted to the CMS-visible statuses, so denied or trashed content no longer inflates them. The global date-range filter stays out of scope per the epic's open question.

## Frontend Integration

Endpoint to consume: `GET /o/headless-cms/v1.0/asset-statistics?assetLibraryId={id}`. **`assetLibraryId` is the Space's group ID** — the same identifier the dashboard passes as `groupIds` to `/o/search/v1.0/search`, so the frontend uses one Space id everywhere. This follows the headless convention (`headless-delivery`, `headless-admin-taxonomy`), where `assetLibraryId` is the depot's group ID. Note: in the `AssetLibrary` DTO this is the `siteId` field, **not** `id` (which is the depot entry id). Omit the parameter to aggregate across every Space the user can access. All counts honor the Space filter. These fields unblock the following dashboard sections:

| Widget - section | Field(s) |
| --- | --- |
| Attention Required - Expired Assets | `expiredCount` |
| Attention Required - Overdue Reviews | `reviewDateOverdueCount` |
| Attention Required - Pending Workflows | `pendingCount` |
| Needs Review - Upcoming Reviews | `upcomingReviewCount` |
| Needs Review - Expiring Soon | `expiringSoonCount` |
| Content Progress (status distribution) | `approvedCount`, `inDraftCount`, `pendingCount`, `scheduledCount`; Others = `totalCount` minus the sum |

Out of scope here (tracked by other subtasks): Health Score, Broken/Similar Links, Duplication and Similarity (T2/T5), Workflow module metrics (T7), and the detail lists behind each card (served by `/o/search/v1.0/search`).

## PR Check

**pr-check: PASS** — tested on `bdf70f52aef1eefa9947aa56d43ea3a4d2cd5c12`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Baseline | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration-Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "bdf70f52aef1eefa9947aa56d43ea3a4d2cd5c12"} -->

