### PR TITLE
LPD-98338 Retry CMS space navigation to fix a flaky members test

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/navigation/navigation.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/navigation/navigation.spec.ts
@@ -420,7 +420,7 @@ test(
 				newUserFullName
 			);
 
-			await spaceSummaryPage.viewAllMembersLink.click();
+			await spaceSummaryPage.openMembersDialog();
 
 			await expect(
 				page
@@ -447,7 +447,7 @@ test(
 
 			await spaceSummaryPage.goto(space.name);
 
-			await spaceSummaryPage.viewAllMembersLink.click();
+			await spaceSummaryPage.openMembersDialog();
 
 			await expect(page.getByRole('listitem').first()).toBeVisible();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -66,18 +66,28 @@ export class SpaceSummaryPage {
 	}
 
 	async goto(spaceName: string) {
-		await this.page.goto(PORTLET_URLS.cms);
-		await this.page.getByRole('menuitem', {name: spaceName}).click();
-		await this.page
-			.getByRole('heading', {exact: true, name: spaceName})
-			.waitFor();
+		await expect(async () => {
+			await this.page.goto(PORTLET_URLS.cms);
+
+			await this.page
+				.getByRole('menuitem', {name: spaceName})
+				.click({timeout: 3000});
+
+			await this.page
+				.getByRole('heading', {exact: true, name: spaceName})
+				.waitFor({timeout: 3000});
+		}).toPass();
 	}
 
-	async addRoleToSpaceMember(roleName: string, userName: string) {
+	async openMembersDialog() {
 		await clickAndExpectToBeVisible({
 			target: this.page.getByRole('dialog'),
 			trigger: this.viewAllMembersLink,
 		});
+	}
+
+	async addRoleToSpaceMember(roleName: string, userName: string) {
+		await this.openMembersDialog();
 
 		const userRow = this.page
 			.getByRole('listitem')
@@ -112,10 +122,7 @@ export class SpaceSummaryPage {
 	}
 
 	async addUserOrUserGroup(name: string, type: UserOrUserGroupType) {
-		await clickAndExpectToBeVisible({
-			target: this.page.getByRole('dialog'),
-			trigger: this.viewAllMembersLink,
-		});
+		await this.openMembersDialog();
 
 		const dialog = this.page.getByRole('dialog');
 
@@ -147,9 +154,7 @@ export class SpaceSummaryPage {
 	}
 
 	async removeUserOrUserGroup(name: string, type: UserOrUserGroupType) {
-		await this.viewAllMembersLink.click();
-
-		await this.page.getByRole('dialog').waitFor();
+		await this.openMembersDialog();
 
 		await this.page
 			.getByLabel('Add People to Collaborate', {exact: true})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98338

## What Is Being Fixed

The e2e-cms-dxp test "A Space Administrator can assign member roles but a Content Reviewer and Member cannot see roles" is flaky. `SpaceSummaryPage.goto` navigated to the CMS home and clicked the space menuitem once; when the space list had not finished rendering the click was lost and the page stayed on the home page, so `getByRole('heading', {name: spaceName})` never appeared and the test intermittently failed.

## How It Is Being Fixed

Wrap the whole navigation (goto, menuitem click, heading wait) in `expect(...).toPass()` with short per-action timeouts, so a landing on the home page re-navigates until the space heading is visible. This mirrors the existing `ContentsPage.goto` pattern. The members dialog is also opened through a shared `openMembersDialog` helper that retries the trigger until the dialog is visible, replacing the bare `viewAllMembersLink.click()` calls.

## Why Are There No Tests?

This only hardens existing Playwright navigation in a page object; it changes no product code and adds no new behavior, so no new test is warranted. Verified with `--repeat-each` (30/30 green) that the previously flaky test is now stable.

## PR Check

**pr-check: PASS** — tested on `cddda20785bbad4a2f3adb054880cbe3724fb291`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |

<!-- pr-check {"result": "success", "sha": "cddda20785bbad4a2f3adb054880cbe3724fb291"} -->