### PR TITLE
LPD-88143 Add standalone CMS site initializer functional tests

### DIFF
--- a/modules/apps/site/site-cms-standalone-site-initializer/test.properties
+++ b/modules/apps/site/site-cms-standalone-site-initializer/test.properties
@@ -1,0 +1,11 @@
+modified.files.includes[relevant][site-cms-standalone-site-initializer-playwright-rule]=**
+
+playwright.projects.includes[playwright-js-tomcat101-postgresql163][relevant][site-cms-standalone-site-initializer-playwright-rule]=\
+    site-cms-standalone-site-initializer.main
+
+relevant.rule.names=site-cms-standalone-site-initializer-playwright-rule
+
+test.batch.names[relevant][site-cms-standalone-site-initializer-playwright-rule]=\
+    playwright-js-tomcat101-postgresql163
+
+testray.main.component.name=Content Management System

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -209,6 +209,7 @@ import {config as siteCmpSiteInitializerConfig} from './tests/site-cmp-site-init
 import {config as siteCmsSiteInitializerConfig} from './tests/site-cms-site-initializer/main/config';
 import {config as siteCmsSiteInitializerPermissionsConfig} from './tests/site-cms-site-initializer/permissions/config';
 import {config as siteCmsSiteInitializerStructureBuilderConfig} from './tests/site-cms-site-initializer/structure-builder/config';
+import {config as siteCmsStandaloneSiteInitializerConfig} from './tests/site-cms-standalone-site-initializer/main/config';
 import {config as siteDsrSiteInitializerConfig} from './tests/site-dsr-site-initializer/main/config';
 import {config as siteMySitesWebConfig} from './tests/site-my-sites-web/main/config';
 import {config as siteNavigationAdminWebConfig} from './tests/site-navigation-admin-web/main/config';
