### PR TITLE
LPD-98460 Sync CMS document friendly URLs to the underlying file

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/CMSBasicDocumentObjectEntryFriendlyURLModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/CMSBasicDocumentObjectEntryFriendlyURLModelListenerTest.java
@@ -1,0 +1,253 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jan Brychta
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class CMSBasicDocumentObjectEntryFriendlyURLModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		CMSTestUtil.getOrAddGroup(
+			CMSBasicDocumentObjectEntryFriendlyURLModelListenerTest.class);
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testOnAfterCreateAndUpdateSyncsFileEntryFriendlyURL()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		Group group = depotEntry.getGroup();
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
+					group.getGroupId(), depotEntry.getCompanyId());
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), depotEntry.getGroupId(),
+			depotEntry.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			null, null, null,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(TestDataConstants.TEST_BYTE_ARRAY),
+			TestDataConstants.TEST_BYTE_ARRAY.length, null, null, null,
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_DOCUMENT", depotEntry.getCompanyId());
+
+		String urlTitle1 = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		ServiceContext addServiceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		addServiceContext.setAttribute(
+			"friendlyUrlMap",
+			HashMapBuilder.put(
+				"en_US", urlTitle1
+			).build());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"file", dlFileEntry.getFileEntryId()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", RandomTestUtil.randomString()
+				).build()
+			).build(),
+			addServiceContext);
+
+		long fileEntryClassNameId = _classNameLocalService.getClassNameId(
+			FileEntry.class.getName());
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long attachmentFileEntryId = GetterUtil.getLong(values.get("file"));
+
+		Assert.assertEquals(
+			HashMapBuilder.put(
+				"en_US", urlTitle1
+			).build(),
+			_getFileEntryUrlTitleMap(
+				fileEntryClassNameId, attachmentFileEntryId));
+
+		String urlTitle2 = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		ServiceContext updateServiceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		updateServiceContext.setAttribute(
+			"friendlyUrlMap",
+			HashMapBuilder.put(
+				"de_DE", urlTitle2
+			).put(
+				"en_US", urlTitle1
+			).build());
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			objectEntry.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				"file", attachmentFileEntryId
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", RandomTestUtil.randomString()
+				).build()
+			).build(),
+			updateServiceContext);
+
+		values = objectEntry.getValues();
+
+		attachmentFileEntryId = GetterUtil.getLong(values.get("file"));
+
+		Assert.assertEquals(
+			HashMapBuilder.put(
+				"de_DE", urlTitle2
+			).put(
+				"en_US", urlTitle1
+			).build(),
+			_getFileEntryUrlTitleMap(
+				fileEntryClassNameId, attachmentFileEntryId));
+	}
+
+	private Map<String, String> _getFileEntryUrlTitleMap(
+			long classNameId, long fileEntryId)
+		throws Exception {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				classNameId, fileEntryId);
+
+		Map<String, String> urlTitleMap = new HashMap<>();
+
+		if (friendlyURLEntry == null) {
+			return urlTitleMap;
+		}
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			urlTitleMap.put(
+				friendlyURLEntryLocalization.getLanguageId(),
+				friendlyURLEntryLocalization.getUrlTitle());
+		}
+
+		return urlTitleMap;
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v4_0_0/test/CMSBasicDocumentFriendlyURLUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v4_0_0/test/CMSBasicDocumentFriendlyURLUpgradeProcessTest.java
@@ -1,0 +1,264 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v4_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jan Brychta
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class CMSBasicDocumentFriendlyURLUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		CMSTestUtil.getOrAddGroup(
+			CMSBasicDocumentFriendlyURLUpgradeProcessTest.class);
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testUpgradeSyncsOutOfSyncFileEntryFriendlyURL()
+		throws Exception {
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			UpgradeProcessUtil.getDefaultLanguageId(
+				TestPropsValues.getCompanyId()));
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				defaultLocale, StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				defaultLocale, StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		Group group = depotEntry.getGroup();
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
+					group.getGroupId(), depotEntry.getCompanyId());
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), depotEntry.getGroupId(),
+			depotEntry.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			null, null, null,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(TestDataConstants.TEST_BYTE_ARRAY),
+			TestDataConstants.TEST_BYTE_ARRAY.length, null, null, null,
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_DOCUMENT", depotEntry.getCompanyId());
+
+		String urlTitle = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
+		ServiceContext addServiceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		addServiceContext.setAttribute(
+			"friendlyUrlMap",
+			HashMapBuilder.put(
+				"en_US", urlTitle
+			).build());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"file", dlFileEntry.getFileEntryId()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", RandomTestUtil.randomString()
+				).build()
+			).build(),
+			addServiceContext);
+
+		long fileEntryClassNameId = _classNameLocalService.getClassNameId(
+			FileEntry.class.getName());
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long attachmentFileEntryId = GetterUtil.getLong(values.get("file"));
+
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(
+			attachmentFileEntryId);
+
+		String staleUrlTitle = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			fileEntry.getGroupId(), fileEntryClassNameId,
+			fileEntry.getFileEntryId(), "en_US",
+			HashMapBuilder.put(
+				"en_US", staleUrlTitle
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			HashMapBuilder.put(
+				"en_US", staleUrlTitle
+			).build(),
+			_getFileEntryUrlTitleMap(
+				fileEntryClassNameId, attachmentFileEntryId));
+
+		_runUpgrade();
+
+		Assert.assertEquals(
+			HashMapBuilder.put(
+				"en_US", urlTitle
+			).build(),
+			_getFileEntryUrlTitleMap(
+				fileEntryClassNameId, attachmentFileEntryId));
+	}
+
+	private Map<String, String> _getFileEntryUrlTitleMap(
+			long classNameId, long fileEntryId)
+		throws Exception {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				classNameId, fileEntryId);
+
+		Map<String, String> urlTitleMap = new HashMap<>();
+
+		if (friendlyURLEntry == null) {
+			return urlTitleMap;
+		}
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			urlTitleMap.put(
+				friendlyURLEntryLocalization.getLanguageId(),
+				friendlyURLEntryLocalization.getUrlTitle());
+		}
+
+		return urlTitleMap;
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.site.cms.site.initializer.internal.upgrade.v4_0_0." +
+			"CMSBasicDocumentFriendlyURLUpgradeProcess";
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.upgrade.registry.SiteCMSSiteInitializerUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")
+	compileOnly project(":apps:friendly-url:friendly-url-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/CMSBasicDocumentFriendlyURLEntryModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/CMSBasicDocumentFriendlyURLEntryModelListener.java
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener;
+
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Keeps a CMS "Basic Document" object entry's friendly URL in sync with the
+ * friendly URL of the raw {@link FileEntry} it wraps (via its "file"
+ * attachment object field), so the public document URL reflects whatever
+ * friendly URL the CMS UI configured, including per-locale translations.
+ *
+ * <p>
+ * This listens on {@link FriendlyURLEntryLocalization} rather than
+ * {@link FriendlyURLEntry} itself, because
+ * {@link com.liferay.friendly.url.service.impl.FriendlyURLEntryLocalServiceImpl}
+ * persists the {@link FriendlyURLEntry} row (firing its model listeners)
+ * before it persists the per-locale {@link FriendlyURLEntryLocalization}
+ * rows that hold the actual url title being set, so a
+ * {@link FriendlyURLEntry} listener would only ever see the url titles from
+ * before this update. Listening on {@link FriendlyURLEntryLocalization}
+ * fires once the specific locale being changed is already committed.
+ * </p>
+ *
+ * <p>
+ * This handles the case where a friendly URL is edited on an object entry
+ * that already exists. The companion
+ * {@link CMSBasicDocumentObjectEntryFriendlyURLModelListener} handles the
+ * case where the friendly URL is set as part of creating the object entry,
+ * when the object entry is not yet visible through
+ * {@code ObjectEntryLocalService} at the moment this listener would fire.
+ * </p>
+ *
+ * @author Jan Brychta
+ */
+@Component(service = ModelListener.class)
+public class CMSBasicDocumentFriendlyURLEntryModelListener
+	extends BaseModelListener<FriendlyURLEntryLocalization> {
+
+	@Override
+	public void onAfterCreate(
+			FriendlyURLEntryLocalization friendlyURLEntryLocalization)
+		throws ModelListenerException {
+
+		try {
+			_syncFileEntryFriendlyURL(friendlyURLEntryLocalization);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	@Override
+	public void onAfterUpdate(
+			FriendlyURLEntryLocalization originalFriendlyURLEntryLocalization,
+			FriendlyURLEntryLocalization friendlyURLEntryLocalization)
+		throws ModelListenerException {
+
+		try {
+			_syncFileEntryFriendlyURL(friendlyURLEntryLocalization);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	private void _syncFileEntryFriendlyURL(
+			FriendlyURLEntryLocalization friendlyURLEntryLocalization)
+		throws Exception {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+				friendlyURLEntryLocalization.getFriendlyURLEntryId());
+
+		if (friendlyURLEntry == null) {
+			return;
+		}
+
+		ObjectDefinition cmsBasicDocumentObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_DOCUMENT", friendlyURLEntry.getCompanyId());
+
+		if (cmsBasicDocumentObjectDefinition == null) {
+			return;
+		}
+
+		long objectEntryClassNameId = _classNameLocalService.getClassNameId(
+			cmsBasicDocumentObjectDefinition.getClassName());
+
+		if (friendlyURLEntry.getClassNameId() != objectEntryClassNameId) {
+			return;
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			friendlyURLEntry.getClassPK());
+
+		if (objectEntry == null) {
+
+			// The object entry is not visible yet through
+
+			// ObjectEntryLocalService, meaning this friendly URL entry is
+			// being created as part of the object entry's own creation.
+			// CMSBasicDocumentObjectEntryFriendlyURLModelListener handles
+			// that case once the object entry is fully persisted.
+
+			return;
+		}
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long dlFileEntryId = GetterUtil.getLong(values.get("file"));
+
+		if (dlFileEntryId <= 0) {
+			return;
+		}
+
+		Map<String, String> urlTitleMap = new HashMap<>();
+
+		for (FriendlyURLEntryLocalization currentFriendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			urlTitleMap.put(
+				currentFriendlyURLEntryLocalization.getLanguageId(),
+				currentFriendlyURLEntryLocalization.getUrlTitle());
+		}
+
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(dlFileEntryId);
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			fileEntry.getGroupId(),
+			_classNameLocalService.getClassNameId(FileEntry.class),
+			fileEntry.getFileEntryId(), friendlyURLEntry.getDefaultLanguageId(),
+			urlTitleMap, ServiceContextThreadLocal.getServiceContext());
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/CMSBasicDocumentObjectEntryFriendlyURLModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/CMSBasicDocumentObjectEntryFriendlyURLModelListener.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener;
+
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Keeps a CMS "Basic Document" object entry's friendly URL in sync with the
+ * friendly URL of the raw {@link FileEntry} it wraps (via its "file"
+ * attachment object field), so the public document URL reflects whatever
+ * friendly URL the CMS UI configured, including per-locale translations.
+ *
+ * <p>
+ * This listens on {@link ObjectEntry} rather than {@link FriendlyURLEntry}.
+ * {@link com.liferay.object.service.impl.ObjectEntryLocalServiceImpl} adds or
+ * updates the object entry's own friendly URL entry before it persists the
+ * object entry itself for a versioned, non-draft object entry (as
+ * "CMSBasicDocument" is configured), so a {@link FriendlyURLEntry} listener
+ * fires while the object entry is not yet visible through
+ * {@code ObjectEntryLocalService}. Listening on {@link ObjectEntry} avoids
+ * that ordering: the object entry parameter is already fully populated when
+ * the listener fires, and by then its friendly URL entry has already been
+ * created or updated.
+ * </p>
+ *
+ * @author Jan Brychta
+ */
+@Component(service = ModelListener.class)
+public class CMSBasicDocumentObjectEntryFriendlyURLModelListener
+	extends BaseModelListener<ObjectEntry> {
+
+	@Override
+	public void onAfterCreate(ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		try {
+			_syncFileEntryFriendlyURL(objectEntry);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	@Override
+	public void onAfterUpdate(
+			ObjectEntry originalObjectEntry, ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		try {
+			_syncFileEntryFriendlyURL(objectEntry);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	private void _syncFileEntryFriendlyURL(ObjectEntry objectEntry)
+		throws Exception {
+
+		ObjectDefinition cmsBasicDocumentObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_DOCUMENT", objectEntry.getCompanyId());
+
+		if ((cmsBasicDocumentObjectDefinition == null) ||
+			(objectEntry.getObjectDefinitionId() !=
+				cmsBasicDocumentObjectDefinition.getObjectDefinitionId())) {
+
+			return;
+		}
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long dlFileEntryId = GetterUtil.getLong(values.get("file"));
+
+		if (dlFileEntryId <= 0) {
+			return;
+		}
+
+		long objectEntryClassNameId = _classNameLocalService.getClassNameId(
+			cmsBasicDocumentObjectDefinition.getClassName());
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				objectEntryClassNameId, objectEntry.getObjectEntryId());
+
+		if (friendlyURLEntry == null) {
+			return;
+		}
+
+		Map<String, String> urlTitleMap = new HashMap<>();
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			urlTitleMap.put(
+				friendlyURLEntryLocalization.getLanguageId(),
+				friendlyURLEntryLocalization.getUrlTitle());
+		}
+
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(dlFileEntryId);
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			fileEntry.getGroupId(),
+			_classNameLocalService.getClassNameId(FileEntry.class),
+			fileEntry.getFileEntryId(), friendlyURLEntry.getDefaultLanguageId(),
+			urlTitleMap, ServiceContextThreadLocal.getServiceContext());
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -5,6 +5,8 @@
 
 package com.liferay.site.cms.site.initializer.internal.upgrade.registry;
 
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -16,12 +18,14 @@ import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSDefaultPermissionsUpgradeProcess;
 import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSObjectRelationshipEdgeUpgradeProcess;
 import com.liferay.site.cms.site.initializer.internal.upgrade.v2_0_0.CMSBulkActionTaskTaskResultUpgradeProcess;
+import com.liferay.site.cms.site.initializer.internal.upgrade.v4_0_0.CMSBasicDocumentFriendlyURLUpgradeProcess;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -57,15 +61,31 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 			new CMSBulkActionTaskTaskResultUpgradeProcess(
 				_companyLocalService, _objectDefinitionLocalService,
 				_objectFieldLocalService));
+
+		registry.register(
+			"3.0.0", "4.0.0",
+			new CMSBasicDocumentFriendlyURLUpgradeProcess(
+				_classNameLocalService, _companyLocalService,
+				_dlAppLocalService, _friendlyURLEntryLocalService,
+				_objectDefinitionLocalService, _objectEntryLocalService));
 	}
 
 	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
 
 	@Reference(
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
 	)
 	private FilterFactory<Predicate> _filterFactory;
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v4_0_0/CMSBasicDocumentFriendlyURLUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v4_0_0/CMSBasicDocumentFriendlyURLUpgradeProcess.java
@@ -1,0 +1,218 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v4_0_0;
+
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Backfills the friendly URL of the raw {@link FileEntry} a CMS "Basic
+ * Document" object entry wraps (via its "file" attachment object field),
+ * for object entries created or updated before the model listeners that
+ * keep the two in sync started existing.
+ *
+ * @author Jan Brychta
+ */
+public class CMSBasicDocumentFriendlyURLUpgradeProcess extends UpgradeProcess {
+
+	public CMSBasicDocumentFriendlyURLUpgradeProcess(
+		ClassNameLocalService classNameLocalService,
+		CompanyLocalService companyLocalService,
+		DLAppLocalService dlAppLocalService,
+		FriendlyURLEntryLocalService friendlyURLEntryLocalService,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryLocalService objectEntryLocalService) {
+
+		_classNameLocalService = classNameLocalService;
+		_companyLocalService = companyLocalService;
+		_dlAppLocalService = dlAppLocalService;
+		_friendlyURLEntryLocalService = friendlyURLEntryLocalService;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(this::_upgradeCompany);
+	}
+
+	private boolean _isInSync(
+		long fileEntryClassNameId, FileEntry fileEntry,
+		Map<String, String> urlTitleMap) {
+
+		FriendlyURLEntry fileEntryFriendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				fileEntryClassNameId, fileEntry.getFileEntryId());
+
+		if (fileEntryFriendlyURLEntry == null) {
+			return false;
+		}
+
+		Map<String, String> fileEntryUrlTitleMap = new HashMap<>();
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					fileEntryFriendlyURLEntry.getFriendlyURLEntryId())) {
+
+			fileEntryUrlTitleMap.put(
+				friendlyURLEntryLocalization.getLanguageId(),
+				friendlyURLEntryLocalization.getUrlTitle());
+		}
+
+		return fileEntryUrlTitleMap.equals(urlTitleMap);
+	}
+
+	private void _upgradeCompany(long companyId) throws PortalException {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_DOCUMENT", companyId);
+
+		if (objectDefinition == null) {
+			return;
+		}
+
+		long objectEntryClassNameId = _classNameLocalService.getClassNameId(
+			objectDefinition.getClassName());
+
+		AtomicInteger syncedCount = new AtomicInteger();
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_objectEntryLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq(
+					"objectDefinitionId",
+					objectDefinition.getObjectDefinitionId())));
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntry objectEntry) -> {
+				try {
+					if (_upgradeObjectEntry(
+							objectEntry, objectEntryClassNameId)) {
+
+						syncedCount.incrementAndGet();
+					}
+				}
+				catch (PortalException portalException) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to sync the friendly URL of the file ",
+								"entry wrapped by CMS basic document ",
+								objectEntry.getObjectEntryId(), " for company ",
+								companyId),
+							portalException);
+					}
+				}
+			});
+
+		actionableDynamicQuery.performActions();
+
+		if (_log.isInfoEnabled() && (syncedCount.get() > 0)) {
+			_log.info(
+				StringBundler.concat(
+					"Synced the friendly URL of ", syncedCount.get(),
+					" file entries wrapped by CMS basic documents for company ",
+					companyId));
+		}
+	}
+
+	private boolean _upgradeObjectEntry(
+			ObjectEntry objectEntry, long objectEntryClassNameId)
+		throws PortalException {
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long dlFileEntryId = GetterUtil.getLong(values.get("file"));
+
+		if (dlFileEntryId <= 0) {
+			return false;
+		}
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				objectEntryClassNameId, objectEntry.getObjectEntryId());
+
+		if (friendlyURLEntry == null) {
+			return false;
+		}
+
+		Map<String, String> urlTitleMap = new HashMap<>();
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			urlTitleMap.put(
+				friendlyURLEntryLocalization.getLanguageId(),
+				friendlyURLEntryLocalization.getUrlTitle());
+		}
+
+		FileEntry fileEntry;
+
+		try {
+			fileEntry = _dlAppLocalService.getFileEntry(dlFileEntryId);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
+
+		long fileEntryClassNameId = _classNameLocalService.getClassNameId(
+			FileEntry.class);
+
+		if (_isInSync(fileEntryClassNameId, fileEntry, urlTitleMap)) {
+			return false;
+		}
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			fileEntry.getGroupId(), fileEntryClassNameId,
+			fileEntry.getFileEntryId(), friendlyURLEntry.getDefaultLanguageId(),
+			urlTitleMap, new ServiceContext());
+
+		return true;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CMSBasicDocumentFriendlyURLUpgradeProcess.class);
+
+	private final ClassNameLocalService _classNameLocalService;
+	private final CompanyLocalService _companyLocalService;
+	private final DLAppLocalService _dlAppLocalService;
+	private final FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98460

