### PR TITLE
LPD-94145 Add the AI Assistant next to the CMS Select File button

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -23,6 +23,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldSetEntry;
+import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.RelationshipInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -40,6 +41,7 @@ import com.liferay.layout.util.structure.ColumnLayoutStructureItem;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormRelationshipStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
@@ -90,6 +92,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
+import com.liferay.site.cms.site.initializer.internal.fragment.renderer.AIAssistantIconComponentSectionFragmentRenderer;
 import com.liferay.site.cms.site.initializer.internal.fragment.renderer.SpacesComponentSectionFragmentRenderer;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -1096,6 +1099,45 @@ public class ActionUtil {
 		return getBaseViewFolderURL(themeDisplay) + objectEntryFolderId;
 	}
 
+	private static void _addAIAssistantFragmentDropZone(
+			List<FragmentEntryLink> addedFragmentEntryLinks,
+			FragmentEntryLinkService fragmentEntryLinkService,
+			FragmentRendererRegistry fragmentRendererRegistry,
+			FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem,
+			Layout layout, LayoutStructure layoutStructure,
+			long segmentsExperienceId, ServiceContext serviceContext)
+		throws Exception {
+
+		if (fragmentStyledLayoutStructureItem == null) {
+			return;
+		}
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
+			StringPool.BLANK, fragmentEntryLinkService,
+			fragmentRendererRegistry,
+			AIAssistantIconComponentSectionFragmentRenderer.class.getName(),
+			layout, segmentsExperienceId, serviceContext);
+
+		if (fragmentEntryLink == null) {
+			return;
+		}
+
+		FragmentDropZoneLayoutStructureItem
+			fragmentDropZoneLayoutStructureItem =
+				(FragmentDropZoneLayoutStructureItem)
+					layoutStructure.addFragmentDropZoneLayoutStructureItem(
+						fragmentStyledLayoutStructureItem.getItemId(), -1);
+
+		fragmentDropZoneLayoutStructureItem.setFragmentDropZoneId(
+			"aiAssistant");
+
+		layoutStructure.addFragmentStyledLayoutStructureItem(
+			fragmentEntryLink.getFragmentEntryLinkId(),
+			fragmentDropZoneLayoutStructureItem.getItemId(), 0);
+
+		addedFragmentEntryLinks.add(fragmentEntryLink);
+	}
+
 	private static LayoutPageTemplateEntry
 			_addEditContentDefaultLayoutPageTemplateEntry(
 				long classNameId, FormManager formManager,
@@ -1214,7 +1256,7 @@ public class ActionUtil {
 			0, contributedRendererKey, fragmentEntry.getType(), serviceContext);
 	}
 
-	private static void _addInputFragmentEntryLink(
+	private static FragmentStyledLayoutStructureItem _addInputFragmentEntryLink(
 			List<FragmentEntryLink> addedFragmentEntryLinks,
 			JSONObject configurationJSONObject, FormManager formManager,
 			String fragmentEntryKey, InfoField<?> infoField, Layout layout,
@@ -1225,7 +1267,7 @@ public class ActionUtil {
 		throws Exception {
 
 		if (infoField == null) {
-			return;
+			return null;
 		}
 
 		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
@@ -1235,7 +1277,7 @@ public class ActionUtil {
 				serviceContext);
 
 		if (fragmentStyledLayoutStructureItem == null) {
-			return;
+			return null;
 		}
 
 		fragmentStyledLayoutStructureItem.updateItemConfig(
@@ -1266,6 +1308,8 @@ public class ActionUtil {
 		if (fragmentEntryLink != null) {
 			addedFragmentEntryLinks.add(fragmentEntryLink);
 		}
+
+		return fragmentStyledLayoutStructureItem;
 	}
 
 	private static LayoutStructure _addInputFragmentEntryLinks(
@@ -1419,11 +1463,24 @@ public class ActionUtil {
 					}
 				}
 
-				_addInputFragmentEntryLink(
-					addedFragmentEntryLinks, null, formManager, null,
-					(InfoField<?>)infoFieldSetEntry, layout, layoutStructure,
-					layoutStructureItem, readOnly, segmentsExperienceId,
-					serviceContext, stylesJSONObject);
+				FragmentStyledLayoutStructureItem
+					fragmentStyledLayoutStructureItem =
+						_addInputFragmentEntryLink(
+							addedFragmentEntryLinks, null, formManager, null,
+							infoField, layout, layoutStructure,
+							layoutStructureItem, readOnly, segmentsExperienceId,
+							serviceContext, stylesJSONObject);
+
+				if (!readOnly &&
+					(FileInfoFieldType.INSTANCE ==
+						infoField.getInfoFieldType())) {
+
+					_addAIAssistantFragmentDropZone(
+						addedFragmentEntryLinks, fragmentEntryLinkService,
+						fragmentRendererRegistry,
+						fragmentStyledLayoutStructureItem, layout,
+						layoutStructure, segmentsExperienceId, serviceContext);
+				}
 			}
 			else if (infoFieldSetEntry instanceof InfoFieldSet) {
 				layoutStructure = _addInputFragmentEntryLinks(


### PR DESCRIPTION
## What Is Being Fixed

The CMS content editor's file fields render only the Select File button.
There is no anchor point in the generated form structure for the AI
Assistant control that should sit alongside it.

## How It Is Being Fixed

This isolates the `ActionUtil.java` changes previously bundled in the main
LPD-94145 work into a standalone PR, per review feedback. When the input
fragments for a content form are generated, a non-read-only file field now
gets an `aiAssistant` fragment drop zone appended to its input fragment,
containing the AI Assistant icon fragment. To wire this up,
`_addInputFragmentEntryLink` returns the created
`FragmentStyledLayoutStructureItem` so the new
`_addAIAssistantFragmentDropZone` helper can attach the drop zone to it.

This change is necessary so we can add the AI Assistant with the Select
File button — it is the structural hook the AI Assistant control binds to.

## Why Are There No Tests?

The change manipulates `LayoutStructure` via persistence services and
fragment renderers, which has no practical unit-test seam. It is verified
functionally in the CMS content editor.

## PR Check

**pr-check: PASS** — tested on `d37fe06b8387c4ae5502edbecfac6690312dd2d7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d37fe06b8387c4ae5502edbecfac6690312dd2d7"} -->
