### PR TITLE
LPD-98570 Clean up standalone CMS modules and configurations

### DIFF
--- a/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-memberships-api")
 	compileOnly project(":apps:staging:staging-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:style-book:style-book-api")
 	compileOnly project(":apps:template:template-api")

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/configuration/admin/display/CMSConfigurationVisibilityController.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/configuration/admin/display/CMSConfigurationVisibilityController.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"configuration.pid=com.liferay.document.library.configuration.DLConfiguration",
+		"configuration.pid=com.liferay.document.library.configuration.DLFileEntryConfiguration",
+		"configuration.pid=com.liferay.document.library.configuration.DLFileEntryFriendlyURLConfiguration",
+		"configuration.pid=com.liferay.document.library.configuration.DLFileEntryMimeTypeConfiguration",
+		"configuration.pid=com.liferay.document.library.internal.configuration.DLFileOrderConfiguration",
+		"configuration.pid=com.liferay.document.library.item.selector.web.internal.configuration.DLImageItemSelectorViewConfiguration",
+		"configuration.pid=com.liferay.document.library.preview.audio.internal.configuration.DLAudioFFMPEGAudioConverterConfiguration",
+		"configuration.pid=com.liferay.document.library.video.internal.configuration.DLVideoFFMPEGVideoConverterConfiguration"
+	},
+	service = ConfigurationVisibilityController.class
+)
+public class CMSConfigurationVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return false;
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98570

## What Is Being Fixed

The standalone CMS build shipped a configuration surface that did not match
what the product actually supports. The API Explorer was broken (404) because
only its web assets module was included, not the impl module that registers the
/o/api application. The Google Drive integration was effectively dead — only its
-api bundle was deployed, with no consumers — yet it still surfaced a "Google
Drive" entry in Instance and System Settings. Several Document Library
configurations that are not relevant to the standalone CMS were also exposed.

## How It Is Being Fixed

The API Explorer is restored by adding the standalone-build marker to
headless-discovery-impl, which registers the /o/api application that serves the
web module's assets. The orphaned Google Drive integration is dropped from the
standalone build by removing the marker from its -api module, since nothing
deployed consumes its exported configuration package. The remaining Document
Library configurations are hidden with a single ConfigurationVisibilityController
in the standalone CMS module that returns false for their PIDs, keeping the
configurations fully functional at runtime while removing them from the settings
UI.

## Why Are There No Tests?

The changes are standalone-CMS build markers and a ConfigurationVisibilityController
that unconditionally hides configurations from the settings UI. There is no
unit-testable logic, and the behavior was verified end-to-end against a running
standalone CMS bundle: the API Explorer serves at /o/api, the Google Drive entry
and the targeted Document Library entries are gone from Instance and System
Settings, and no bundle-resolution or runtime regressions occur.

## PR Check

**pr-check: PASS** — tested on `3a8085680c6aacc47ce0cbd7c34c85a79807ba5f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3a8085680c6aacc47ce0cbd7c34c85a79807ba5f"} -->
