### PR TITLE
LPD-98921 Guard valueless content field when indexing web content

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
@@ -293,6 +293,10 @@ public class JournalArticleModelDocumentContributor
 
 		Value value = ddmFormFieldValue.getValue();
 
+		if (value == null) {
+			return StringPool.BLANK;
+		}
+
 		return value.getString(locale);
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
@@ -6,9 +6,14 @@
 package com.liferay.journal.internal.search.spi.model.index.contributor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.constants.JournalArticleConstants;
@@ -16,18 +21,24 @@ import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalConverter;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -87,6 +98,23 @@ public class JournalArticleModelDocumentContributorTest {
 	}
 
 	@Test
+	public void testContributeArticleWithSeparatorContentField()
+		throws Exception {
+
+		JournalArticle journalArticle = _addArticleWithSeparatorContentField();
+
+		DocumentImpl documentImpl = new DocumentImpl();
+
+		_modelDocumentContributor.contribute(documentImpl, journalArticle);
+
+		Assert.assertEquals(
+			journalArticle.getArticleId(), documentImpl.get(Field.ARTICLE_ID));
+		Assert.assertNotNull(documentImpl.getField(Field.UID));
+		Assert.assertEquals(
+			StringPool.BLANK, documentImpl.get(LocaleUtil.US, Field.CONTENT));
+	}
+
+	@Test
 	public void testFieldContent() throws Exception {
 		Document document = _getDocument();
 
@@ -112,6 +140,32 @@ public class JournalArticleModelDocumentContributorTest {
 			document.get("defaultLanguageId"));
 	}
 
+	private JournalArticle _addArticleWithSeparatorContentField()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(LocaleUtil.US),
+			LocaleUtil.US);
+
+		ddmForm.addDDMFormField(
+			DDMFormTestUtil.createLocalizableTextDDMFormField("name"));
+		ddmForm.addDDMFormField(
+			DDMFormTestUtil.createSeparatorDDMFormField("content", false));
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(), ddmForm);
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), ddmStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class),
+			TemplateConstants.LANG_TYPE_FTL, "${name.getData()}",
+			LocaleUtil.US);
+
+		return JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(), _getSeparatorContent(),
+			ddmStructure.getStructureKey(), ddmTemplate.getTemplateKey());
+	}
+
 	private String _getDDMIndexerContent(String languageId) throws Exception {
 		com.liferay.portal.kernel.xml.Document document =
 			_journalArticle.getDocument();
@@ -134,6 +188,40 @@ public class JournalArticleModelDocumentContributorTest {
 		_modelDocumentContributor.contribute(documentImpl, _journalArticle);
 
 		return documentImpl;
+	}
+
+	private String _getSeparatorContent() {
+		com.liferay.portal.kernel.xml.Document document =
+			SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		rootElement.addAttribute("available-locales", "en_US");
+		rootElement.addAttribute("default-locale", "en_US");
+
+		rootElement.addElement("request");
+
+		Element nameElement = rootElement.addElement("dynamic-element");
+
+		nameElement.addAttribute("index-type", "keyword");
+		nameElement.addAttribute("instance-id", RandomTestUtil.randomString());
+		nameElement.addAttribute("name", "name");
+		nameElement.addAttribute("type", "text");
+
+		Element dynamicContentElement = nameElement.addElement(
+			"dynamic-content");
+
+		dynamicContentElement.addAttribute("language-id", "en_US");
+		dynamicContentElement.addCDATA("english content");
+
+		Element contentElement = rootElement.addElement("dynamic-element");
+
+		contentElement.addAttribute(
+			"instance-id", RandomTestUtil.randomString());
+		contentElement.addAttribute("name", "content");
+		contentElement.addAttribute("type", "separator");
+
+		return document.asXML();
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98921

## What Is Being Fixed

Reindexing a web content article whose DDM structure contains a valueless field named "content" (a Separator, or an empty transient field) threw a NullPointerException, aborting indexing of the whole article so it silently disappeared from search. In JournalArticleModelDocumentContributor the embedding-contribution path looked up DDM field values under the hard-coded key "content" and called value.getString(locale) without checking whether the field carried a value. A transient field such as a Separator has a null value, so getString threw.

## How It Is Being Fixed

_getEmbeddingText now guards the null value and returns StringPool.BLANK, mirroring the existing empty-list branch a few lines above and the null/transient handling already present in DDMIndexerImpl. A valueless field contributes no embedding text instead of crashing the indexer.

The integration test JournalArticleModelDocumentContributorTest adds a case that builds a structure whose "content" field is a Separator, creates an article on it, and calls contribute() directly. Against the unguarded code the test reproduces the exact NullPointerException at JournalArticleModelDocumentContributor:296; with the guard the article is indexed. Both directions were verified locally.

## PR Check

**pr-check: FAIL** — tested on `9a43656b16b44f707d69e508dbd5fa5edb8ff733`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | FAIL (pre-existing on master, unrelated to this change) |

<!-- pr-check {"result": "success", "sha": "9a43656b16b44f707d69e508dbd5fa5edb8ff733"} -->
