### PR TITLE
LPD-98311 Add DLApp fetch methods to avoid exception control flow

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
@@ -10,15 +10,12 @@ import com.liferay.adaptive.media.image.content.transformer.backwards.compatibil
 import com.liferay.adaptive.media.image.html.AMImageHTMLTagFactory;
 import com.liferay.adaptive.media.image.html.constants.AMImageHTMLConstants;
 import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
@@ -141,17 +138,15 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 		long folderId = GetterUtil.getLong(matcher.group(3));
 		String title = matcher.group(4);
 
-		try {
-			return _dlAppLocalService.getFileEntry(groupId, folderId, title);
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
-			}
+		FileEntry fileEntry = _dlAppLocalService.fetchFileEntry(
+			groupId, folderId, title);
 
-			return _dlAppLocalService.getFileEntryByFileName(
-				groupId, folderId, title);
+		if (fileEntry != null) {
+			return fileEntry;
 		}
+
+		return _dlAppLocalService.getFileEntryByFileName(
+			groupId, folderId, title);
 	}
 
 	private Group _getGroup(long companyId, String name)
@@ -298,9 +293,6 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 	private static final String _OPEN_TAG_TOKEN_IMG = "<img";
 
 	private static final String _OPEN_TAG_TOKEN_PICTURE = "<picture";
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		AMBackwardsCompatibilityHtmlContentTransformer.class);
 
 	private static final Pattern _pattern = Pattern.compile(
 		"((?:/?[^\\s]*)/documents/(\\d+)/(\\d+)/([^/?]+)(?:/([-0-9a-fA-F]+))?" +

--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/test/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/test/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformerTest.java
@@ -144,7 +144,7 @@ public class AMBackwardsCompatibilityHtmlContentTransformerTest {
 	@Test
 	public void testReplacesImageTagsWithLegacyContent() throws Exception {
 		Mockito.when(
-			_dlAppLocalService.getFileEntry(20138, 0, "sample.jpg")
+			_dlAppLocalService.fetchFileEntry(20138, 0, "sample.jpg")
 		).thenReturn(
 			_fileEntry
 		);

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPAttachmentFileEntryCreator.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPAttachmentFileEntryCreator.java
@@ -7,7 +7,6 @@ package com.liferay.commerce.initializer.util;
 
 import com.liferay.commerce.product.model.CPAttachmentFileEntry;
 import com.liferay.commerce.product.service.CPAttachmentFileEntryLocalService;
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.petra.string.StringPool;
@@ -102,25 +101,22 @@ public class CPAttachmentFileEntryCreator {
 		FileEntry fileEntry = null;
 
 		try {
-			fileEntry = _dlAppService.getFileEntry(
+			fileEntry = _dlAppService.fetchFileEntry(
 				serviceContext.getScopeGroupId(),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName);
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
+
+			if (fileEntry == null) {
+				Repository repository = _repositoryProvider.getRepository(
+					serviceContext.getScopeGroupId());
+
+				file = _file.createTempFile(inputStream);
+
+				fileEntry = _dlAppService.addFileEntry(
+					null, repository.getRepositoryId(),
+					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
+					_mimeTypes.getContentType(file), fileName, null, null, null,
+					file, null, null, null, serviceContext);
 			}
-
-			Repository repository = _repositoryProvider.getRepository(
-				serviceContext.getScopeGroupId());
-
-			file = _file.createTempFile(inputStream);
-
-			fileEntry = _dlAppService.addFileEntry(
-				null, repository.getRepositoryId(),
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
-				_mimeTypes.getContentType(file), fileName, null, null, null,
-				file, null, null, null, serviceContext);
 		}
 		finally {
 			if (file != null) {

--- a/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
@@ -5,16 +5,14 @@
 
 package com.liferay.document.library.opener.internal.upload;
 
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.opener.upload.UniqueFileEntryTitleProvider;
-import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.upload.UniqueFileNameProvider;
 
 import java.util.Locale;
@@ -67,29 +65,28 @@ public class UniqueFileEntryTitleProviderImpl
 		return _provide(groupId, folderId, extension, title);
 	}
 
-	private boolean _exists(UnsafeRunnable<PortalException> unsafeRunnable) {
-		try {
-			unsafeRunnable.run();
+	private boolean _exists(
+		UnsafeSupplier<FileEntry, PortalException> unsafeSupplier) {
 
-			return true;
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
+		try {
+			FileEntry fileEntry = unsafeSupplier.get();
+
+			if (fileEntry != null) {
+				return true;
 			}
+
+			return false;
 		}
 		catch (PortalException portalException) {
 			throw new SystemException(portalException);
 		}
-
-		return false;
 	}
 
 	private boolean _fileNameExists(
 		long groupId, long folderId, String fileName) {
 
 		return _exists(
-			() -> _dlAppLocalService.getFileEntryByFileName(
+			() -> _dlAppLocalService.fetchFileEntryByFileName(
 				groupId, folderId, fileName));
 	}
 
@@ -111,11 +108,8 @@ public class UniqueFileEntryTitleProviderImpl
 
 	private boolean _titleExists(long groupId, long folderId, String title) {
 		return _exists(
-			() -> _dlAppLocalService.getFileEntry(groupId, folderId, title));
+			() -> _dlAppLocalService.fetchFileEntry(groupId, folderId, title));
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		UniqueFileEntryTitleProviderImpl.class);
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/bulk/selection/MultipleFileEntryBulkSelection.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/bulk/selection/MultipleFileEntryBulkSelection.java
@@ -10,13 +10,10 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.bulk.selection.BaseMultipleEntryBulkSelection;
 import com.liferay.bulk.selection.BulkSelection;
 import com.liferay.bulk.selection.BulkSelectionFactory;
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.util.DLAssetHelper;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 
 import java.util.Map;
@@ -56,22 +53,12 @@ public class MultipleFileEntryBulkSelection
 	@Override
 	protected FileEntry fetchEntry(long fileEntryId) {
 		try {
-			return _dlAppService.getFileEntry(fileEntryId);
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(noSuchFileEntryException);
-			}
-
-			return null;
+			return _dlAppService.fetchFileEntry(fileEntryId);
 		}
 		catch (PortalException portalException) {
 			return ReflectionUtil.throwException(portalException);
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		MultipleFileEntryBulkSelection.class);
 
 	private final AssetEntryLocalService _assetEntryLocalService;
 	private final DLAppService _dlAppService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/trash/DLFileShortcutTrashHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/trash/DLFileShortcutTrashHandler.java
@@ -5,7 +5,6 @@
 
 package com.liferay.document.library.internal.trash;
 
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.model.DLFileShortcutConstants;
@@ -194,23 +193,11 @@ public class DLFileShortcutTrashHandler extends BaseDLTrashHandler {
 			return false;
 		}
 
-		try {
-			FileEntry toFileEntry = _dlAppLocalService.getFileEntry(
-				dlFileShortcut.getToFileEntryId());
+		FileEntry toFileEntry = _dlAppLocalService.fetchFileEntry(
+			dlFileShortcut.getToFileEntryId());
 
-			if (toFileEntry.isInTrash()) {
-				return false;
-			}
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
-			}
-
-			return false;
-		}
-
-		if (!hasTrashPermission(
+		if ((toFileEntry == null) || toFileEntry.isInTrash() ||
+			!hasTrashPermission(
 				PermissionThreadLocal.getPermissionChecker(),
 				dlFileShortcut.getGroupId(), classPK,
 				TrashActionKeys.RESTORE)) {

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/local/service/test/DLAppLocalServiceWhenGettingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/local/service/test/DLAppLocalServiceWhenGettingAFileEntryTest.java
@@ -36,6 +36,13 @@ public class DLAppLocalServiceWhenGettingAFileEntryTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
+	@Test
+	public void testFetchFileEntry() throws Exception {
+		_testFetchFileEntryByFileNameNotPresentInRootFolder();
+		_testFetchFileEntryNotPresentInRootFolder();
+		_testFetchFileEntryPresentInRootFolder();
+	}
+
 	@Test(expected = NoSuchFileEntryException.class)
 	public void testShouldFailIfNotPresentInRootFolder() throws Exception {
 		DLAppLocalServiceUtil.getFileEntry(
@@ -53,6 +60,38 @@ public class DLAppLocalServiceWhenGettingAFileEntryTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		FileEntry fileEntry2 = DLAppLocalServiceUtil.getFileEntry(
+			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			fileEntry1.getTitle());
+
+		Assert.assertEquals(
+			fileEntry1.getFileEntryId(), fileEntry2.getFileEntryId());
+	}
+
+	private void _testFetchFileEntryByFileNameNotPresentInRootFolder()
+		throws Exception {
+
+		Assert.assertNull(
+			DLAppLocalServiceUtil.fetchFileEntryByFileName(
+				group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				StringUtil.randomString()));
+	}
+
+	private void _testFetchFileEntryNotPresentInRootFolder() throws Exception {
+		Assert.assertNull(
+			DLAppLocalServiceUtil.fetchFileEntry(
+				group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				StringUtil.randomString()));
+	}
+
+	private void _testFetchFileEntryPresentInRootFolder() throws Exception {
+		FileEntry fileEntry1 = DLAppLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			new byte[0], null, null, null,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		FileEntry fileEntry2 = DLAppLocalServiceUtil.fetchFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			fileEntry1.getTitle());
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenGettingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenGettingAFileEntryTest.java
@@ -65,6 +65,12 @@ public class DLAppServiceWhenGettingAFileEntryTest extends BaseDLAppTestCase {
 	}
 
 	@Test
+	public void testFetchFileEntry() throws Exception {
+		_testFetchFileEntryNotPresentInRootFolder();
+		_testFetchFileEntryPresentInRootFolder();
+	}
+
+	@Test
 	public void testGetExpiredFileEntryAsContentReviewer() throws Exception {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -139,6 +145,25 @@ public class DLAppServiceWhenGettingAFileEntryTest extends BaseDLAppTestCase {
 
 		DLFileEntryLocalServiceUtil.checkFileEntries(
 			dlFileEntry.getCompanyId(), 60);
+	}
+
+	private void _testFetchFileEntryNotPresentInRootFolder() throws Exception {
+		Assert.assertNull(
+			dlAppService.fetchFileEntry(
+				group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				StringUtil.randomString()));
+	}
+
+	private void _testFetchFileEntryPresentInRootFolder() throws Exception {
+		FileEntry fileEntry1 = DLAppServiceTestUtil.addFileEntry(
+			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		FileEntry fileEntry2 = dlAppService.fetchFileEntry(
+			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			fileEntry1.getTitle());
+
+		Assert.assertEquals(
+			fileEntry1.getFileEntryId(), fileEntry2.getFileEntryId());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
@@ -12,7 +12,6 @@ import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
 import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.document.library.asset.model.DLFileEntryClassTypeReader;
 import com.liferay.document.library.constants.DLPortletKeys;
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
@@ -77,34 +76,26 @@ public class DLFileEntryAssetRendererFactory
 	public AssetRenderer<FileEntry> getAssetRenderer(long classPK, int type)
 		throws PortalException {
 
-		FileEntry fileEntry = null;
+		FileEntry fileEntry = _dlAppLocalService.fetchFileEntry(classPK);
 		FileVersion fileVersion = null;
 
-		try {
-			fileEntry = _dlAppLocalService.getFileEntry(classPK);
-
-			if (type == TYPE_LATEST) {
-				fileVersion = fileEntry.getLatestFileVersion();
-			}
-			else if (type == TYPE_LATEST_APPROVED) {
-				fileVersion = fileEntry.getFileVersion();
-			}
-			else {
-				throw new IllegalArgumentException(
-					"Unknown asset renderer type " + type);
-			}
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
+		if (fileEntry == null) {
 
 			// LPS-52675
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
-			}
 
 			fileVersion = _dlAppLocalService.getFileVersion(classPK);
 
 			fileEntry = fileVersion.getFileEntry();
+		}
+		else if (type == TYPE_LATEST) {
+			fileVersion = fileEntry.getLatestFileVersion();
+		}
+		else if (type == TYPE_LATEST_APPROVED) {
+			fileVersion = fileEntry.getFileVersion();
+		}
+		else {
+			throw new IllegalArgumentException(
+				"Unknown asset renderer type " + type);
 		}
 
 		DLFileEntryAssetRenderer dlFileEntryAssetRenderer =

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
@@ -53,27 +53,15 @@ import java.util.List;
 public class ActionUtil {
 
 	public static List<FileEntry> getFileEntries(
-			HttpServletRequest httpServletRequest)
-		throws PortalException {
+		HttpServletRequest httpServletRequest) {
 
 		return TransformUtil.transformToList(
 			ParamUtil.getLongValues(httpServletRequest, "rowIdsFileEntry"),
-			fileEntryId -> {
-				try {
-					return DLAppServiceUtil.getFileEntry(fileEntryId);
-				}
-				catch (NoSuchFileEntryException noSuchFileEntryException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(noSuchFileEntryException);
-					}
-				}
-
-				return null;
-			});
+			DLAppServiceUtil::fetchFileEntry);
 	}
 
-	public static List<FileEntry> getFileEntries(PortletRequest portletRequest)
-		throws PortalException {
+	public static List<FileEntry> getFileEntries(
+		PortletRequest portletRequest) {
 
 		return getFileEntries(PortalUtil.getHttpServletRequest(portletRequest));
 	}
@@ -127,8 +115,7 @@ public class ActionUtil {
 	}
 
 	public static List<FileShortcut> getFileShortcuts(
-			HttpServletRequest httpServletRequest)
-		throws PortalException {
+		HttpServletRequest httpServletRequest) {
 
 		return TransformUtil.transformToList(
 			ParamUtil.getLongValues(httpServletRequest, "rowIdsDLFileShortcut"),
@@ -149,8 +136,7 @@ public class ActionUtil {
 	}
 
 	public static List<FileShortcut> getFileShortcuts(
-			PortletRequest portletRequest)
-		throws PortalException {
+		PortletRequest portletRequest) {
 
 		return getFileShortcuts(
 			PortalUtil.getHttpServletRequest(portletRequest));
@@ -266,8 +252,8 @@ public class ActionUtil {
 		return getFolder(PortalUtil.getHttpServletRequest(portletRequest));
 	}
 
-	public static List<Folder> getFolders(HttpServletRequest httpServletRequest)
-		throws PortalException {
+	public static List<Folder> getFolders(
+		HttpServletRequest httpServletRequest) {
 
 		return TransformUtil.transformToList(
 			ParamUtil.getLongValues(httpServletRequest, "rowIdsFolder"),
@@ -285,9 +271,7 @@ public class ActionUtil {
 			});
 	}
 
-	public static List<Folder> getFolders(PortletRequest portletRequest)
-		throws PortalException {
-
+	public static List<Folder> getFolders(PortletRequest portletRequest) {
 		return getFolders(PortalUtil.getHttpServletRequest(portletRequest));
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/UploadFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/UploadFileEntryMVCActionCommand.java
@@ -6,7 +6,6 @@
 package com.liferay.document.library.web.internal.portlet.action;
 
 import com.liferay.document.library.constants.DLPortletKeys;
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.util.DLValidator;
@@ -216,23 +215,14 @@ public class UploadFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				UploadPortletRequest uploadPortletRequest)
 			throws PortalException {
 
-			try {
-				long fileEntryId = GetterUtil.getLong(
-					uploadPortletRequest.getParameter("fileEntryId"));
+			long fileEntryId = GetterUtil.getLong(
+				uploadPortletRequest.getParameter("fileEntryId"));
 
-				if (fileEntryId == 0) {
-					return null;
-				}
-
-				return _dlAppService.getFileEntry(fileEntryId);
-			}
-			catch (NoSuchFileEntryException noSuchFileEntryException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(noSuchFileEntryException);
-				}
-
+			if (fileEntryId == 0) {
 				return null;
 			}
+
+			return _dlAppService.fetchFileEntry(fileEntryId);
 		}
 
 		private String _getDescription(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
@@ -1025,18 +1025,14 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 			long groupId, long parentFolderId, String fileName)
 		throws PortalException {
 
-		try {
-			return _dlAppService.getFileEntryByFileName(
-				groupId, parentFolderId, fileName);
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
-			}
+		FileEntry fileEntry = _dlAppService.fetchFileEntryByFileName(
+			groupId, parentFolderId, fileName);
 
-			return _dlAppService.getFileEntry(
-				groupId, parentFolderId, fileName);
+		if (fileEntry != null) {
+			return fileEntry;
 		}
+
+		return _dlAppService.getFileEntry(groupId, parentFolderId, fileName);
 	}
 
 	private String _getFileName(String[] pathArray) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/UploadDDMUserPersonalFolderMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/UploadDDMUserPersonalFolderMVCActionCommand.java
@@ -5,7 +5,6 @@
 
 package com.liferay.dynamic.data.mapping.form.web.internal.portlet.action;
 
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.util.DLValidator;
@@ -143,14 +142,7 @@ public class UploadDDMUserPersonalFolderMVCActionCommand
 				uploadPortletRequest.getParameter("fileEntryId"));
 
 			if (fileEntryId > 0) {
-				try {
-					fileEntry = _dlAppService.getFileEntry(fileEntryId);
-				}
-				catch (NoSuchFileEntryException noSuchFileEntryException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(noSuchFileEntryException);
-					}
-				}
+				fileEntry = _dlAppService.fetchFileEntry(fileEntryId);
 			}
 
 			String fileName = uploadPortletRequest.getFileName(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesReverseIterator.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesReverseIterator.java
@@ -391,18 +391,11 @@ public class DLReferencesReverseIterator
 					String title = MapUtil.getString(map, "title");
 
 					if (Validator.isNotNull(title)) {
-						try {
-							fileEntry =
-								DLAppLocalServiceUtil.getFileEntryByFileName(
-									groupId, folderId, title);
-						}
-						catch (NoSuchFileEntryException
-									noSuchFileEntryException) {
+						fileEntry =
+							DLAppLocalServiceUtil.fetchFileEntryByFileName(
+								groupId, folderId, title);
 
-							if (_log.isDebugEnabled()) {
-								_log.debug(noSuchFileEntryException);
-							}
-
+						if (fileEntry == null) {
 							fileEntry = DLAppLocalServiceUtil.getFileEntry(
 								groupId, folderId, title);
 						}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -10,7 +10,6 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryModel;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.exportimport.attachment.ExportImportAttachmentManager;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
@@ -2322,28 +2321,19 @@ public class DefaultObjectEntryManagerImpl
 				String scopeKey)
 		throws Exception {
 
-		try {
-			if (Validator.isNotNull(fileEntry.getExternalReferenceCode())) {
-				return _dlAppService.getFileEntryByExternalReferenceCode(
-					fileEntry.getExternalReferenceCode(),
-					_getFileEntryGroupId(
-						_getGroupExternalReferenceCode(fileEntry),
-						objectDefinition, scopeKey));
-			}
-
-			if (fileEntry.getId() != null) {
-				return _dlAppService.getFileEntry(fileEntry.getId());
-			}
-
-			return null;
+		if (Validator.isNotNull(fileEntry.getExternalReferenceCode())) {
+			return _dlAppService.fetchFileEntryByExternalReferenceCode(
+				fileEntry.getExternalReferenceCode(),
+				_getFileEntryGroupId(
+					_getGroupExternalReferenceCode(fileEntry), objectDefinition,
+					scopeKey));
 		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(noSuchFileEntryException);
-			}
 
-			return null;
+		if (fileEntry.getId() != null) {
+			return _dlAppService.fetchFileEntry(fileEntry.getId());
 		}
+
+		return null;
 	}
 
 	private String _getDateString(Date date) {

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1481,15 +1481,11 @@ public class WebServerServlet extends HttpServlet {
 			String fileName = HttpComponentsUtil.decodeURL(pathArray[2]);
 
 			try {
-				try {
-					DLAppLocalServiceUtil.getFileEntryByFileName(
+				FileEntry fileEntry =
+					DLAppLocalServiceUtil.fetchFileEntryByFileName(
 						groupId, folderId, fileName);
-				}
-				catch (NoSuchFileEntryException noSuchFileEntryException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(noSuchFileEntryException);
-					}
 
+				if (fileEntry == null) {
 					DLAppLocalServiceUtil.getFileEntry(
 						groupId, folderId, fileName);
 				}
@@ -1921,41 +1917,30 @@ public class WebServerServlet extends HttpServlet {
 					0, fileName.indexOf(StringPool.QUESTION));
 			}
 
-			try {
-				FileEntry fileEntry =
-					DLAppLocalServiceUtil.getFileEntryByFileName(
-						groupId, folderId, fileName);
-
-				_checkFileEntry(fileEntry, httpServletRequest);
-
-				return fileEntry;
-			}
-			catch (NoSuchFileEntryException noSuchFileEntryException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(noSuchFileEntryException);
-				}
-
-				FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			FileEntry fileEntry =
+				DLAppLocalServiceUtil.fetchFileEntryByFileName(
 					groupId, folderId, fileName);
 
-				_checkFileEntry(fileEntry, httpServletRequest);
-
-				return fileEntry;
+			if (fileEntry == null) {
+				fileEntry = DLAppLocalServiceUtil.getFileEntry(
+					groupId, folderId, fileName);
 			}
-		}
-		else {
-			long groupId = GetterUtil.getLong(pathArray[0]);
-
-			String uuid = pathArray[3];
-
-			FileEntry fileEntry =
-				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
-					uuid, groupId);
 
 			_checkFileEntry(fileEntry, httpServletRequest);
 
 			return fileEntry;
 		}
+
+		long groupId = GetterUtil.getLong(pathArray[0]);
+
+		String uuid = pathArray[3];
+
+		FileEntry fileEntry =
+			DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(uuid, groupId);
+
+		_checkFileEntry(fileEntry, httpServletRequest);
+
+		return fileEntry;
 	}
 
 	private PermissionChecker _getPermissionChecker(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
@@ -1161,6 +1161,218 @@ public class DLAppServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntry(HttpPrincipal httpPrincipal, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLAppServiceUtil.class, "fetchFileEntry",
+				_fetchFileEntryParameterTypes27);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, fileEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntry(
+				HttpPrincipal httpPrincipal, long groupId, long folderId,
+				String title)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLAppServiceUtil.class, "fetchFileEntry",
+				_fetchFileEntryParameterTypes28);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, folderId, title);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLAppServiceUtil.class, "fetchFileEntryByExternalReferenceCode",
+				_fetchFileEntryByExternalReferenceCodeParameterTypes29);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByFileName(
+				HttpPrincipal httpPrincipal, long groupId, long folderId,
+				String fileName)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLAppServiceUtil.class, "fetchFileEntryByFileName",
+				_fetchFileEntryByFileNameParameterTypes30);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, folderId, fileName);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByUuidAndGroupId(
+				HttpPrincipal httpPrincipal, String uuid, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLAppServiceUtil.class, "fetchFileEntryByUuidAndGroupId",
+				_fetchFileEntryByUuidAndGroupIdParameterTypes31);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, uuid, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List
 		<com.liferay.portal.kernel.repository.model.FileEntry> getFileEntries(
 				HttpPrincipal httpPrincipal, long repositoryId, long folderId)
@@ -1169,7 +1381,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes27);
+				_getFileEntriesParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId);
@@ -1213,7 +1425,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes28);
+				_getFileEntriesParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, start, end);
@@ -1260,7 +1472,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes29);
+				_getFileEntriesParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, start, end,
@@ -1305,7 +1517,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes30);
+				_getFileEntriesParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, fileEntryTypeId);
@@ -1349,7 +1561,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes31);
+				_getFileEntriesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, fileEntryTypeId, start, end);
@@ -1396,7 +1608,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes32);
+				_getFileEntriesParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, fileEntryTypeId, start, end,
@@ -1441,7 +1653,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes33);
+				_getFileEntriesParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, mimeTypes);
@@ -1488,7 +1700,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes34);
+				_getFileEntriesParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, mimeTypes, start, end,
@@ -1532,7 +1744,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntriesAndFileShortcuts",
-				_getFileEntriesAndFileShortcutsParameterTypes35);
+				_getFileEntriesAndFileShortcutsParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, start, end);
@@ -1573,7 +1785,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntriesAndFileShortcutsCount",
-				_getFileEntriesAndFileShortcutsCountParameterTypes36);
+				_getFileEntriesAndFileShortcutsCountParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status);
@@ -1614,7 +1826,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntriesAndFileShortcutsCount",
-				_getFileEntriesAndFileShortcutsCountParameterTypes37);
+				_getFileEntriesAndFileShortcutsCountParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes);
@@ -1654,7 +1866,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes38);
+				_getFileEntriesCountParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId);
@@ -1695,7 +1907,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes39);
+				_getFileEntriesCountParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, fileEntryTypeId);
@@ -1736,7 +1948,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes40);
+				_getFileEntriesCountParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, mimeTypes);
@@ -1776,7 +1988,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntry",
-				_getFileEntryParameterTypes41);
+				_getFileEntryParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId);
@@ -1819,7 +2031,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntry",
-				_getFileEntryParameterTypes42);
+				_getFileEntryParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, title);
@@ -1862,7 +2074,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntryByExternalReferenceCode",
-				_getFileEntryByExternalReferenceCodeParameterTypes43);
+				_getFileEntryByExternalReferenceCodeParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -1905,7 +2117,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntryByFileName",
-				_getFileEntryByFileNameParameterTypes44);
+				_getFileEntryByFileNameParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, fileName);
@@ -1947,7 +2159,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileEntryByUuidAndGroupId",
-				_getFileEntryByUuidAndGroupIdParameterTypes45);
+				_getFileEntryByUuidAndGroupIdParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, uuid, groupId);
@@ -1988,7 +2200,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileShortcut",
-				_getFileShortcutParameterTypes46);
+				_getFileShortcutParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileShortcutId);
@@ -2032,7 +2244,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFileShortcutByExternalReferenceCode",
-				_getFileShortcutByExternalReferenceCodeParameterTypes47);
+				_getFileShortcutByExternalReferenceCodeParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -2073,7 +2285,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFileVersion",
-				_getFileVersionParameterTypes48);
+				_getFileVersionParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileVersionId);
@@ -2114,7 +2326,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolder",
-				_getFolderParameterTypes49);
+				_getFolderParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -2155,7 +2367,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolder",
-				_getFolderParameterTypes50);
+				_getFolderParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, name);
@@ -2197,7 +2409,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolderByExternalReferenceCode",
-				_getFolderByExternalReferenceCodeParameterTypes51);
+				_getFolderByExternalReferenceCodeParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -2239,7 +2451,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes52);
+				_getFoldersParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -2282,7 +2494,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes53);
+				_getFoldersParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders);
@@ -2326,7 +2538,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes54);
+				_getFoldersParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders,
@@ -2374,7 +2586,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes55);
+				_getFoldersParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders,
@@ -2422,7 +2634,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes56);
+				_getFoldersParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, status,
@@ -2466,7 +2678,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes57);
+				_getFoldersParameterTypes62);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end);
@@ -2512,7 +2724,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes58);
+				_getFoldersParameterTypes63);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end,
@@ -2557,7 +2769,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes59);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes64);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, includeMountFolders,
@@ -2603,7 +2815,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes60);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes65);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, includeMountFolders,
@@ -2650,7 +2862,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes61);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes66);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2698,7 +2910,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes62);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes67);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2741,7 +2953,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes63);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes68);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, includeMountFolders);
@@ -2783,7 +2995,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes64);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes69);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2827,7 +3039,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes65);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes70);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2868,7 +3080,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes66);
+				_getFoldersCountParameterTypes71);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -2909,7 +3121,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes67);
+				_getFoldersCountParameterTypes72);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders);
@@ -2950,7 +3162,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes68);
+				_getFoldersCountParameterTypes73);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, status,
@@ -2992,7 +3204,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersFileEntriesCount",
-				_getFoldersFileEntriesCountParameterTypes69);
+				_getFoldersFileEntriesCountParameterTypes74);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderIds, status);
@@ -3035,7 +3247,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes70);
+				_getGroupFileEntriesParameterTypes75);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, start, end);
@@ -3083,7 +3295,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes71);
+				_getGroupFileEntriesParameterTypes76);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, start, end, orderByComparator);
@@ -3128,7 +3340,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes72);
+				_getGroupFileEntriesParameterTypes77);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, start, end);
@@ -3176,7 +3388,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes73);
+				_getGroupFileEntriesParameterTypes78);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, start, end,
@@ -3226,7 +3438,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes74);
+				_getGroupFileEntriesParameterTypes79);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, mimeTypes, status,
@@ -3269,7 +3481,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes75);
+				_getGroupFileEntriesCountParameterTypes80);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId);
@@ -3310,7 +3522,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes76);
+				_getGroupFileEntriesCountParameterTypes81);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId);
@@ -3351,7 +3563,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes77);
+				_getGroupFileEntriesCountParameterTypes82);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, mimeTypes, status);
@@ -3392,7 +3604,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileShortcuts",
-				_getGroupFileShortcutsParameterTypes78);
+				_getGroupFileShortcutsParameterTypes83);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -3435,7 +3647,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFolders",
-				_getMountFoldersParameterTypes79);
+				_getMountFoldersParameterTypes84);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -3478,7 +3690,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFolders",
-				_getMountFoldersParameterTypes80);
+				_getMountFoldersParameterTypes85);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end);
@@ -3524,7 +3736,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFolders",
-				_getMountFoldersParameterTypes81);
+				_getMountFoldersParameterTypes86);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end,
@@ -3566,7 +3778,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFoldersCount",
-				_getMountFoldersCountParameterTypes82);
+				_getMountFoldersCountParameterTypes87);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -3607,7 +3819,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes83);
+				_getSubfolderIdsParameterTypes88);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderIds, folderId);
@@ -3643,7 +3855,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes84);
+				_getSubfolderIdsParameterTypes89);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId);
@@ -3684,7 +3896,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes85);
+				_getSubfolderIdsParameterTypes90);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, recurse);
@@ -3725,7 +3937,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getTempFileNames",
-				_getTempFileNamesParameterTypes86);
+				_getTempFileNamesParameterTypes91);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, folderName);
@@ -3765,7 +3977,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "lockFolder",
-				_lockFolderParameterTypes87);
+				_lockFolderParameterTypes92);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId);
@@ -3806,7 +4018,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "lockFolder",
-				_lockFolderParameterTypes88);
+				_lockFolderParameterTypes93);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, owner, inheritable,
@@ -3849,7 +4061,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "moveFileEntry",
-				_moveFileEntryParameterTypes89);
+				_moveFileEntryParameterTypes94);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, newFolderId, serviceContext);
@@ -3891,7 +4103,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "moveFolder",
-				_moveFolderParameterTypes90);
+				_moveFolderParameterTypes95);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, serviceContext);
@@ -3932,7 +4144,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "refreshFileEntryLock",
-				_refreshFileEntryLockParameterTypes91);
+				_refreshFileEntryLockParameterTypes96);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, lockUuid, companyId, expirationTime);
@@ -3973,7 +4185,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "refreshFolderLock",
-				_refreshFolderLockParameterTypes92);
+				_refreshFolderLockParameterTypes97);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, lockUuid, companyId, expirationTime);
@@ -4014,7 +4226,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "revertFileEntry",
-				_revertFileEntryParameterTypes93);
+				_revertFileEntryParameterTypes98);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, version, serviceContext);
@@ -4050,7 +4262,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes94);
+				DLAppServiceUtil.class, "search", _searchParameterTypes99);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, creatorUserId, status, start, end);
@@ -4090,7 +4302,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes95);
+				DLAppServiceUtil.class, "search", _searchParameterTypes100);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, creatorUserId, folderId, mimeTypes,
@@ -4131,7 +4343,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes96);
+				DLAppServiceUtil.class, "search", _searchParameterTypes101);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, searchContext);
@@ -4172,7 +4384,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes97);
+				DLAppServiceUtil.class, "search", _searchParameterTypes102);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, searchContext, query);
@@ -4212,7 +4424,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "subscribeFileEntry",
-				_subscribeFileEntryParameterTypes98);
+				_subscribeFileEntryParameterTypes103);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, fileEntryId);
@@ -4248,7 +4460,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "subscribeFileEntryType",
-				_subscribeFileEntryTypeParameterTypes99);
+				_subscribeFileEntryTypeParameterTypes104);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, fileEntryTypeId);
@@ -4284,7 +4496,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "subscribeFolder",
-				_subscribeFolderParameterTypes100);
+				_subscribeFolderParameterTypes105);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -4321,7 +4533,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unlockFolder",
-				_unlockFolderParameterTypes101);
+				_unlockFolderParameterTypes106);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, lockUuid);
@@ -4358,7 +4570,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unlockFolder",
-				_unlockFolderParameterTypes102);
+				_unlockFolderParameterTypes107);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, name, lockUuid);
@@ -4394,7 +4606,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unsubscribeFileEntry",
-				_unsubscribeFileEntryParameterTypes103);
+				_unsubscribeFileEntryParameterTypes108);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, fileEntryId);
@@ -4430,7 +4642,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unsubscribeFileEntryType",
-				_unsubscribeFileEntryTypeParameterTypes104);
+				_unsubscribeFileEntryTypeParameterTypes109);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, fileEntryTypeId);
@@ -4466,7 +4678,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unsubscribeFolder",
-				_unsubscribeFolderParameterTypes105);
+				_unsubscribeFolderParameterTypes110);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -4510,7 +4722,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntry",
-				_updateFileEntryParameterTypes106);
+				_updateFileEntryParameterTypes111);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4561,7 +4773,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntry",
-				_updateFileEntryParameterTypes107);
+				_updateFileEntryParameterTypes112);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4613,7 +4825,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntry",
-				_updateFileEntryParameterTypes108);
+				_updateFileEntryParameterTypes113);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4665,7 +4877,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntryAndCheckIn",
-				_updateFileEntryAndCheckInParameterTypes109);
+				_updateFileEntryAndCheckInParameterTypes114);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4717,7 +4929,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntryAndCheckIn",
-				_updateFileEntryAndCheckInParameterTypes110);
+				_updateFileEntryAndCheckInParameterTypes115);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4764,7 +4976,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileShortcut",
-				_updateFileShortcutParameterTypes111);
+				_updateFileShortcutParameterTypes116);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileShortcutId, folderId, toFileEntryId,
@@ -4809,7 +5021,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes112);
+				_updateFolderParameterTypes117);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, name, description, serviceContext);
@@ -4850,7 +5062,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "verifyFileEntryCheckOut",
-				_verifyFileEntryCheckOutParameterTypes113);
+				_verifyFileEntryCheckOutParameterTypes118);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, fileEntryId, lockUuid);
@@ -4891,7 +5103,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "verifyFileEntryLock",
-				_verifyFileEntryLockParameterTypes114);
+				_verifyFileEntryLockParameterTypes119);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, fileEntryId, lockUuid);
@@ -4932,7 +5144,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "verifyInheritableLock",
-				_verifyInheritableLockParameterTypes115);
+				_verifyInheritableLockParameterTypes120);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, lockUuid);
@@ -5075,260 +5287,274 @@ public class DLAppServiceHttp {
 		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[] _deleteTempFileEntryParameterTypes26 =
 		new Class[] {long.class, long.class, String.class, String.class};
-	private static final Class<?>[] _getFileEntriesParameterTypes27 =
+	private static final Class<?>[] _fetchFileEntryParameterTypes27 =
+		new Class[] {long.class};
+	private static final Class<?>[] _fetchFileEntryParameterTypes28 =
+		new Class[] {long.class, long.class, String.class};
+	private static final Class<?>[]
+		_fetchFileEntryByExternalReferenceCodeParameterTypes29 = new Class[] {
+			String.class, long.class
+		};
+	private static final Class<?>[] _fetchFileEntryByFileNameParameterTypes30 =
+		new Class[] {long.class, long.class, String.class};
+	private static final Class<?>[]
+		_fetchFileEntryByUuidAndGroupIdParameterTypes31 = new Class[] {
+			String.class, long.class
+		};
+	private static final Class<?>[] _getFileEntriesParameterTypes32 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getFileEntriesParameterTypes28 =
+	private static final Class<?>[] _getFileEntriesParameterTypes33 =
 		new Class[] {long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getFileEntriesParameterTypes29 =
+	private static final Class<?>[] _getFileEntriesParameterTypes34 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFileEntriesParameterTypes30 =
+	private static final Class<?>[] _getFileEntriesParameterTypes35 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _getFileEntriesParameterTypes31 =
+	private static final Class<?>[] _getFileEntriesParameterTypes36 =
 		new Class[] {long.class, long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getFileEntriesParameterTypes32 =
+	private static final Class<?>[] _getFileEntriesParameterTypes37 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFileEntriesParameterTypes33 =
+	private static final Class<?>[] _getFileEntriesParameterTypes38 =
 		new Class[] {long.class, long.class, String[].class};
-	private static final Class<?>[] _getFileEntriesParameterTypes34 =
+	private static final Class<?>[] _getFileEntriesParameterTypes39 =
 		new Class[] {
 			long.class, long.class, String[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getFileEntriesAndFileShortcutsParameterTypes35 = new Class[] {
+		_getFileEntriesAndFileShortcutsParameterTypes40 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getFileEntriesAndFileShortcutsCountParameterTypes36 = new Class[] {
+		_getFileEntriesAndFileShortcutsCountParameterTypes41 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getFileEntriesAndFileShortcutsCountParameterTypes37 = new Class[] {
+		_getFileEntriesAndFileShortcutsCountParameterTypes42 = new Class[] {
 			long.class, long.class, int.class, String[].class
 		};
-	private static final Class<?>[] _getFileEntriesCountParameterTypes38 =
+	private static final Class<?>[] _getFileEntriesCountParameterTypes43 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getFileEntriesCountParameterTypes39 =
+	private static final Class<?>[] _getFileEntriesCountParameterTypes44 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _getFileEntriesCountParameterTypes40 =
+	private static final Class<?>[] _getFileEntriesCountParameterTypes45 =
 		new Class[] {long.class, long.class, String[].class};
-	private static final Class<?>[] _getFileEntryParameterTypes41 =
+	private static final Class<?>[] _getFileEntryParameterTypes46 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getFileEntryParameterTypes42 =
+	private static final Class<?>[] _getFileEntryParameterTypes47 =
 		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[]
-		_getFileEntryByExternalReferenceCodeParameterTypes43 = new Class[] {
+		_getFileEntryByExternalReferenceCodeParameterTypes48 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getFileEntryByFileNameParameterTypes44 =
+	private static final Class<?>[] _getFileEntryByFileNameParameterTypes49 =
 		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[]
-		_getFileEntryByUuidAndGroupIdParameterTypes45 = new Class[] {
+		_getFileEntryByUuidAndGroupIdParameterTypes50 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getFileShortcutParameterTypes46 =
+	private static final Class<?>[] _getFileShortcutParameterTypes51 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_getFileShortcutByExternalReferenceCodeParameterTypes47 = new Class[] {
+		_getFileShortcutByExternalReferenceCodeParameterTypes52 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getFileVersionParameterTypes48 =
+	private static final Class<?>[] _getFileVersionParameterTypes53 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getFolderParameterTypes49 = new Class[] {
+	private static final Class<?>[] _getFolderParameterTypes54 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getFolderParameterTypes50 = new Class[] {
+	private static final Class<?>[] _getFolderParameterTypes55 = new Class[] {
 		long.class, long.class, String.class
 	};
 	private static final Class<?>[]
-		_getFolderByExternalReferenceCodeParameterTypes51 = new Class[] {
+		_getFolderByExternalReferenceCodeParameterTypes56 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getFoldersParameterTypes52 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes57 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes53 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes58 = new Class[] {
 		long.class, long.class, boolean.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes54 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes59 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes55 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes60 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes56 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes61 = new Class[] {
 		long.class, long.class, int.class, boolean.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes57 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes62 = new Class[] {
 		long.class, long.class, int.class, int.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes58 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes63 = new Class[] {
 		long.class, long.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes59 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes64 =
 			new Class[] {
 				long.class, long.class, int.class, boolean.class, int.class,
 				int.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes60 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes65 =
 			new Class[] {
 				long.class, long.class, int.class, boolean.class, int.class,
 				int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes61 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes66 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class,
 				boolean.class, boolean.class, int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes62 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes67 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class,
 				boolean.class, int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes63 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes68 =
 			new Class[] {long.class, long.class, int.class, boolean.class};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes64 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes69 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class, boolean.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes65 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes70 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class,
 				boolean.class, boolean.class
 			};
-	private static final Class<?>[] _getFoldersCountParameterTypes66 =
+	private static final Class<?>[] _getFoldersCountParameterTypes71 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getFoldersCountParameterTypes67 =
+	private static final Class<?>[] _getFoldersCountParameterTypes72 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _getFoldersCountParameterTypes68 =
+	private static final Class<?>[] _getFoldersCountParameterTypes73 =
 		new Class[] {long.class, long.class, int.class, boolean.class};
 	private static final Class<?>[]
-		_getFoldersFileEntriesCountParameterTypes69 = new Class[] {
+		_getFoldersFileEntriesCountParameterTypes74 = new Class[] {
 			long.class, java.util.List.class, int.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes70 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes75 =
 		new Class[] {long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes71 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes76 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes72 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes77 =
 		new Class[] {long.class, long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes73 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes78 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes74 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes79 =
 		new Class[] {
 			long.class, long.class, long.class, String[].class, int.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes75 =
+	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes80 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes76 =
+	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes81 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes77 =
+	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes82 =
 		new Class[] {
 			long.class, long.class, long.class, String[].class, int.class
 		};
-	private static final Class<?>[] _getGroupFileShortcutsParameterTypes78 =
+	private static final Class<?>[] _getGroupFileShortcutsParameterTypes83 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getMountFoldersParameterTypes79 =
+	private static final Class<?>[] _getMountFoldersParameterTypes84 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getMountFoldersParameterTypes80 =
+	private static final Class<?>[] _getMountFoldersParameterTypes85 =
 		new Class[] {long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getMountFoldersParameterTypes81 =
+	private static final Class<?>[] _getMountFoldersParameterTypes86 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getMountFoldersCountParameterTypes82 =
+	private static final Class<?>[] _getMountFoldersCountParameterTypes87 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes83 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes88 =
 		new Class[] {long.class, java.util.List.class, long.class};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes84 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes89 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes85 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes90 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _getTempFileNamesParameterTypes86 =
+	private static final Class<?>[] _getTempFileNamesParameterTypes91 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _lockFolderParameterTypes87 = new Class[] {
+	private static final Class<?>[] _lockFolderParameterTypes92 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _lockFolderParameterTypes88 = new Class[] {
+	private static final Class<?>[] _lockFolderParameterTypes93 = new Class[] {
 		long.class, long.class, String.class, boolean.class, long.class
 	};
-	private static final Class<?>[] _moveFileEntryParameterTypes89 =
+	private static final Class<?>[] _moveFileEntryParameterTypes94 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveFolderParameterTypes90 = new Class[] {
+	private static final Class<?>[] _moveFolderParameterTypes95 = new Class[] {
 		long.class, long.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _refreshFileEntryLockParameterTypes91 =
+	private static final Class<?>[] _refreshFileEntryLockParameterTypes96 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _refreshFolderLockParameterTypes92 =
+	private static final Class<?>[] _refreshFolderLockParameterTypes97 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _revertFileEntryParameterTypes93 =
+	private static final Class<?>[] _revertFileEntryParameterTypes98 =
 		new Class[] {
 			long.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _searchParameterTypes94 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes99 = new Class[] {
 		long.class, long.class, int.class, int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes95 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes100 = new Class[] {
 		long.class, long.class, long.class, String[].class, int.class,
 		int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes96 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes101 = new Class[] {
 		long.class, com.liferay.portal.kernel.search.SearchContext.class
 	};
-	private static final Class<?>[] _searchParameterTypes97 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes102 = new Class[] {
 		long.class, com.liferay.portal.kernel.search.SearchContext.class,
 		com.liferay.portal.kernel.search.Query.class
 	};
-	private static final Class<?>[] _subscribeFileEntryParameterTypes98 =
+	private static final Class<?>[] _subscribeFileEntryParameterTypes103 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _subscribeFileEntryTypeParameterTypes99 =
+	private static final Class<?>[] _subscribeFileEntryTypeParameterTypes104 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _subscribeFolderParameterTypes100 =
+	private static final Class<?>[] _subscribeFolderParameterTypes105 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unlockFolderParameterTypes101 =
+	private static final Class<?>[] _unlockFolderParameterTypes106 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _unlockFolderParameterTypes102 =
+	private static final Class<?>[] _unlockFolderParameterTypes107 =
 		new Class[] {long.class, long.class, String.class, String.class};
-	private static final Class<?>[] _unsubscribeFileEntryParameterTypes103 =
+	private static final Class<?>[] _unsubscribeFileEntryParameterTypes108 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unsubscribeFileEntryTypeParameterTypes104 =
+	private static final Class<?>[] _unsubscribeFileEntryTypeParameterTypes109 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unsubscribeFolderParameterTypes105 =
+	private static final Class<?>[] _unsubscribeFolderParameterTypes110 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _updateFileEntryParameterTypes106 =
+	private static final Class<?>[] _updateFileEntryParameterTypes111 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
@@ -5338,7 +5564,7 @@ public class DLAppServiceHttp {
 			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFileEntryParameterTypes107 =
+	private static final Class<?>[] _updateFileEntryParameterTypes112 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
@@ -5348,7 +5574,7 @@ public class DLAppServiceHttp {
 			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFileEntryParameterTypes108 =
+	private static final Class<?>[] _updateFileEntryParameterTypes113 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
@@ -5359,7 +5585,7 @@ public class DLAppServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateFileEntryAndCheckInParameterTypes109 = new Class[] {
+		_updateFileEntryAndCheckInParameterTypes114 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
@@ -5369,7 +5595,7 @@ public class DLAppServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateFileEntryAndCheckInParameterTypes110 = new Class[] {
+		_updateFileEntryAndCheckInParameterTypes115 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
@@ -5378,22 +5604,22 @@ public class DLAppServiceHttp {
 			java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFileShortcutParameterTypes111 =
+	private static final Class<?>[] _updateFileShortcutParameterTypes116 =
 		new Class[] {
 			long.class, long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes112 =
+	private static final Class<?>[] _updateFolderParameterTypes117 =
 		new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes113 =
+	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes118 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _verifyFileEntryLockParameterTypes114 =
+	private static final Class<?>[] _verifyFileEntryLockParameterTypes119 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _verifyInheritableLockParameterTypes115 =
+	private static final Class<?>[] _verifyInheritableLockParameterTypes120 =
 		new Class[] {long.class, long.class, String.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1855765025
+// LIFERAY-SERVICE-BUILDER-HASH:1417818601

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -599,6 +599,22 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		}
 	}
 
+	@Override
+	public FileEntry fetchFileEntry(long groupId, long folderId, String title)
+		throws PortalException {
+
+		try {
+			return dlAppLocalService.getFileEntry(groupId, folderId, title);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
+	}
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.
@@ -617,6 +633,24 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 
 		return localRepository.fetchFileEntryByExternalReferenceCode(
 			externalReferenceCode);
+	}
+
+	@Override
+	public FileEntry fetchFileEntryByFileName(
+			long groupId, long folderId, String fileName)
+		throws PortalException {
+
+		try {
+			return dlAppLocalService.getFileEntryByFileName(
+				groupId, folderId, fileName);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -1043,6 +1043,88 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			groupId, getUserId(), folderName, fileName);
 	}
 
+	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		try {
+			return dlAppService.getFileEntry(fileEntryId);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
+	}
+
+	@Override
+	public FileEntry fetchFileEntry(long groupId, long folderId, String title)
+		throws PortalException {
+
+		try {
+			return dlAppService.getFileEntry(groupId, folderId, title);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
+	}
+
+	@Override
+	public FileEntry fetchFileEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		try {
+			return dlAppService.getFileEntryByExternalReferenceCode(
+				externalReferenceCode, groupId);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
+	}
+
+	@Override
+	public FileEntry fetchFileEntryByFileName(
+			long groupId, long folderId, String fileName)
+		throws PortalException {
+
+		try {
+			return dlAppService.getFileEntryByFileName(
+				groupId, folderId, fileName);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
+	}
+
+	@Override
+	public FileEntry fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException {
+
+		try {
+			return dlAppService.getFileEntryByUuidAndGroupId(uuid, groupId);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
+	}
+
 	/**
 	 * Returns all the file entries in the folder.
 	 *

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -348,6 +348,10 @@ public interface DLAppLocalService extends BaseLocalService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntry(long groupId, long folderId, String title)
+		throws PortalException;
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.
@@ -360,6 +364,11 @@ public interface DLAppLocalService extends BaseLocalService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FileEntry fetchFileEntryByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntryByFileName(
+			long groupId, long folderId, String fileName)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -822,4 +831,4 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:929140234
+// LIFERAY-SERVICE-BUILDER-HASH:-1466682005

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -416,6 +416,13 @@ public class DLAppLocalServiceUtil {
 		return getService().fetchFileEntry(fileEntryId);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntry(long groupId, long folderId, String title)
+		throws PortalException {
+
+		return getService().fetchFileEntry(groupId, folderId, title);
+	}
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.
@@ -432,6 +439,15 @@ public class DLAppLocalServiceUtil {
 
 		return getService().fetchFileEntryByExternalReferenceCode(
 			groupId, externalReferenceCode);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByFileName(
+				long groupId, long folderId, String fileName)
+		throws PortalException {
+
+		return getService().fetchFileEntryByFileName(
+			groupId, folderId, fileName);
 	}
 
 	public static com.liferay.portal.kernel.repository.model.FileEntry
@@ -1046,4 +1062,4 @@ public class DLAppLocalServiceUtil {
 	private static volatile DLAppLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1180157448
+// LIFERAY-SERVICE-BUILDER-HASH:683354836

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -428,6 +428,14 @@ public class DLAppLocalServiceWrapper
 		return _dlAppLocalService.fetchFileEntry(fileEntryId);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry fetchFileEntry(
+			long groupId, long folderId, String title)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFileEntry(groupId, folderId, title);
+	}
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.
@@ -445,6 +453,16 @@ public class DLAppLocalServiceWrapper
 
 		return _dlAppLocalService.fetchFileEntryByExternalReferenceCode(
 			groupId, externalReferenceCode);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByFileName(
+				long groupId, long folderId, String fileName)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFileEntryByFileName(
+			groupId, folderId, fileName);
 	}
 
 	@Override
@@ -1091,4 +1109,4 @@ public class DLAppLocalServiceWrapper
 	private DLAppLocalService _dlAppLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:150245717
+// LIFERAY-SERVICE-BUILDER-HASH:-271478601

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
@@ -593,6 +593,27 @@ public interface DLAppService extends BaseService {
 			long groupId, long folderId, String folderName, String fileName)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntry(long groupId, long folderId, String title)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntryByFileName(
+			long groupId, long folderId, String fileName)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException;
+
 	/**
 	 * Returns all the file entries in the folder.
 	 *
@@ -2034,4 +2055,4 @@ public interface DLAppService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1492789591
+// LIFERAY-SERVICE-BUILDER-HASH:-1359349339

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
@@ -700,6 +700,45 @@ public class DLAppServiceUtil {
 			groupId, folderId, folderName, fileName);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntry(long fileEntryId)
+		throws PortalException {
+
+		return getService().fetchFileEntry(fileEntryId);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntry(long groupId, long folderId, String title)
+		throws PortalException {
+
+		return getService().fetchFileEntry(groupId, folderId, title);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().fetchFileEntryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByFileName(
+				long groupId, long folderId, String fileName)
+		throws PortalException {
+
+		return getService().fetchFileEntryByFileName(
+			groupId, folderId, fileName);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException {
+
+		return getService().fetchFileEntryByUuidAndGroupId(uuid, groupId);
+	}
+
 	/**
 	 * Returns all the file entries in the folder.
 	 *
@@ -2521,4 +2560,4 @@ public class DLAppServiceUtil {
 	private static volatile DLAppService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-35035
+// LIFERAY-SERVICE-BUILDER-HASH:1346529934

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
@@ -718,6 +718,50 @@ public class DLAppServiceWrapper
 			groupId, folderId, folderName, fileName);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry fetchFileEntry(
+			long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppService.fetchFileEntry(fileEntryId);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry fetchFileEntry(
+			long groupId, long folderId, String title)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppService.fetchFileEntry(groupId, folderId, title);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppService.fetchFileEntryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByFileName(
+				long groupId, long folderId, String fileName)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppService.fetchFileEntryByFileName(
+			groupId, folderId, fileName);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppService.fetchFileEntryByUuidAndGroupId(uuid, groupId);
+	}
+
 	/**
 	 * Returns all the file entries in the folder.
 	 *
@@ -2629,4 +2673,4 @@ public class DLAppServiceWrapper
 	private DLAppService _dlAppService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1002062415
+// LIFERAY-SERVICE-BUILDER-HASH:1402510782


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98311

## What Is Being Fixed

The document library `get*` file entry methods on `DLAppService` and `DLAppLocalService` throw `NoSuchFileEntryException` when an entry is missing. Many callers wrapped these calls in a try/catch purely to test for existence — returning null, returning false, falling back to another lookup, or creating the entry on the catch path. Using a thrown exception as a boolean is slower because it fills in a stack trace, obscures intent, and repeats the same handling across many modules. `DLAppService` had no `fetch*` file entry variants at all, and `DLAppLocalService` was missing most of them.

## How It Is Being Fixed

Added the missing `fetch*` file entry methods to both services through Service Builder. Each returns null instead of throwing by delegating to the corresponding `get*` through the service reference and swallowing only `NoSuchFileEntryException`, so the exception-as-control-flow is centralized in one place per method.

Replaced the control-flow catch sites with these `fetch*` calls across document library, adaptive media, commerce, dynamic data mapping, export/import, the object REST manager, and the web server servlet. Genuine error handling — where a missing entry is rethrown as a domain exception, or translated to an HTTP 404 at a servlet boundary — was left untouched, as were the broad `catch (PortalException)` sites.

Added integration tests covering the new `fetch*` methods (present returns the entry, missing returns null) and updated the one affected unit test mock.

## PR Check

**pr-check: PASS** — tested on `904df030079aa9f74cefd6e70eba12455e687e90`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "904df030079aa9f74cefd6e70eba12455e687e90"} -->
