### PR TITLE
LPD-98190 Do not mark file responses cacheable inside a publication

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/CacheControlWebServerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/CacheControlWebServerTest.java
@@ -6,9 +6,13 @@
 package com.liferay.document.library.webserver.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.test.util.BaseWebServerTestCase;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.friendly.url.resolver.FileEntryFriendlyURLResolver;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -64,6 +68,34 @@ public class CacheControlWebServerTest extends BaseWebServerTestCase {
 			mockHttpServletResponse.getHeader(HttpHeaders.CACHE_CONTROL));
 	}
 
+	@Test
+	public void testDownloadWhenCTCollectionIsCheckedOut() throws Exception {
+		String urlTitle = RandomTestUtil.randomString();
+
+		_addFileEntry(RandomTestUtil.randomString(), urlTitle);
+
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, group.getCompanyId(), TestPropsValues.getUserId(), 0,
+			RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			MockHttpServletResponse mockHttpServletResponse = service(
+				HttpMethods.GET, _getFileEntryFriendlyURL(urlTitle),
+				Collections.emptyMap(),
+				HashMapBuilder.put(
+					"download", Boolean.TRUE.toString()
+				).build(),
+				TestPropsValues.getUser(), null);
+
+			Assert.assertEquals(
+				HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE,
+				mockHttpServletResponse.getHeader(HttpHeaders.CACHE_CONTROL));
+		}
+	}
+
 	private FileEntry _addFileEntry(String fileName, String urlTitle)
 		throws Exception {
 
@@ -82,6 +114,9 @@ public class CacheControlWebServerTest extends BaseWebServerTestCase {
 			"%s%s/%s", FriendlyURLResolverConstants.URL_SEPARATOR_X_FILE_ENTRY,
 			group.getFriendlyURL(), urlTitle);
 	}
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
@@ -8,6 +8,7 @@ package com.liferay.document.library.web.internal.servlet;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.web.internal.configuration.CacheControlConfiguration;
 import com.liferay.document.library.web.internal.configuration.helper.CacheControlConfigurationHelper;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -49,6 +50,10 @@ public class CacheControlFileEntryHttpHeaderCustomizer
 
 	private String _getHttpHeaderValue(FileEntry fileEntry, String currentValue)
 		throws PortalException {
+
+		if (!CTCollectionThreadLocal.isProductionMode()) {
+			return HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE;
+		}
 
 		CacheControlConfiguration cacheControlConfiguration =
 			_cacheControlConfigurationHelper.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98190

## What Is Being Fixed

When a user has a publication checked out and downloads a document (for example through a `/documents/d/<site>/<friendly-url>` URL), the response body contains the publication's version of the file, but `CacheControlFileEntryHttpHeaderCustomizer` decides the Cache-Control header solely on whether the guest user can view the file entry. The response is therefore marked cacheable, so any HTTP cache in front of the portal (nginx, Varnish, a CDN) stores the publication's unpublished content under the public URL and serves it to every visitor until the cache entry expires. This caused a production customer incident (LPP-63996) where an unpublished document version went live days before its publication's scheduled publish date.

## How It Is Being Fixed

`CacheControlFileEntryHttpHeaderCustomizer` now returns `Cache-Control: private, no-cache, no-store, must-revalidate` whenever `CTCollectionThreadLocal.isProductionMode()` is false, before any other cacheability logic runs. The thread local reflects the change tracking context that actually produced the response — whether it comes from the requester's checked-out publication or an explicit preview parameter — so publication-context content is never stored by shared caches, while production-mode downloads keep their configured caching behavior. A new integration test drives `WebServerServlet` through the friendly URL path inside a checked-out publication and asserts the no-cache header; the existing test covers the unchanged production path.

## PR Check

**pr-check: PASS** — tested on `5623d656b0f7fc7b0c8926a8bfebf46094f26e9c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5623d656b0f7fc7b0c8926a8bfebf46094f26e9c"} -->
