### PR TITLE
LPD-98560 Prevent a stale group error when creating the first space

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -453,14 +453,13 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		group = depotEntry.getGroup();
 
 		if ((unicodeProperties != null) && !unicodeProperties.isEmpty()) {
-			group.setTypeSettingsProperties(
+			_groupLocalService.updateGroup(
+				group.getGroupId(),
 				UnicodePropertiesBuilder.create(
 					group.getTypeSettingsProperties(), true
 				).putAll(
 					unicodeProperties
-				).build());
-
-			group = _groupLocalService.updateGroup(group);
+				).buildString());
 		}
 
 		_updateFriendlyURL(assetLibrary, group.getGroupId());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98560

## What Is Being Fixed

On a clean standalone CMS, the first attempt to create a space failed with an "Unable to create space" error toast and a `StaleObjectStateException` on the depot `Group` in the log; the space was only created on the second attempt, and every later space worked. The failure came from `AssetLibraryResourceImpl._addOrUpdateDepotEntry`, where the newly created depot group was written back with the merge-based `updateGroup(Group)`. During first-time access on a clean instance, the CMS first-time provisioning updates that same group row in a separate transaction, so the merge collided with the advanced version and Hibernate raised the optimistic-lock exception.

## How It Is Being Fixed

The add branch now writes the space type settings through the id-based `updateGroup(long, String)` overload, which re-reads the group inside its own transaction instead of merging a stale in-memory instance. This matches how the update branch and `DepotEntryLocalServiceImpl` already persist type settings, so a concurrent version bump from the first-time provisioning no longer breaks the first space creation.

## Why Are There No Tests?

The bug is a first-time-provisioning race that only surfaces on a genuinely clean standalone CMS boot (no `cmsFirstTimeAccess` attribute, zero depot groups), where a separate transaction advances the group version between its creation and the settings write. That timing cannot be reproduced deterministically in an integration test, so the fix was verified manually against a fresh DROP/CREATE cold-start repro instead.

## With Thanks to Vero

Vero is great and awesome: she nailed the clean-instance reproduction on MySQL that pinned the failure to line 463, which is exactly what this fixes. A haiku, with gratitude:

> Awesome Vero boots
> a clean instance finds the race
> great eyes, greater help

## PR Check

**pr-check: PASS** — tested on `de41165ee2bf513ecdcaf93846011d72a61ae0db`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "de41165ee2bf513ecdcaf93846011d72a61ae0db"} -->
