### PR TITLE
LPD-97821 Fix web content preview on a specific display page

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/asset/display/page/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/asset/display/page/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
@@ -251,8 +251,6 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 		HttpServletRequest httpServletRequest =
 			(HttpServletRequest)requestContext.get("request");
 
-		String layoutMode = ParamUtil.getString(httpServletRequest, "p_l_mode");
-
 		if (Validator.isNull(currentDefaultAssetPublisherPortletId)) {
 			String actualPortletAuthenticationToken = AuthTokenUtil.getToken(
 				httpServletRequest, layout.getPlid(),
@@ -295,6 +293,8 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 		actualParams.put(
 			namespace + "assetEntryId",
 			new String[] {String.valueOf(assetEntry.getEntryId())});
+
+		String layoutMode = ParamUtil.getString(httpServletRequest, "p_l_mode");
 
 		if (Objects.equals(layoutMode, Constants.PREVIEW)) {
 			_markWorkflowAssetPreview(

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/asset/display/page/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/asset/display/page/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
@@ -10,6 +10,7 @@ import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLRes
 import com.liferay.asset.display.page.util.AssetDisplayPageUtil;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
@@ -32,6 +33,8 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutFriendlyURLComposite;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
@@ -51,14 +54,17 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.permission.WorkflowPermissionUtil;
 
@@ -245,6 +251,8 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 		HttpServletRequest httpServletRequest =
 			(HttpServletRequest)requestContext.get("request");
 
+		String layoutMode = ParamUtil.getString(httpServletRequest, "p_l_mode");
+
 		if (Validator.isNull(currentDefaultAssetPublisherPortletId)) {
 			String actualPortletAuthenticationToken = AuthTokenUtil.getToken(
 				httpServletRequest, layout.getPlid(),
@@ -287,6 +295,11 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 		actualParams.put(
 			namespace + "assetEntryId",
 			new String[] {String.valueOf(assetEntry.getEntryId())});
+
+		if (Objects.equals(layoutMode, Constants.PREVIEW)) {
+			_markWorkflowAssetPreview(
+				assetEntry, assetRendererFactory, httpServletRequest);
+		}
 
 		String ddmTemplateKey = _getDDMTemplateKey(groupId, friendlyURL);
 
@@ -589,6 +602,31 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 
 		return false;
 	}
+
+	private void _markWorkflowAssetPreview(
+		AssetEntry assetEntry, AssetRendererFactory<?> assetRendererFactory,
+		HttpServletRequest httpServletRequest) {
+
+		try {
+			AssetRenderer<?> assetRenderer =
+				assetRendererFactory.getAssetRenderer(assetEntry.getClassPK());
+
+			if (assetRenderer.hasEditPermission(
+					PermissionThreadLocal.getPermissionChecker())) {
+
+				httpServletRequest.setAttribute(
+					WebKeys.WORKFLOW_ASSET_PREVIEW, Boolean.TRUE);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DefaultAssetDisplayPageFriendlyURLResolver.class);
 
 	@Reference
 	private AssetDisplayPageFriendlyURLProvider

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -84,7 +85,7 @@ public class AssetPublisherViewContentDisplayContext {
 			return false;
 		}
 
-		if (!_assetEntry.isVisible()) {
+		if (!_assetEntry.isVisible() && !_isWorkflowAssetPreview()) {
 			SessionErrors.add(
 				_renderRequest, NoSuchModelException.class.getName());
 
@@ -158,6 +159,20 @@ public class AssetPublisherViewContentDisplayContext {
 		_viewMode = ParamUtil.getString(_renderRequest, "viewMode");
 
 		return _viewMode;
+	}
+
+	private boolean _isWorkflowAssetPreview() {
+		if (!GetterUtil.getBoolean(
+				_renderRequest.getAttribute(WebKeys.WORKFLOW_ASSET_PREVIEW))) {
+
+			return false;
+		}
+
+		if (_assetEntry.getEntryId() == _getAssetEntryId()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _setAssetObjects() {

--- a/modules/apps/asset/asset-publisher-web/src/test/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContextTest.java
+++ b/modules/apps/asset/asset-publisher-web/src/test/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContextTest.java
@@ -6,9 +6,11 @@
 package com.liferay.asset.publisher.web.internal.display.context;
 
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
 
@@ -39,8 +41,24 @@ public class AssetPublisherViewContentDisplayContextTest {
 
 	@Test
 	public void testIsAssetEntryVisible() {
+		Assert.assertFalse(_isAssetEntryVisible("1", false));
+		Assert.assertFalse(_isAssetEntryVisible("2", true));
+		Assert.assertTrue(_isAssetEntryVisible("1", true));
+	}
+
+	private boolean _isAssetEntryVisible(
+		String assetEntryId, boolean workflowAssetPreview) {
+
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			new MockLiferayPortletRenderRequest();
+
+		if (workflowAssetPreview) {
+			mockLiferayPortletRenderRequest.setAttribute(
+				WebKeys.WORKFLOW_ASSET_PREVIEW, Boolean.TRUE);
+		}
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"assetEntryId", assetEntryId);
 
 		AssetPublisherViewContentDisplayContext
 			assetPublisherViewContentDisplayContext =
@@ -48,6 +66,12 @@ public class AssetPublisherViewContentDisplayContextTest {
 					mockLiferayPortletRenderRequest, false);
 
 		AssetEntry assetEntry = Mockito.mock(AssetEntry.class);
+
+		Mockito.when(
+			assetEntry.getEntryId()
+		).thenReturn(
+			1L
+		);
 
 		Mockito.when(
 			assetEntry.isVisible()
@@ -58,8 +82,11 @@ public class AssetPublisherViewContentDisplayContextTest {
 		ReflectionTestUtil.setFieldValue(
 			assetPublisherViewContentDisplayContext, "_assetEntry", assetEntry);
 
-		Assert.assertFalse(
-			assetPublisherViewContentDisplayContext.isAssetEntryVisible());
+		ReflectionTestUtil.setFieldValue(
+			assetPublisherViewContentDisplayContext, "_assetRenderer",
+			Mockito.mock(AssetRenderer.class));
+
+		return assetPublisherViewContentDisplayContext.isAssetEntryVisible();
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97821

## What Is Being Fixed

Previewing a web content article on a specific display page failed when the article was still under workflow and not yet visible. The asset publisher's visibility check treated the not-yet-approved article as missing and surfaced a "no such model" error instead of rendering the preview.

## How It Is Being Fixed

The default asset display page friendly URL resolver detects the preview layout mode and, when the current user has edit permission on the asset, marks the request with the WORKFLOW_ASSET_PREVIEW attribute. The asset publisher view content display context honors that attribute and bypasses the visibility check, scoped to the asset entry actually being previewed so other assets on the page are unaffected. The layout mode local is declared where it is used, and a unit test covers the entry-scoped preview behavior.

## PR Check

**pr-check: PASS** — tested on `2746f7f9692e653f139ec0f374405da763379935`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2746f7f9692e653f139ec0f374405da763379935"} -->

@Chaitanya-Sammetla 
