### PR TITLE
LPD-92348 Add Playwright coverage for CMS folder operations

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -8,10 +8,12 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
+import {PermissionsPage} from '../permissions/pages/PermissionsPage';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -316,5 +318,307 @@ test(
 				objectEntryFolder2.id
 			);
 		}
+	}
+);
+
+test(
+	'Can add a folder in the Files section',
+	{tag: '@LPD-92348'},
+	async ({apiHelpers, assetsPage, folderPage, page}) => {
+		const folderTitle = getRandomString();
+
+		await assetsPage.gotoFiles();
+
+		const [response] = await Promise.all([
+			page.waitForResponse(
+				(response) =>
+					response.url().includes('/object-entry-folders') &&
+					response.request().method() === 'POST'
+			),
+			folderPage.createFolder(folderTitle),
+		]);
+
+		const {id} = await response.json();
+
+		try {
+			await expect(
+				page.getByLabel(folderTitle, {exact: true})
+			).toBeVisible();
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(id);
+		}
+	}
+);
+
+test(
+	'Can delete a folder in the Files section',
+	{tag: '@LPD-92348'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderTitle = getRandomString();
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+			scopeKey: 'Default',
+			title: folderTitle,
+		});
+
+		try {
+			await assetsPage.gotoFiles();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: folderTitle,
+			});
+
+			await waitForAlert(page, `Success:${folderTitle} was moved`, {
+				autoClose: false,
+			});
+
+			await expect(
+				page.getByRole('link', {name: folderTitle})
+			).toBeHidden();
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+		}
+	}
+);
+
+test(
+	'Can delete a folder in a Space',
+	{tag: '@LPD-92348'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderTitle = getRandomString();
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: space.assetLibraryKey,
+			title: folderTitle,
+		});
+
+		await assetsPage.gotoSpaceContents(spaceName);
+
+		await assetsPage.execItemAction({
+			action: 'Delete',
+			filter: folderTitle,
+		});
+
+		await waitForAlert(page, `Success:${folderTitle} was moved`, {
+			autoClose: false,
+		});
+
+		await expect(page.getByRole('link', {name: folderTitle})).toBeHidden();
+	}
+);
+
+test(
+	'Can edit a folder in the Contents section',
+	{tag: '@LPD-92348'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderTitle = getRandomString();
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: 'Default',
+			title: folderTitle,
+		});
+
+		try {
+			await assetsPage.gotoContents();
+
+			await assetsPage.execItemAction({
+				action: 'Edit',
+				filter: folderTitle,
+			});
+
+			const newFolderTitle = getRandomString();
+
+			const nameInput = page.getByLabel('Name');
+
+			await expect(nameInput).toHaveValue(folderTitle);
+
+			await nameInput.fill(newFolderTitle);
+
+			await page.getByRole('button', {name: 'Save'}).click();
+
+			await waitForAlert(
+				page,
+				`Success:${newFolderTitle} was updated successfully.`
+			);
+
+			await expect(
+				page.getByRole('link', {name: newFolderTitle})
+			).toBeVisible();
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+		}
+	}
+);
+
+test(
+	'Can edit a folder in a Space',
+	{tag: '@LPD-92348'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderTitle = getRandomString();
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: space.assetLibraryKey,
+			title: folderTitle,
+		});
+
+		await assetsPage.gotoSpaceContents(spaceName);
+
+		await assetsPage.execItemAction({
+			action: 'Edit',
+			filter: folderTitle,
+		});
+
+		const newFolderTitle = getRandomString();
+
+		const nameInput = page.getByLabel('Name');
+
+		await expect(nameInput).toHaveValue(folderTitle);
+
+		await nameInput.fill(newFolderTitle);
+
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(
+			page,
+			`Success:${newFolderTitle} was updated successfully.`
+		);
+
+		await expect(
+			page.getByRole('link', {name: newFolderTitle})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Can grant a folder permission to a Space role',
+	{tag: '@LPD-92348'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderTitle = getRandomString();
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: space.assetLibraryKey,
+			title: folderTitle,
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+		await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space.externalReferenceCode,
+			user.externalReferenceCode
+		);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			space.externalReferenceCode,
+			user.externalReferenceCode,
+			['Asset Library Member']
+		);
+
+		// Grant the Space member role permission to update the folder
+
+		await assetsPage.gotoSpaceContents(spaceName);
+
+		const permissionsMenuItem = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Permissions',
+		});
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: permissionsMenuItem.first(),
+			trigger: page.getByRole('button', {
+				name: `${folderTitle} Actions`,
+			}),
+		});
+
+		await permissionsMenuItem.first().hover();
+
+		await expect(permissionsMenuItem).toHaveCount(2);
+
+		await permissionsMenuItem.last().click();
+
+		const permissionsPage = new PermissionsPage(page);
+
+		await permissionsPage.checkPermissionsAndSave([
+			{action: 'UPDATE', role: 'Asset Library Member'},
+		]);
+
+		// Switch to the Space member and verify the granted permission
+
+		await performUserSwitch(page, user.alternateName);
+
+		await assetsPage.gotoSpaceContents(spaceName);
+
+		await clickAndExpectToBeVisible({
+			target: page.getByRole('menuitem', {
+				exact: true,
+				name: 'View Folder',
+			}),
+			trigger: page.getByRole('button', {
+				name: `${folderTitle} Actions`,
+			}),
+		});
+
+		await expect(
+			page.getByRole('menuitem', {exact: true, name: 'Edit'})
+		).toBeVisible();
+	}
+);
+
+test(
+	'The All section creation menu does not offer a New Folder option',
+	{tag: '@LPD-92348'},
+	async ({assetsPage, page}) => {
+		await assetsPage.gotoAll();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'Basic Web Content'}),
+			trigger: assetsPage.newButton,
+		});
+
+		await expect(
+			page.getByRole('menuitem', {exact: true, name: 'Folder'})
+		).toBeHidden();
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92348

## What Is Being Fixed

The CMS Assets application had gaps in its folder-operation coverage. Folder permissions were entirely untested, and creating, editing, and deleting folders through the UI were only partially covered across the Content, Files, and Space sections.

## How It Is Being Fixed

Adds Playwright tests to `folders.spec.ts` in the `site-cms-site-initializer` suite for the uncovered folder operations: adding a folder through the Files UI, deleting a folder in the Files section and in a Space, editing a folder in the Contents section and in a Space, granting a folder permission to a Space role and verifying the effect after switching to a member user, and asserting the All section creation menu offers no New Folder option.

Setup runs through `apiHelpers` (folders, spaces, users), with fresh Spaces so cleanup cascades automatically, and menu navigation uses the shared retry helpers to stay flake-free. All seven tests pass a `--repeat-each=10` flake check.

## Test Execution

cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/folders.spec.ts --grep @LPD-92348

## PR Check

**pr-check: PASS** — tested on `2992baf3ba72ee92b45445eb760c42f7126b4fa7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Per-Module Compile and JavaScript Unit Tests matched the diff but are not applicable: the only change is a Playwright test spec. The TypeScript compile is verified by the formatter's TypeScript check, and the module's `test` script is Playwright, which pr-check scopes out.

<!-- pr-check {"result": "success", "sha": "2992baf3ba72ee92b45445eb760c42f7126b4fa7"} -->
