### PR TITLE
LPD-97821 Fix web content preview on a specific display page

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/asset/display/page/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/asset/display/page/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
@@ -10,6 +10,7 @@ import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLRes
 import com.liferay.asset.display.page.util.AssetDisplayPageUtil;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
@@ -32,6 +33,8 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutFriendlyURLComposite;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
@@ -51,14 +54,17 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.permission.WorkflowPermissionUtil;
 
@@ -245,6 +251,8 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 		HttpServletRequest httpServletRequest =
 			(HttpServletRequest)requestContext.get("request");
 
+		String layoutMode = ParamUtil.getString(httpServletRequest, "p_l_mode");
+
 		if (Validator.isNull(currentDefaultAssetPublisherPortletId)) {
 			String actualPortletAuthenticationToken = AuthTokenUtil.getToken(
 				httpServletRequest, layout.getPlid(),
@@ -287,6 +295,11 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 		actualParams.put(
 			namespace + "assetEntryId",
 			new String[] {String.valueOf(assetEntry.getEntryId())});
+
+		if (Objects.equals(layoutMode, Constants.PREVIEW)) {
+			_markWorkflowAssetPreview(
+				assetEntry, assetRendererFactory, httpServletRequest);
+		}
 
 		String ddmTemplateKey = _getDDMTemplateKey(groupId, friendlyURL);
 
@@ -589,6 +602,31 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 
 		return false;
 	}
+
+	private void _markWorkflowAssetPreview(
+		AssetEntry assetEntry, AssetRendererFactory<?> assetRendererFactory,
+		HttpServletRequest httpServletRequest) {
+
+		try {
+			AssetRenderer<?> assetRenderer =
+				assetRendererFactory.getAssetRenderer(assetEntry.getClassPK());
+
+			if (assetRenderer.hasEditPermission(
+					PermissionThreadLocal.getPermissionChecker())) {
+
+				httpServletRequest.setAttribute(
+					WebKeys.WORKFLOW_ASSET_PREVIEW, Boolean.TRUE);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DefaultAssetDisplayPageFriendlyURLResolver.class);
 
 	@Reference
 	private AssetDisplayPageFriendlyURLProvider

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -84,7 +85,7 @@ public class AssetPublisherViewContentDisplayContext {
 			return false;
 		}
 
-		if (!_assetEntry.isVisible()) {
+		if (!_assetEntry.isVisible() && !_isWorkflowAssetPreview()) {
 			SessionErrors.add(
 				_renderRequest, NoSuchModelException.class.getName());
 
@@ -158,6 +159,20 @@ public class AssetPublisherViewContentDisplayContext {
 		_viewMode = ParamUtil.getString(_renderRequest, "viewMode");
 
 		return _viewMode;
+	}
+
+	private boolean _isWorkflowAssetPreview() {
+		if (!GetterUtil.getBoolean(
+				_renderRequest.getAttribute(WebKeys.WORKFLOW_ASSET_PREVIEW))) {
+
+			return false;
+		}
+
+		if (_assetEntry.getEntryId() == _getAssetEntryId()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _setAssetObjects() {

--- a/modules/apps/asset/asset-publisher-web/src/test/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContextTest.java
+++ b/modules/apps/asset/asset-publisher-web/src/test/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContextTest.java
@@ -6,9 +6,11 @@
 package com.liferay.asset.publisher.web.internal.display.context;
 
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
 
@@ -39,8 +41,24 @@ public class AssetPublisherViewContentDisplayContextTest {
 
 	@Test
 	public void testIsAssetEntryVisible() {
+		Assert.assertFalse(_isAssetEntryVisible("1", false));
+		Assert.assertFalse(_isAssetEntryVisible("2", true));
+		Assert.assertTrue(_isAssetEntryVisible("1", true));
+	}
+
+	private boolean _isAssetEntryVisible(
+		String assetEntryId, boolean workflowAssetPreview) {
+
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			new MockLiferayPortletRenderRequest();
+
+		if (workflowAssetPreview) {
+			mockLiferayPortletRenderRequest.setAttribute(
+				WebKeys.WORKFLOW_ASSET_PREVIEW, Boolean.TRUE);
+		}
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"assetEntryId", assetEntryId);
 
 		AssetPublisherViewContentDisplayContext
 			assetPublisherViewContentDisplayContext =
@@ -48,6 +66,12 @@ public class AssetPublisherViewContentDisplayContextTest {
 					mockLiferayPortletRenderRequest, false);
 
 		AssetEntry assetEntry = Mockito.mock(AssetEntry.class);
+
+		Mockito.when(
+			assetEntry.getEntryId()
+		).thenReturn(
+			1L
+		);
 
 		Mockito.when(
 			assetEntry.isVisible()
@@ -58,8 +82,11 @@ public class AssetPublisherViewContentDisplayContextTest {
 		ReflectionTestUtil.setFieldValue(
 			assetPublisherViewContentDisplayContext, "_assetEntry", assetEntry);
 
-		Assert.assertFalse(
-			assetPublisherViewContentDisplayContext.isAssetEntryVisible());
+		ReflectionTestUtil.setFieldValue(
+			assetPublisherViewContentDisplayContext, "_assetRenderer",
+			Mockito.mock(AssetRenderer.class));
+
+		return assetPublisherViewContentDisplayContext.isAssetEntryVisible();
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97821

## What Is Being Fixed

Previewing a Journal Article (web content) assigned as a Specific Display Page and rendered through a Default Asset Publisher widget was broken: the preview either failed to show the content at all or blocked it whenever the content was still pending workflow approval, even though the previewer had edit permission on it. This used to work in earlier releases.

## How It Is Being Fixed

The friendly URL resolver and the page-preview struts action had stopped forwarding the `assetEntryId`, `mvcPath`, and `type` render parameters the Default Asset Publisher portlet needs to render the content, and the portlet's visibility check unconditionally rejected non-visible (pending workflow) content regardless of the previewer's permissions. Both call sites now share a new `DefaultAssetPublisherRenderParametersUtil` to rebuild those render parameters, and set a `WORKFLOW_ASSET_PREVIEW` request attribute, together with the specific asset entry ID that was permission-checked, so `AssetPublisherViewContentDisplayContext` can bypass the visibility check for that one entry without also bypassing it for unrelated assets rendered by other Asset Publisher widgets on the same page. A unit test locks in that entry-scoped behavior.

## PR Check

**pr-check: PASS** — tested on `5a15342d57f1f10c76d8906bf24b6c4b91705bde`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5a15342d57f1f10c76d8906bf24b6c4b91705bde"} -->
