### PR TITLE
LPD-98285 Fix asset library friendly URL patch failing with a 500

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -419,10 +419,12 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				group = _groupLocalService.updateGroup(group);
 			}
 
+			_updateFriendlyURL(assetLibrary, group.getGroupId());
+
 			_updateDLSizeLimitConfiguration(
 				assetLibrary, group.getGroupId(), mimeTypeSizeLimits);
 
-			DepotEntry updatedDepotEntry = _depotEntryService.updateDepotEntry(
+			return _depotEntryService.updateDepotEntry(
 				depotEntry.getDepotEntryId(), nameMap, descriptionMap,
 				_getDepotAppCustomizationMap(
 					depotEntry.getCompanyId(), externalReferenceCode),
@@ -432,10 +434,6 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 					unicodeProperties
 				).build(),
 				serviceContext);
-
-			_updateFriendlyURL(assetLibrary, group.getGroupId());
-
-			return updatedDepotEntry;
 		}
 
 		if (Validator.isNotNull(externalReferenceCode)) {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -408,7 +408,8 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			DepotEntry depotEntry = _depotEntryService.getGroupDepotEntry(
 				group.getGroupId());
 
-			if (!externalReferenceCode.equals(
+			if (Validator.isNotNull(assetLibrary.getExternalReferenceCode()) &&
+				!externalReferenceCode.equals(
 					assetLibrary.getExternalReferenceCode())) {
 
 				group = depotEntry.getGroup();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98285

## What Is Being Fixed

Patching an asset library with a custom friendly URL returned HTTP 500. The failure was an `org.hibernate.StaleObjectStateException` raised while merging the depot group in `GroupLocalServiceImpl.updateFriendlyURL`, which the vulcan `ExceptionMapper` logged at ERROR and the integration test framework reported as a concurrent failure. Two group writes happened within the single patch request: a partial patch that omitted the external reference code was treated as a request to clear it (running an extra `updateGroup`), and the depot entry update also wrote the group before the friendly URL update ran, so the following merge loaded a stale group. The ordering was introduced in `a27ac00c` (LPD-88344), which added the friendly URL update after the depot entry update.

## How It Is Being Fixed

Two changes in `AssetLibraryResourceImpl._addOrUpdateDepotEntry`. First, the external-reference-code branch now runs only when the request supplies a genuinely different, non-null code, so a partial patch no longer performs a spurious group update or clears the code. Second, the friendly URL is updated before the depot entry, so it no longer merges a group that an earlier write in the same request already advanced.

## Why Are There No Tests?

The scenario is already covered by `AssetLibraryResourceTest.testPatchAssetLibrary` (integration) and the `spaceFriendlyURL` Playwright spec, both of which were failing before this change and pass after it. No new test is needed to reproduce the regression.

## Test Execution

    cd modules/apps/headless/headless-asset-library/headless-asset-library-test && gradlew testIntegration --tests com.liferay.headless.asset.library.resource.v1_0.test.AssetLibraryResourceTest
    cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/spaces/spaceFriendlyURL.spec.ts

Verified: integration 28/28, Playwright 7/7.

## PR Check

**pr-check: PASS** — tested on `64207e7cbd4d28fca7688ea507ee651d209c8d14`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "64207e7cbd4d28fca7688ea507ee651d209c8d14"} -->