## What Is Being Fixed

CMS represents an uploaded document as an object entry that wraps the underlying file entry via an attachment field. The public `/documents/d/...` URL that actually serves the file resolves against the file entry's own friendly URL, but nothing kept that in sync with the friendly URL configured through the CMS UI on the object entry. As a result, neither the default-locale friendly URL nor any translated one ever worked on the publicly served document, even though the CMS's own friendly URL editor showed the value correctly.

## How It Is Being Fixed

Two model listeners keep the object entry's friendly URL synced to the file entry it wraps. The split is necessary because of internal persistence ordering in the object and friendly URL frameworks: the object entry listener catches the friendly URL configured as part of creating the document, since the friendly URL entry it needs isn't visible yet if it reacted at that earlier point instead; the friendly URL localization listener catches a friendly URL edited as a separate step after the document already exists, reacting to the specific per-locale data being persisted rather than to the friendly URL entry's own row, whose model listener fires before that locale data is actually written.

An upgrade process backfills every existing document whose file entry predates this fix, comparing its stored friendly URL against the object entry's and correcting any mismatch.

## PR Check

**pr-check: PASS** — tested on `85bea777084045c6d0e2d9e87b0f4c602af816d8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "85bea777084045c6d0e2d9e87b0f4c602af816d8"} -->