@@ -451,6 +452,7 @@ export default defineConfig({
 		siteCmsSiteInitializerConfig,
 		siteCmsSiteInitializerPermissionsConfig,
 		siteCmsSiteInitializerStructureBuilderConfig,
+		siteCmsStandaloneSiteInitializerConfig,
 		siteDsrSiteInitializerConfig,
 		siteMySitesWebConfig,
 		siteNavigationAdminWebConfig,

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/config.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'site-cms-standalone-site-initializer.main',
+	testDir: 'tests/site-cms-standalone-site-initializer/main',
+};

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/configuration.spec.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/configuration.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = mergeTests(
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+// The categories the standalone CMS keeps visible (CMSConfigurationCategoryShowFilter).
+
+const VISIBLE_CATEGORY_NAMES = new Set([
+	'AI Creator',
+	'Accessibility',
+	'Batch Engine',
+	'Comments',
+	'Community Tools',
+	'Default Permissions',
+	'Documents and Media',
+	'Email',
+	'Feature Flags',
+	'Instance Configuration',
+	'LDAP',
+	'Localization',
+	'Login',
+	'Marketplace',
+	'OAuth 2',
+	'Object',
+	'SCIM',
+	'Security Tools',
+	'SSO',
+	'Translation',
+	'User Authentication',
+	'Web API',
+]);
+
+const SETTINGS_URLS = {
+	'instance settings':
+		'/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet',
+	'system settings':
+		'/group/control_panel/~/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet',
+};
+
+for (const [label, url] of Object.entries(SETTINGS_URLS)) {
+	test(
+		`only shows allowlisted configuration categories in ${label}`,
+		{tag: '@LPD-94604'},
+		async ({page}) => {
+			await page.goto(url);
+
+			const categoryLinks = page.locator('.list-group-card-item-text');
+
+			await expect(categoryLinks.first()).toBeVisible();
+
+			const categoryNames = (await categoryLinks.allInnerTexts()).map(
+				(name) => name.trim()
+			);
+
+			expect(categoryNames.length).toBeGreaterThan(0);
+
+			// No category outside the standalone CMS allowlist leaks through
+
+			for (const categoryName of categoryNames) {
+				expect(VISIBLE_CATEGORY_NAMES).toContain(categoryName);
+			}
+
+			// A few representative allowlisted categories are present
+
+			expect(categoryNames).toContain('Login');
+			expect(categoryNames).toContain('Web API');
+			expect(categoryNames).toContain('Documents and Media');
+		}
+	);
+}

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/controlPanelApplications.spec.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/controlPanelApplications.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = mergeTests(
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+// Landing on a control panel application renders the full product menu.
+
+const CONTROL_PANEL_URL =
+	'/group/control_panel/manage?p_p_id=com_liferay_roles_admin_web_portlet_RolesAdminPortlet';
+
+test(
+	'hides administration applications that are irrelevant to the standalone CMS',
+	{tag: '@LPD-94604'},
+	async ({page}) => {
+		await page.goto(CONTROL_PANEL_URL);
+
+		const productMenu = page.locator('nav.menubar');
+
+		await expect(productMenu).toBeAttached();
+
+		// Applications kept in the standalone CMS are still reachable
+
+		await expect(
+			productMenu.getByRole('menuitem', {exact: true, name: 'Roles'})
+		).toHaveCount(1);
+		await expect(
+			productMenu.getByRole('menuitem', {exact: true, name: 'Objects'})
+		).toHaveCount(1);
+
+		// Applications filtered out by CMSPanelAppShowFilter are gone
+
+		await expect(
+			productMenu.getByRole('menuitem', {name: 'Service Accounts'})
+		).toHaveCount(0);
+		await expect(
+			productMenu.getByRole('menuitem', {exact: true, name: 'Sites'})
+		).toHaveCount(0);
+	}
+);

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/env/portal-ext.properties
@@ -1,0 +1,3 @@
+feature.flag.LPD-11235=false
+feature.flag.LPD-17564=true
+feature.flag.LPD-34594=true

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/env/portal-ext.properties
@@ -1,3 +1,4 @@
 feature.flag.LPD-11235=false
 feature.flag.LPD-17564=true
+
 feature.flag.LPD-34594=true

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/login.spec.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/login.spec.ts
@@ -9,16 +9,11 @@ import {CMSLoginPage} from './pages/CMSLoginPage';
 
 test.describe('Standalone CMS login page', () => {
 	let cmsLoginPage: CMSLoginPage;
-	let slideDotLabels: string[];
-	let slideTitles: string[];
 
 	test.beforeEach(async ({page}) => {
 		cmsLoginPage = new CMSLoginPage(page);
 
 		await cmsLoginPage.goto();
-
-		slideDotLabels = await cmsLoginPage.getSlideDotLabels();
-		slideTitles = await cmsLoginPage.getSlideTitles();
 	});
 
 	test(
@@ -29,69 +24,6 @@ test.describe('Standalone CMS login page', () => {
 
 			await expect(cmsLoginPage.emailAddressInput).toBeVisible();
 			await expect(cmsLoginPage.passwordInput).toBeVisible();
-		}
-	);
-
-	test(
-		'shows a login carousel with a slide and a dot for every highlight',
-		{tag: '@LPD-95488'},
-		async ({page}) => {
-
-			// Pause autoplay so the asserted slide does not advance mid-check
-
-			await cmsLoginPage.pauseButton.click();
-
-			// Every highlight is reachable through its navigation dot
-
-			for (const label of slideDotLabels) {
-				await expect(cmsLoginPage.dot(label)).toBeVisible();
-			}
-
-			// Only the active slide is exposed to assistive technology
-
-			await expect(page.getByRole('heading', {level: 2})).toHaveText(
-				slideTitles[0]
-			);
-
-			await expect(cmsLoginPage.dot(slideDotLabels[0])).toHaveAttribute(
-				'aria-current',
-				'true'
-			);
-		}
-	);
-
-	test(
-		'toggles between pausing and resuming the carousel autoplay',
-		{tag: '@LPD-95488'},
-		async () => {
-			await expect(cmsLoginPage.pauseButton).toBeVisible();
-
-			await cmsLoginPage.pauseButton.click();
-
-			await expect(cmsLoginPage.resumeButton).toBeVisible();
-
-			await cmsLoginPage.resumeButton.click();
-
-			await expect(cmsLoginPage.pauseButton).toBeVisible();
-		}
-	);
-
-	test(
-		'navigates to a slide when its dot is clicked',
-		{tag: '@LPD-95488'},
-		async ({page}) => {
-			await cmsLoginPage.pauseButton.click();
-
-			await cmsLoginPage.dot(slideDotLabels[2]).click();
-
-			await expect(page.getByRole('heading', {level: 2})).toHaveText(
-				slideTitles[2]
-			);
-
-			await expect(cmsLoginPage.dot(slideDotLabels[2])).toHaveAttribute(
-				'aria-current',
-				'true'
-			);
 		}
 	);
 });

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/login.spec.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/login.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, test} from '@playwright/test';
+
+import {CMSLoginPage} from './pages/CMSLoginPage';
+
+test.describe('Standalone CMS login page', () => {
+	let cmsLoginPage: CMSLoginPage;
+	let slideDotLabels: string[];
+	let slideTitles: string[];
+
+	test.beforeEach(async ({page}) => {
+		cmsLoginPage = new CMSLoginPage(page);
+
+		await cmsLoginPage.goto();
+
+		slideDotLabels = await cmsLoginPage.getSlideDotLabels();
+		slideTitles = await cmsLoginPage.getSlideTitles();
+	});
+
+	test(
+		'shows the CMS welcome message and the sign in form',
+		{tag: '@LPD-95488'},
+		async () => {
+			await expect(cmsLoginPage.welcomeHeading).toBeVisible();
+
+			await expect(cmsLoginPage.emailAddressInput).toBeVisible();
+			await expect(cmsLoginPage.passwordInput).toBeVisible();
+		}
+	);
+
+	test(
+		'shows a login carousel with a slide and a dot for every highlight',
+		{tag: '@LPD-95488'},
+		async ({page}) => {
+
+			// Pause autoplay so the asserted slide does not advance mid-check
+
+			await cmsLoginPage.pauseButton.click();
+
+			// Every highlight is reachable through its navigation dot
+
+			for (const label of slideDotLabels) {
+				await expect(cmsLoginPage.dot(label)).toBeVisible();
+			}
+
+			// Only the active slide is exposed to assistive technology
+
+			await expect(page.getByRole('heading', {level: 2})).toHaveText(
+				slideTitles[0]
+			);
+
+			await expect(cmsLoginPage.dot(slideDotLabels[0])).toHaveAttribute(
+				'aria-current',
+				'true'
+			);
+		}
+	);
+
+	test(
+		'toggles between pausing and resuming the carousel autoplay',
+		{tag: '@LPD-95488'},
+		async () => {
+			await expect(cmsLoginPage.pauseButton).toBeVisible();
+
+			await cmsLoginPage.pauseButton.click();
+
+			await expect(cmsLoginPage.resumeButton).toBeVisible();
+
+			await cmsLoginPage.resumeButton.click();
+
+			await expect(cmsLoginPage.pauseButton).toBeVisible();
+		}
+	);
+
+	test(
+		'navigates to a slide when its dot is clicked',
+		{tag: '@LPD-95488'},
+		async ({page}) => {
+			await cmsLoginPage.pauseButton.click();
+
+			await cmsLoginPage.dot(slideDotLabels[2]).click();
+
+			await expect(page.getByRole('heading', {level: 2})).toHaveText(
+				slideTitles[2]
+			);
+
+			await expect(cmsLoginPage.dot(slideDotLabels[2])).toHaveAttribute(
+				'aria-current',
+				'true'
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/pages/CMSLoginPage.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/pages/CMSLoginPage.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect} from '@playwright/test';
+
+export const CAROUSEL_SLIDE_KEYS = [
+	'structured-content-for-every-channel',
+	'all-your-assets-one-smart-library',
+	'collaboration-without-friction',
+	'control-every-piece-of-content',
+];
+
+export class CMSLoginPage {
+	readonly page: Page;
+
+	readonly carousel: Locator;
+	readonly emailAddressInput: Locator;
+	readonly passwordInput: Locator;
+	readonly pauseButton: Locator;
+	readonly resumeButton: Locator;
+	readonly welcomeHeading: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.carousel = page.locator('.login-carousel');
+
+		this.emailAddressInput = page.getByLabel('Email Address');
+
+		this.passwordInput = page.getByLabel('Password');
+
+		this.pauseButton = page.getByRole('button', {name: 'Pause'});
+
+		this.resumeButton = page.getByRole('button', {name: 'Resume'});
+
+		this.welcomeHeading = page.getByRole('heading', {
+			name: 'Headless CMS',
+		});
+	}
+
+	activeSlideHeading(title: string): Locator {
+		return this.page.getByRole('heading', {level: 2, name: title});
+	}
+
+	dot(label: string): Locator {
+		return this.page.getByRole('button', {name: label});
+	}
+
+	async getSlideDotLabels(): Promise<string[]> {
+		return this.page.evaluate(
+			(count) =>
+				Array.from({length: count}, (_, index) =>
+					Liferay.Util.sub(Liferay.Language.get('go-to-slide-x'), [
+						String(index + 1),
+					])
+				),
+			CAROUSEL_SLIDE_KEYS.length
+		);
+	}
+
+	async getSlideTitles(): Promise<string[]> {
+		return this.page.evaluate(
+			(keys) => keys.map((key) => Liferay.Language.get(key)),
+			CAROUSEL_SLIDE_KEYS
+		);
+	}
+
+	async goto() {
+		await this.page.goto('/sign-in');
+
+		await expect(this.carousel).toBeVisible();
+	}
+}

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/pages/CMSLoginPage.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/pages/CMSLoginPage.ts
@@ -5,21 +5,12 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
-export const CAROUSEL_SLIDE_KEYS = [
-	'structured-content-for-every-channel',
-	'all-your-assets-one-smart-library',
-	'collaboration-without-friction',
-	'control-every-piece-of-content',
-];
-
 export class CMSLoginPage {
 	readonly page: Page;
 
 	readonly carousel: Locator;
 	readonly emailAddressInput: Locator;
 	readonly passwordInput: Locator;
-	readonly pauseButton: Locator;
-	readonly resumeButton: Locator;
 	readonly welcomeHeading: Locator;
 
 	constructor(page: Page) {
@@ -31,40 +22,9 @@ export class CMSLoginPage {
 
 		this.passwordInput = page.getByLabel('Password');
 
-		this.pauseButton = page.getByRole('button', {name: 'Pause'});
-
-		this.resumeButton = page.getByRole('button', {name: 'Resume'});
-
 		this.welcomeHeading = page.getByRole('heading', {
 			name: 'Headless CMS',
 		});
-	}
-
-	activeSlideHeading(title: string): Locator {
-		return this.page.getByRole('heading', {level: 2, name: title});
-	}
-
-	dot(label: string): Locator {
-		return this.page.getByRole('button', {name: label});
-	}
-
-	async getSlideDotLabels(): Promise<string[]> {
-		return this.page.evaluate(
-			(count) =>
-				Array.from({length: count}, (_, index) =>
-					Liferay.Util.sub(Liferay.Language.get('go-to-slide-x'), [
-						String(index + 1),
-					])
-				),
-			CAROUSEL_SLIDE_KEYS.length
-		);
-	}
-
-	async getSlideTitles(): Promise<string[]> {
-		return this.page.evaluate(
-			(keys) => keys.map((key) => Liferay.Language.get(key)),
-			CAROUSEL_SLIDE_KEYS
-		);
 	}
 
 	async goto() {

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/redirect.spec.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/redirect.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = mergeTests(
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'redirects a signed in user from the guest portal layout to the CMS',
+	{tag: '@LPD-96232'},
+	async ({page}) => {
+		await page.goto('/c/portal/layout');
+
+		await expect(page).toHaveURL(/\/web\/cms(\/|$)/);
+	}
+);

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/roles.spec.ts
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/roles.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = mergeTests(
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const ROLES_ADMIN_URL =
+	'/group/control_panel/manage?p_p_id=com_liferay_roles_admin_web_portlet_RolesAdminPortlet';
+
+test(
+	'hides account and site role types from the roles administration',
+	{tag: '@LPD-94207'},
+	async ({page}) => {
+		await page.goto(ROLES_ADMIN_URL);
+
+		const roleTypeNavigation = page.locator('.navigation-bar');
+
+		// The remaining role types are still offered
+
+		await expect(
+			roleTypeNavigation.getByRole('link', {name: 'Regular Roles'})
+		).toBeVisible();
+		await expect(
+			roleTypeNavigation.getByRole('link', {name: 'Organization Roles'})
+		).toBeVisible();
+
+		// Account and site role types are hidden in the standalone CMS
+
+		await expect(
+			roleTypeNavigation.getByRole('link', {name: 'Account Roles'})
+		).toHaveCount(0);
+		await expect(
+			roleTypeNavigation.getByRole('link', {name: 'Site Roles'})
+		).toHaveCount(0);
+	}
+);

--- a/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/test.properties
+++ b/modules/test/playwright/tests/site-cms-standalone-site-initializer/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Content Management System


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88143

## What Is Being Fixed

The standalone CMS site initializer module had no functional test coverage for its user-facing behaviors: the custom login experience, the redirect that keeps signed in users inside the CMS, and the way the standalone bundle hides DXP concepts that do not apply to a headless CMS (site and account roles, non-CMS administration applications, and configuration categories). These were only exercised manually.

## How It Is Being Fixed

A dedicated Playwright project, site-cms-standalone-site-initializer, is added so these behaviors run independently of the main CMS content management suite, with their own feature flags and their own test batch registration. The project covers the custom login page and its carousel (with the carousel copy resolved from language keys rather than hardcoded text), the redirect to the CMS for signed in guests, the hidden account and site role types in the roles administration, the allowlisted configuration categories in system and instance settings, and the administration applications filtered out of the standalone control panel.

## PR Check

**pr-check: PASS** — tested on `e44c907f6af2c1d48ac73b8432c9c64d02bff869`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

The Per-Module Compile and JavaScript Unit Test validations matched the diff mechanically but were not applicable: the changed module ships no OSGi bundle, and Playwright suites are out of pr-check scope. The nine new specs were run directly against the bundle and all pass.

<!-- pr-check {"result": "success", "sha": "e44c907f6af2c1d48ac73b8432c9c64d02bff869"} -->
