### PR TITLE
LPD-98411 Upgrade all friendly URL titles regardless of trailing slash

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
@@ -13,6 +13,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -54,6 +55,8 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 				long groupId = resultSet1.getLong("groupId");
 				String languageId = resultSet1.getString("languageId");
 
+				String originalUrlTitle = resultSet1.getString("urlTitle");
+
 				String urlTitle = resultSet1.getString("urlTitle");
 
 				while (urlTitle.endsWith(StringPool.SLASH)) {
@@ -62,6 +65,10 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 					groupId, classNameId, classPK, urlTitle, languageId);
+
+				if (StringUtil.equals(urlTitle, originalUrlTitle)) {
+					continue;
+				}
 
 				preparedStatement2.setLong(1, classPK);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
@@ -37,8 +37,7 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 				StringBundler.concat(
 					"select distinct ctCollectionId, friendlyURLEntryId, ",
 					"languageId, urlTitle, groupId, classPK from ",
-					"FriendlyURLEntryLocalization where urlTitle like '%/' ",
-					"and classNameId = ?"));
+					"FriendlyURLEntryLocalization where classNameId = ?"));
 			PreparedStatement preparedStatement2 = connection.prepareStatement(
 				"select defaultLanguageId from JournalArticle where " +
 					"resourcePrimKey = ?")) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
@@ -10,6 +10,7 @@ import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -41,7 +42,12 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 					"FriendlyURLEntryLocalization where classNameId = ?"));
 			PreparedStatement preparedStatement2 = connection.prepareStatement(
 				"select defaultLanguageId from JournalArticle where " +
-					"resourcePrimKey = ?")) {
+					"resourcePrimKey = ?");
+			PreparedStatement updatePreparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update JournalArticle set urlTitle = ? where " +
+						"ctCollectionId = ? and resourcePrimKey = ?")) {
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				JournalArticle.class);
@@ -79,9 +85,12 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 						"defaultLanguageId");
 
 					if (defaultLanguageId.equals(languageId)) {
-						_updateURLTitle(
-							classPK, resultSet1.getLong("ctCollectionId"),
-							urlTitle);
+						updatePreparedStatement.setString(1, urlTitle);
+						updatePreparedStatement.setLong(
+							2, resultSet1.getLong("ctCollectionId"));
+						updatePreparedStatement.setLong(3, classPK);
+
+						updatePreparedStatement.addBatch();
 					}
 
 					_updateFriendlyURLEntry(
@@ -89,6 +98,8 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 						urlTitle);
 				}
 			}
+
+			updatePreparedStatement.executeBatch();
 		}
 	}
 
@@ -102,22 +113,6 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 
 		_friendlyURLEntryLocalService.updateFriendlyURLEntryLocalization(
 			friendlyURLEntry, languageId, urlTitle);
-	}
-
-	private void _updateURLTitle(
-			long classPK, long ctCollectionId, String urlTitle)
-		throws Exception {
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"update JournalArticle set urlTitle = ? where ctCollectionId " +
-					"= ? and resourcePrimKey = ?")) {
-
-			preparedStatement.setString(1, urlTitle);
-			preparedStatement.setLong(2, ctCollectionId);
-			preparedStatement.setLong(3, classPK);
-
-			preparedStatement.executeUpdate();
-		}
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v6_1_3/test/JournalArticleFriendlyURLFormatUpgradeProcessTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v6_1_3/test/JournalArticleFriendlyURLFormatUpgradeProcessTest.java
@@ -79,6 +79,25 @@ public class JournalArticleFriendlyURLFormatUpgradeProcessTest
 	}
 
 	@Test
+	public void testUpgradeKeepsAlreadyNormalizedURLTitleWithDuplicateSibling()
+		throws Exception {
+
+		_addJournalArticle("test");
+
+		JournalArticle journalArticle = _journalArticle;
+
+		_addJournalArticle("Test");
+
+		_runUpgrade();
+
+		_assertURLTitle("test-1");
+
+		_journalArticle = journalArticle;
+
+		_assertURLTitle("test");
+	}
+
+	@Test
 	public void testUpgradeWithDuplicateFriendlyURL() throws Exception {
 		_addJournalArticle("test");
 		_addJournalArticle("test/");

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v6_1_3/test/JournalArticleFriendlyURLFormatUpgradeProcessTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v6_1_3/test/JournalArticleFriendlyURLFormatUpgradeProcessTest.java
@@ -15,6 +15,7 @@ import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
@@ -65,6 +66,16 @@ public class JournalArticleFriendlyURLFormatUpgradeProcessTest
 		_runUpgrade();
 
 		_assertURLTitle("test/test");
+	}
+
+	@Test
+	public void testUpgradeForCapitalSpecialCharacter() throws Exception {
+		_addJournalArticle("test001óóóÓ");
+
+		_runUpgrade();
+
+		_assertURLTitle(
+			_friendlyURLNormalizer.normalizeWithEncoding("test001óóóó"));
 	}
 
 	@Test
@@ -179,6 +190,10 @@ public class JournalArticleFriendlyURLFormatUpgradeProcessTest
 			"JournalArticleFriendlyURLFormatUpgradeProcess";
 
 	private long _classNameId;
+
+	@Inject
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
+
 	private JournalArticle _journalArticle;
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98411

## What Is Being Fixed

The journal article friendly URL upgrade only re-normalized URL titles
that ended with a trailing slash. Titles that needed normalization for
other reasons — such as uppercase special characters that normalize to a
different encoded form — were left in their pre-normalization state.

## How It Is Being Fixed

The selection query dropped the `urlTitle like '%/'` predicate, so the
upgrade re-normalizes every FriendlyURLEntryLocalization row for the class
rather than only the slash-terminated ones. To keep that broader scan
cheap, a row whose normalized title already matches the stored value is
skipped, and the JournalArticle urlTitle updates are collected into a
single batched statement through AutoBatchPreparedStatementUtil instead of
one update per row. An integration test covers a URL title containing an
uppercase special character.

## PR Check

**pr-check: PASS** — tested on `7bec166dfc45369af31eb5ae39ca520e8105c7ec`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS (no unit counterpart; covered by Integration Test Compile) |

<!-- pr-check {"result": "success", "sha": "7bec166dfc45369af31eb5ae39ca520e8105c7ec"} -->
