### PR TITLE
LPD-98151 Require update permission to open the template edit view

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -678,8 +678,8 @@ public class JournalContentDisplayContext {
 			PortalUtil.getControlPanelPortletURL(
 				_portletRequest, JournalPortletKeys.JOURNAL,
 				PortletRequest.RENDER_PHASE)
-		).setMVCPath(
-			"/edit_ddm_template.jsp"
+		).setMVCRenderCommandName(
+			"/journal/edit_ddm_template"
 		).setRedirect(
 			_themeDisplay.getURLCurrent()
 		).setParameter(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditDDMTemplateDisplayContextTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditDDMTemplateDisplayContextTest.java
@@ -6,14 +6,21 @@
 package com.liferay.journal.web.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
@@ -25,6 +32,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -88,27 +96,162 @@ public class JournalEditDDMTemplateDisplayContextTest {
 		}
 	}
 
-	private MockLiferayPortletRenderRequest
-			_getMockLiferayPortletRenderRequest()
+	@Test
+	public void testRenderAddViewWithAddTemplatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		Assert.assertNotNull(
+			mockLiferayPortletRenderRequest.getAttribute(
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+		Assert.assertFalse(
+			SessionErrors.contains(
+				mockLiferayPortletRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	@Test
+	public void testRenderAddViewWithoutAddTemplatePermission()
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.addUser(_group.getGroupId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		_assertMustHavePermission(mockLiferayPortletRenderRequest);
+	}
+
+	@Test
+	public void testRenderEditViewWithoutUpdatePermission() throws Exception {
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.addUser(_group.getGroupId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		_assertMustHavePermission(mockLiferayPortletRenderRequest);
+	}
+
+	@Test
+	public void testRenderEditViewWithUpdatePermission() throws Exception {
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		Assert.assertNotNull(
+			mockLiferayPortletRenderRequest.getAttribute(
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+		Assert.assertFalse(
+			SessionErrors.contains(
+				mockLiferayPortletRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	@Test
+	public void testRenderPropertiesViewWithoutUpdatePermission()
+		throws Exception {
+
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.addUser(_group.getGroupId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"editProperties", Boolean.TRUE.toString());
+
+		_render(mockLiferayPortletRenderRequest);
+
+		_assertMustHavePermission(mockLiferayPortletRenderRequest);
+	}
+
+	@Test
+	public void testRenderPropertiesViewWithUpdatePermission()
+		throws Exception {
+
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"editProperties", Boolean.TRUE.toString());
+
+		_render(mockLiferayPortletRenderRequest);
+
+		Assert.assertNotNull(
+			mockLiferayPortletRenderRequest.getAttribute(
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+		Assert.assertFalse(
+			SessionErrors.contains(
+				mockLiferayPortletRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	private DDMTemplate _addDDMTemplate() throws Exception {
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		return DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), ddmStructure.getStructureId(),
+			_portal.getClassNameId(JournalArticle.class));
+	}
+
+	private void _assertMustHavePermission(RenderRequest renderRequest) {
+		Assert.assertTrue(
+			SessionErrors.contains(
+				renderRequest, PrincipalException.MustHavePermission.class));
+		Assert.assertNull(
+			renderRequest.getAttribute(_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+	}
+
+	private MockLiferayPortletRenderRequest _getMockLiferayPortletRenderRequest(
+			User user)
 		throws Exception {
 
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			new MockLiferayPortletRenderRequest();
 
-		String path = "/edit_ddm_template.jsp";
+		for (String path :
+				new String[] {
+					"/ddm_template/edit_properties.jsp",
+					"/edit_ddm_template.jsp", "/error.jsp"
+				}) {
 
-		mockLiferayPortletRenderRequest.setAttribute(
-			MVCRenderConstants.
-				PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX + path,
-			new MockLiferayPortletContext(path));
+			mockLiferayPortletRenderRequest.setAttribute(
+				MVCRenderConstants.
+					PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX +
+						path,
+				new MockLiferayPortletContext(path));
+		}
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(_group.getCompanyId()));
 		themeDisplay.setLocale(LocaleUtil.getDefault());
-
-		User user = UserTestUtil.getAdminUser(_group.getCompanyId());
 
 		themeDisplay.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(user));
@@ -119,36 +262,47 @@ public class JournalEditDDMTemplateDisplayContextTest {
 		mockLiferayPortletRenderRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 
-		mockLiferayPortletRenderRequest.setParameter("mvcPath", path);
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", "/journal/edit_ddm_template");
 
 		return mockLiferayPortletRenderRequest;
 	}
 
 	private boolean _isAutogenerateDDMTemplateKey() throws Exception {
 		RenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest();
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
 
-		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
-
-		mvcPortlet.render(
-			mockLiferayPortletRenderRequest,
-			new MockLiferayPortletRenderResponse());
+		_render(mockLiferayPortletRenderRequest);
 
 		Object journalEditDDMTemplateDisplayContext =
 			mockLiferayPortletRenderRequest.getAttribute(
-				"com.liferay.journal.web.internal.display.context." +
-					"JournalEditDDMTemplateDisplayContext");
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME);
 
 		return ReflectionTestUtil.invoke(
 			journalEditDDMTemplateDisplayContext, "autogenerateDDMTemplateKey",
 			new Class<?>[0]);
 	}
 
+	private void _render(RenderRequest renderRequest) throws Exception {
+		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
+
+		mvcPortlet.render(
+			renderRequest, new MockLiferayPortletRenderResponse());
+	}
+
+	private static final String _DISPLAY_CONTEXT_ATTRIBUTE_NAME =
+		"com.liferay.journal.web.internal.display.context." +
+			"JournalEditDDMTemplateDisplayContext";
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private Portal _portal;
 
 	@Inject(
 		filter = "component.name=com.liferay.journal.web.internal.portlet.JournalPortlet"

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateManagementToolbarDisplayContext.java
@@ -116,9 +116,9 @@ public class JournalDDMTemplateManagementToolbarDisplayContext
 		return CreationMenuBuilder.addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setHref(
-					liferayPortletResponse.createRenderURL(), "mvcPath",
-					"/edit_ddm_template.jsp", "redirect",
-					themeDisplay.getURLCurrent(), "classPK",
+					liferayPortletResponse.createRenderURL(),
+					"mvcRenderCommandName", "/journal/edit_ddm_template",
+					"redirect", themeDisplay.getURLCurrent(), "classPK",
 					_journalDDMTemplateDisplayContext.getClassPK());
 				dropdownItem.setLabel(
 					LanguageUtil.format(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1280,8 +1280,8 @@ public class JournalEditArticleDisplayContext {
 			"editDDMTemplateURL",
 			() -> PortletURLBuilder.createRenderURL(
 				_liferayPortletResponse
-			).setMVCPath(
-				"/edit_ddm_template.jsp"
+			).setMVCRenderCommandName(
+				"/journal/edit_ddm_template"
 			).setRedirect(
 				_themeDisplay.getURLCurrent()
 			).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
@@ -151,12 +151,14 @@ public class JournalEditDDMTemplateDisplayContext {
 			"propertiesViewURL",
 			() -> PortletURLBuilder.createRenderURL(
 				_renderResponse
-			).setMVCPath(
-				"/ddm_template/edit_properties.jsp"
+			).setMVCRenderCommandName(
+				"/journal/edit_ddm_template"
 			).setParameter(
 				"classPK", getClassPK()
 			).setParameter(
 				"ddmTemplateId", getDDMTemplateId()
+			).setParameter(
+				"editProperties", true
 			).setWindowState(
 				LiferayWindowState.EXCLUSIVE
 			).buildString()

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalDDMTemplateVerticalCard.java
@@ -78,8 +78,8 @@ public class JournalDDMTemplateVerticalCard extends BaseVerticalCard {
 
 			return PortletURLBuilder.createRenderURL(
 				_renderResponse
-			).setMVCPath(
-				"/edit_ddm_template.jsp"
+			).setMVCRenderCommandName(
+				"/journal/edit_ddm_template"
 			).setRedirect(
 				themeDisplay.getURLCurrent()
 			).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
@@ -62,8 +62,6 @@ import com.liferay.journal.util.JournalHelper;
 import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
 import com.liferay.journal.web.internal.display.context.JournalDisplayContext;
 import com.liferay.journal.web.internal.display.context.JournalEditDDMStructuresDisplayContext;
-import com.liferay.journal.web.internal.display.context.JournalEditDDMTemplateDisplayContext;
-import com.liferay.journal.web.internal.helper.JournalDDMTemplateHelper;
 import com.liferay.journal.web.internal.portlet.action.ActionUtil;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.exception.LocaleException;
@@ -213,16 +211,6 @@ public class JournalPortlet extends MVCPortlet {
 					JournalEditDDMStructuresDisplayContext.class.getName(),
 					new JournalEditDDMStructuresDisplayContext(
 						_portal, renderRequest, renderResponse));
-			}
-			else if (Objects.equals(
-						path, "/ddm_template/edit_properties.jsp") ||
-					 Objects.equals(path, "/edit_ddm_template.jsp")) {
-
-				renderRequest.setAttribute(
-					JournalEditDDMTemplateDisplayContext.class.getName(),
-					new JournalEditDDMTemplateDisplayContext(
-						_ddmTemplateHelper, _journalDDMTemplateHelper, _portal,
-						renderRequest, renderResponse));
 			}
 		}
 		catch (ConfigurationException configurationException) {
@@ -438,9 +426,6 @@ public class JournalPortlet extends MVCPortlet {
 
 	@Reference
 	private JournalConverter _journalConverter;
-
-	@Reference
-	private JournalDDMTemplateHelper _journalDDMTemplateHelper;
 
 	@Reference
 	private JournalFolderService _journalFolderService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AddDDMTemplateMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AddDDMTemplateMVCActionCommand.java
@@ -156,8 +156,8 @@ public class AddDDMTemplateMVCActionCommand extends BaseMVCActionCommand {
 				WebKeys.REDIRECT,
 				PortletURLBuilder.createRenderURL(
 					_portal.getLiferayPortletResponse(actionResponse)
-				).setMVCPath(
-					"/edit_ddm_template.jsp"
+				).setMVCRenderCommandName(
+					"/journal/edit_ddm_template"
 				).setRedirect(
 					ParamUtil.getString(uploadPortletRequest, "redirect")
 				).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditDDMTemplateMVCRenderCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditDDMTemplateMVCRenderCommand.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action;
+
+import com.liferay.dynamic.data.mapping.constants.DDMActionKeys;
+import com.liferay.dynamic.data.mapping.exception.NoSuchTemplateException;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.util.DDMTemplateHelper;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.web.internal.display.context.JournalEditDDMTemplateDisplayContext;
+import com.liferay.journal.web.internal.helper.JournalDDMTemplateHelper;
+import com.liferay.journal.web.internal.security.permission.resource.DDMTemplatePermission;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletException;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Shakir Shamim
+ */
+@Component(
+	property = {
+		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"mvc.command.name=/journal/edit_ddm_template"
+	},
+	service = MVCRenderCommand.class
+)
+public class EditDDMTemplateMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			renderRequest);
+
+		try {
+			_checkDDMTemplateUpdatePermission(httpServletRequest);
+
+			renderRequest.setAttribute(
+				JournalEditDDMTemplateDisplayContext.class.getName(),
+				new JournalEditDDMTemplateDisplayContext(
+					_ddmTemplateHelper, _journalDDMTemplateHelper, _portal,
+					renderRequest, renderResponse));
+		}
+		catch (Exception exception) {
+			if (exception instanceof NoSuchTemplateException ||
+				exception instanceof PrincipalException) {
+
+				SessionErrors.add(renderRequest, exception.getClass());
+
+				return "/error.jsp";
+			}
+
+			throw new PortletException(exception);
+		}
+
+		if (ParamUtil.getBoolean(httpServletRequest, "editProperties")) {
+			return "/ddm_template/edit_properties.jsp";
+		}
+
+		return "/edit_ddm_template.jsp";
+	}
+
+	private void _checkDDMTemplateUpdatePermission(
+			HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		long ddmTemplateId = ParamUtil.getLong(
+			httpServletRequest, "ddmTemplateId");
+
+		if (ddmTemplateId > 0) {
+			if (!DDMTemplatePermission.contains(
+					themeDisplay.getPermissionChecker(), ddmTemplateId,
+					ActionKeys.UPDATE)) {
+
+				throw new PrincipalException.MustHavePermission(
+					themeDisplay.getPermissionChecker(),
+					DDMTemplate.class.getName(), ddmTemplateId,
+					ActionKeys.UPDATE);
+			}
+
+			return;
+		}
+
+		if (!DDMTemplatePermission.containsAddTemplatePermission(
+				themeDisplay.getPermissionChecker(),
+				themeDisplay.getScopeGroupId(),
+				_portal.getClassNameId(DDMStructure.class),
+				_portal.getClassNameId(JournalArticle.class))) {
+
+			throw new PrincipalException.MustHavePermission(
+				themeDisplay.getPermissionChecker(),
+				DDMActionKeys.ADD_TEMPLATE);
+		}
+	}
+
+	@Reference
+	private DDMTemplateHelper _ddmTemplateHelper;
+
+	@Reference
+	private JournalDDMTemplateHelper _journalDDMTemplateHelper;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDDMTemplateMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDDMTemplateMVCActionCommand.java
@@ -99,8 +99,8 @@ public class UpdateDDMTemplateMVCActionCommand extends BaseMVCActionCommand {
 				WebKeys.REDIRECT,
 				PortletURLBuilder.createRenderURL(
 					_portal.getLiferayPortletResponse(actionResponse)
-				).setMVCPath(
-					"/edit_ddm_template.jsp"
+				).setMVCRenderCommandName(
+					"/journal/edit_ddm_template"
 				).setRedirect(
 					ParamUtil.getString(uploadPortletRequest, "redirect")
 				).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateExportScriptConfigurationIcon.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateExportScriptConfigurationIcon.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
-		"path=/edit_ddm_template.jsp"
+		"path=/journal/edit_ddm_template"
 	},
 	service = PortletConfigurationIcon.class
 )

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateImportScriptConfigurationIcon.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateImportScriptConfigurationIcon.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
-		"path=/edit_ddm_template.jsp"
+		"path=/journal/edit_ddm_template"
 	},
 	service = PortletConfigurationIcon.class
 )

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalDDMTemplateActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalDDMTemplateActionDropdownItemsProvider.java
@@ -152,8 +152,8 @@ public class JournalDDMTemplateActionDropdownItemsProvider {
 
 		return dropdownItem -> {
 			dropdownItem.setHref(
-				_renderResponse.createRenderURL(), "mvcPath",
-				"/edit_ddm_template.jsp", "redirect",
+				_renderResponse.createRenderURL(), "mvcRenderCommandName",
+				"/journal/edit_ddm_template", "redirect",
 				_themeDisplay.getURLCurrent(), "ddmTemplateId",
 				_ddmTemplate.getTemplateId());
 			dropdownItem.setIcon("pencil");

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/edit_properties.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/edit_properties.jsp
@@ -7,10 +7,14 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+JournalEditDDMTemplateDisplayContext journalEditDDMTemplateDisplayContext = (JournalEditDDMTemplateDisplayContext)request.getAttribute(JournalEditDDMTemplateDisplayContext.class.getName());
+%>
+
 <div class="journal-ddm-template-properties">
 	<liferay-frontend:form-navigator
 		fieldSetCssClass="form-group-sm mb-0 panel-group-flush"
-		formModelBean='<%= DDMTemplateLocalServiceUtil.fetchDDMTemplate(ParamUtil.getLong(request, "ddmTemplateId")) %>'
+		formModelBean="<%= journalEditDDMTemplateDisplayContext.getDDMTemplate() %>"
 		id="<%= JournalWebConstants.FORM_NAVIGATOR_ID_JOURNAL_DDM_TEMPLATE %>"
 		showButtons="<%= false %>"
 	/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -26,11 +26,11 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 %>
 
 <portlet:actionURL name="/journal/add_ddm_template" var="addDDMTemplateURL">
-	<portlet:param name="mvcPath" value="/edit_ddm_template.jsp" />
+	<portlet:param name="mvcRenderCommandName" value="/journal/edit_ddm_template" />
 </portlet:actionURL>
 
 <portlet:actionURL name="/journal/update_ddm_template" var="updateDDMTemplateURL">
-	<portlet:param name="mvcPath" value="/edit_ddm_template.jsp" />
+	<portlet:param name="mvcRenderCommandName" value="/journal/edit_ddm_template" />
 </portlet:actionURL>
 
 <aui:form action="<%= (ddmTemplate == null) ? addDDMTemplateURL : updateDDMTemplateURL %>" cssClass="edit-article-form" enctype="multipart/form-data" method="post" name="fm" onSubmit="event.preventDefault();">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
@@ -59,8 +59,8 @@ if (ddmStructure != null) {
 			if (DDMTemplatePermission.contains(permissionChecker, ddmTemplate, ActionKeys.UPDATE)) {
 				rowHREF = PortletURLBuilder.createRenderURL(
 					renderResponse
-				).setMVCPath(
-					"/edit_ddm_template.jsp"
+				).setMVCRenderCommandName(
+					"/journal/edit_ddm_template"
 				).setRedirect(
 					currentURL
 				).setParameter(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98151

## What Is Being Fixed

A user with only view access to web content (DDM) templates could reach the template editor and its properties panel by crafting the Journal portlet render URL. The render path performed no permission check, and the properties panel loaded the template through the unchecked local service, so the editor rendered and the template configuration was disclosed even though saving was already blocked at the service layer.

## How It Is Being Fixed

Reworked per review. Following the precedent @adolfopa and @jkappler pointed at — `EditFolderMVCRenderCommand` in document-library, `EditArticleMVCRenderCommand` in this module — the edit view now has a dedicated `EditDDMTemplateMVCRenderCommand` that checks permission before building the display context:

- `UPDATE` on the template when `ddmTemplateId` is given.
- `ADD_TEMPLATE` on the scope group otherwise. This closes the previous `ddmTemplateId <= 0` early return, which left the new-template path unchecked — and since `ParamUtil.getLong` returns `0` for an absent or unparseable value, simply omitting the parameter bypassed the check entirely.

The gate matches the save path exactly: `DDMTemplateServiceImpl.updateTemplate` checks `ActionKeys.UPDATE`, and `addTemplate` calls `checkAddTemplatePermission` with the same four arguments used here, so there is no open-but-cannot-save mismatch. The add-flow arguments also match `JournalDDMTemplateManagementToolbarDisplayContext`, which decides whether the Add button renders.

Two consequences worth a reviewer's attention:

**The properties panel had to move onto the command.** `/ddm_template/edit_properties.jsp` previously did `DDMTemplateLocalServiceUtil.fetchDDMTemplate(ParamUtil.getLong(request, "ddmTemplateId"))` — an unchecked load straight from a request parameter, and the second attack path named in the ticket. It now reads the template from the display context, so it cannot render configuration for a request that did not pass the check. It is selected by an `editProperties` parameter on the same command. This is why the fix goes further than `EditArticleMVCRenderCommand`, whose sub-panels are still served via `mvcPath`.

**The script icons were repointed.** `PortletConfigurationIconTracker` matches icons against the value of whichever path parameter the URL carries, so `JournalDDMTemplateImportScriptConfigurationIcon` and `JournalDDMTemplateExportScriptConfigurationIcon` moved from `path=/edit_ddm_template.jsp` to `path=/journal/edit_ddm_template`. Without this the vertical-ellipsis menu disappears from the template editor entirely, since those are the only icons registered for that path. This matches the sibling `path=/journal/edit_article` icons in the same package.

## Tests

`JournalEditDDMTemplateDisplayContextTest` covers the edit view, the properties panel and the add flow, each with and without permission, asserting both that `MustHavePermission` is recorded and that the display context is never built when access is denied. 8/8 pass against a deployed bundle.

The with-permission cases are load-bearing rather than decorative: injecting an unconditional denial into the add branch fails three tests, and the only one that catches it is `testRenderAddViewWithAddTemplatePermission`. A denial-only suite — as the first revision of this PR had — would have passed that mutation silently.
