### PR TITLE
LPD-98339 Fix CMS asset vocabulary export and import test

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryPortletDataHandlerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryPortletDataHandlerTest.java
@@ -16,7 +16,6 @@ import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.lar.DataLevel;
@@ -24,18 +23,15 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
-import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
-import com.liferay.exportimport.kernel.staging.constants.StagingConstants;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
 import com.liferay.exportimport.test.util.lar.BasePortletDataHandlerTestCase;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -66,6 +62,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Zoltan Csaszi
  */
+@DataGuard(scope = DataGuard.Scope.NONE)
 @RunWith(Arquillian.class)
 public class AssetCategoryPortletDataHandlerTest
 	extends BasePortletDataHandlerTestCase {
@@ -141,7 +138,7 @@ public class AssetCategoryPortletDataHandlerTest
 
 		_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
 
-		_addAssetVocabulary();
+		_addAssetVocabulary(assetVocabulary.getName());
 
 		ExportImportConfiguration exportImportConfiguration =
 			_setUpExportImportConfiguration();
@@ -244,7 +241,7 @@ public class AssetCategoryPortletDataHandlerTest
 
 			AssetVocabulary assetVocabulary = _addAssetVocabulary();
 
-			DepotEntry depotEntry = _addStagedDepotEntry();
+			DepotEntry depotEntry = _addDepotEntry();
 
 			Group depotGroup = depotEntry.getGroup();
 
@@ -329,23 +326,25 @@ public class AssetCategoryPortletDataHandlerTest
 	}
 
 	private AssetVocabulary _addAssetVocabulary() throws Exception {
-		return _assetVocabularyLocalService.addVocabulary(
-			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
-			"vocabulary", ServiceContextTestUtil.getServiceContext());
+		return _addAssetVocabulary(RandomTestUtil.randomString());
 	}
 
-	private DepotEntry _addStagedDepotEntry() throws Exception {
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			DepotConstants.TYPE_ASSET_LIBRARY,
+	private AssetVocabulary _addAssetVocabulary(String name) throws Exception {
+		return _assetVocabularyLocalService.addVocabulary(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(), name,
 			ServiceContextTestUtil.getServiceContext());
+	}
 
-		return _enableLocalStaging(depotEntry);
+	private DepotEntry _addDepotEntry() throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	private void _assertBatchEngineImportTaskError(LogCapture logCapture) {
@@ -356,29 +355,6 @@ public class AssetCategoryPortletDataHandlerTest
 		LogEntry logEntry = logEntries.get(0);
 
 		Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
-	}
-
-	private DepotEntry _enableLocalStaging(DepotEntry depotEntry)
-		throws Exception {
-
-		Group stagingGroup = _enableLocalStaging(depotEntry.getGroup());
-
-		return DepotEntryLocalServiceUtil.fetchGroupDepotEntry(
-			stagingGroup.getGroupId());
-	}
-
-	private Group _enableLocalStaging(Group group) throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(group.getGroupId());
-
-		_setStagingAttributes(serviceContext);
-
-		serviceContext.setAttribute("staging", Boolean.TRUE);
-
-		StagingLocalServiceUtil.enableLocalStaging(
-			TestPropsValues.getUserId(), group, false, false, serviceContext);
-
-		return group.getStagingGroup();
 	}
 
 	private File _exportLayoutsAsFile() throws Exception {
@@ -400,25 +376,6 @@ public class AssetCategoryPortletDataHandlerTest
 										ASSET_CATEGORIES_ADMIN,
 								new String[] {Boolean.TRUE.toString()}
 							).build())));
-	}
-
-	private void _setStagingAttribute(
-		ServiceContext serviceContext, String key) {
-
-		serviceContext.setAttribute(
-			StagingConstants.STAGED_PREFIX + key + StringPool.DOUBLE_DASH,
-			String.valueOf(Boolean.TRUE));
-	}
-
-	private void _setStagingAttributes(ServiceContext serviceContext) {
-		_setStagingAttribute(
-			serviceContext, PortletDataHandlerKeys.DATA_STRATEGY_MIRROR);
-		_setStagingAttribute(
-			serviceContext, PortletDataHandlerKeys.PORTLET_CONFIGURATION_ALL);
-		_setStagingAttribute(
-			serviceContext, PortletDataHandlerKeys.PORTLET_DATA_ALL);
-		_setStagingAttribute(
-			serviceContext, PortletDataHandlerKeys.PORTLET_SETUP_ALL);
 	}
 
 	private ExportImportConfiguration _setUpExportImportConfiguration()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98339

### What

`AssetCategoryPortletDataHandlerTest.testExportImportCMSAssetVocabulary` associated the CMS asset vocabulary with a depot's local-staging group instead of the live Space, so the group association was lost across the LAR export/import round-trip and the assertion failed. This corrects the setup to use the live `TYPE_SPACE` depot group and removes the now-unused staging scaffolding.

### Why

Under `LPD-17564` the LAR round-trip for taxonomy vocabularies runs through the headless/batch-engine path (`TaxonomyVocabularyResourceImpl`), which keeps an associated group only when its `depotEntryType` type-setting equals `TYPE_SPACE` (`TaxonomyGroupUtil.getAssetLibraryGroupIds`). A local-staging group carries no `depotEntryType` type-setting, so the filter never matched and the import fell back to `GROUP_ID_ALL` (-1). The committed test also wired the depot as `TYPE_ASSET_LIBRARY`, whereas CMS associations are always Spaces. There is no product defect; only the test setup was wrong.

### How

The staging helper `_addStagedDepotEntry` becomes a plain `_addDepotEntry` that returns a live `TYPE_SPACE` depot, so the vocabulary associates with the live Space group (`depotEntryType = TYPE_SPACE`). The orphaned staging helpers and their imports are removed. `@DataGuard(scope = NONE)` stays because the test writes into the shared CMS system group, and the random-name vocabulary split stays because the duplicate-title test needs two same-named vocabularies with different external reference codes.

### Testing

```
cd modules/apps/asset/asset-categories-test && gradlew testIntegration --tests AssetCategoryPortletDataHandlerTest
```

All 25 methods pass, including `testExportImportCMSAssetVocabulary`.

---

**pr-check: PASS** — tested on `1254293c3b8c4b0c14b1df3a32a34826cda8e18d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

Java Unit Tests fired on the diff but were intentionally skipped for this test-only change. Integration/Playwright/Poshi runs are out of pr-check scope.
