### PR TITLE
LPD-97359 CMS Recycle Bin type filter returns no results for trashed content

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -52,7 +52,8 @@ public class ObjectEntryFolderModelDocumentContributor
 			document.addKeyword(
 				"objectDefinitionExternalReferenceCode",
 				ObjectEntryFolderConstants.
-					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER);
+					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER,
+				true);
 		}
 
 		document.addLocalizedKeyword(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -416,7 +416,7 @@ public class ObjectEntryModelDocumentContributor
 
 		document.addKeyword(
 			"objectDefinitionExternalReferenceCode",
-			objectDefinition.getExternalReferenceCode());
+			objectDefinition.getExternalReferenceCode(), true);
 		document.addKeyword(
 			"objectDefinitionId", objectEntry.getObjectDefinitionId());
 		document.addKeyword(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -60,8 +61,9 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 				"cms_section", "contents"
 			).put(
 				"objectDefinitionExternalReferenceCode",
-				ObjectEntryFolderConstants.
-					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER
+				StringUtil.toLowerCase(
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER)
 			).build(),
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS);
 		_testContribute(
@@ -71,8 +73,9 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 				"cms_section", "files"
 			).put(
 				"objectDefinitionExternalReferenceCode",
-				ObjectEntryFolderConstants.
-					EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER
+				StringUtil.toLowerCase(
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_OBJECT_ENTRY_FOLDER)
 			).build(),
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES);
 		_testContribute(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerIndexedFieldsTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
 import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
@@ -76,7 +77,8 @@ public class ObjectEntryIndexerIndexedFieldsTest {
 				).query(
 					QueriesUtil.term(
 						"objectDefinitionExternalReferenceCode",
-						_objectDefinition.getExternalReferenceCode())
+						StringUtil.toLowerCase(
+							_objectDefinition.getExternalReferenceCode()))
 				).build()
 			).build());
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1497,14 +1497,6 @@ test(
 	'All section can be filtered by Type',
 	{tag: ['@LPD-85551', '@LPD-87956', '@LPD-97359']},
 	async ({apiHelpers, assetsPage, page}) => {
-
-		// LPD-97359: the CMS Type filter (objectDefinitionExternalReferenceCode)
-		// returns "No Results Found" for a valid type, in both the Recycle Bin
-		// and the All section. Recorded as an expected failure until the fix
-		// lands, at which point this test turns green and test.fail() is removed.
-
-		test.fail();
-
 		const documentTitle = getRandomString();
 		const webContentTitle = getRandomString();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97359

## What Is Being Fixed

In the CMS Recycle Bin (and the Contents/Files section views), filtering by the Type facet returned no results even for entries that genuinely belong to the selected type. Selecting "Basic Web Content" showed "0 Results Found" while the same entry was visible with that exact type when no filter was applied.

## How It Is Being Fixed

The Type filter builds an OData filter of the form objectDefinitionExternalReferenceCode eq 'L_CMS_BASIC_WEB_CONTENT'. The OData expression visitor always lowercases string literals before searching, but the object entry and object entry folder documents indexed this keyword with its original case, so the lowercased query could never match an uppercase external reference code. Both document contributors now index the value in lowercase (via the lowercasing addKeyword overload), so every OData comparison on this field matches regardless of case. This also restores the folder pseudo-type option and the All section's objectDefinitionExternalReferenceCode ne 'L_OBJECT_ENTRY_FOLDER' exclusion, which were broken by the same mismatch. Note that existing object entry and object entry folder documents need a reindex for the fix to apply to pre-existing content.

## PR Check

**pr-check: PASS** — tested on `a051e85844d8c69e5e15a3544b417677b0c2dada`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a051e85844d8c69e5e15a3544b417677b0c2dada"} -->
