### PR TITLE
LPD-98921 Guard valueless content field when indexing web content

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
@@ -293,6 +293,10 @@ public class JournalArticleModelDocumentContributor
 
 		Value value = ddmFormFieldValue.getValue();
 
+		if (value == null) {
+			return StringPool.BLANK;
+		}
+
 		return value.getString(locale);
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
@@ -6,9 +6,14 @@
 package com.liferay.journal.internal.search.spi.model.index.contributor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.constants.JournalArticleConstants;
@@ -16,18 +21,24 @@ import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalConverter;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -87,6 +98,23 @@ public class JournalArticleModelDocumentContributorTest {
 	}
 
 	@Test
+	public void testContributeArticleWithSeparatorContentField()
+		throws Exception {
+
+		JournalArticle journalArticle = _addArticleWithSeparatorContentField();
+
+		DocumentImpl documentImpl = new DocumentImpl();
+
+		_modelDocumentContributor.contribute(documentImpl, journalArticle);
+
+		Assert.assertEquals(
+			journalArticle.getArticleId(), documentImpl.get(Field.ARTICLE_ID));
+		Assert.assertNotNull(documentImpl.getField(Field.UID));
+		Assert.assertEquals(
+			StringPool.BLANK, documentImpl.get(LocaleUtil.US, Field.CONTENT));
+	}
+
+	@Test
 	public void testFieldContent() throws Exception {
 		Document document = _getDocument();
 
@@ -112,6 +140,32 @@ public class JournalArticleModelDocumentContributorTest {
 			document.get("defaultLanguageId"));
 	}
 
+	private JournalArticle _addArticleWithSeparatorContentField()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(LocaleUtil.US),
+			LocaleUtil.US);
+
+		ddmForm.addDDMFormField(
+			DDMFormTestUtil.createLocalizableTextDDMFormField("name"));
+		ddmForm.addDDMFormField(
+			DDMFormTestUtil.createSeparatorDDMFormField("content", false));
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(), ddmForm);
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), ddmStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class),
+			TemplateConstants.LANG_TYPE_FTL, "${name.getData()}",
+			LocaleUtil.US);
+
+		return JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(), _getSeparatorContent(),
+			ddmStructure.getStructureKey(), ddmTemplate.getTemplateKey());
+	}
+
 	private String _getDDMIndexerContent(String languageId) throws Exception {
 		com.liferay.portal.kernel.xml.Document document =
 			_journalArticle.getDocument();
@@ -134,6 +188,40 @@ public class JournalArticleModelDocumentContributorTest {
 		_modelDocumentContributor.contribute(documentImpl, _journalArticle);
 
 		return documentImpl;
+	}
+
+	private String _getSeparatorContent() {
+		com.liferay.portal.kernel.xml.Document document =
+			SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		rootElement.addAttribute("available-locales", "en_US");
+		rootElement.addAttribute("default-locale", "en_US");
+
+		rootElement.addElement("request");
+
+		Element nameElement = rootElement.addElement("dynamic-element");
+
+		nameElement.addAttribute("index-type", "keyword");
+		nameElement.addAttribute("instance-id", RandomTestUtil.randomString());
+		nameElement.addAttribute("name", "name");
+		nameElement.addAttribute("type", "text");
+
+		Element dynamicContentElement = nameElement.addElement(
+			"dynamic-content");
+
+		dynamicContentElement.addAttribute("language-id", "en_US");
+		dynamicContentElement.addCDATA("english content");
+
+		Element contentElement = rootElement.addElement("dynamic-element");
+
+		contentElement.addAttribute(
+			"instance-id", RandomTestUtil.randomString());
+		contentElement.addAttribute("name", "content");
+		contentElement.addAttribute("type", "separator");
+
+		return document.asXML();
 	}
 
 	@Inject

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
@@ -89,12 +89,38 @@ public class JournalArticleModelDocumentContributorTest {
 	}
 
 	@Test
-	public void testAvailableLanguageIds() throws Exception {
+	public void testContributeArticleAvailableLanguageIds() throws Exception {
 		Assert.assertEquals(
 			SetUtil.fromArray(
 				LocalizationUtil.getAvailableLanguageIds(
 					_journalArticle.getDocument())),
 			SetUtil.fromArray(_journalArticle.getAvailableLanguageIds()));
+	}
+
+	@Test
+	public void testContributeArticleContent() throws Exception {
+		Document document = _getDocument();
+
+		for (String languageId : _journalArticle.getAvailableLanguageIds()) {
+			Assert.assertEquals(
+				_getDDMIndexerContent(languageId),
+				document.get(
+					LocaleUtil.fromLanguageId(languageId), Field.CONTENT));
+		}
+	}
+
+	@Test
+	public void testContributeArticleDefaultLanguageId() throws Exception {
+		DDMStructure ddmStructure = _journalArticle.getDDMStructure();
+
+		DDMFormValues ddmFormValues = _ddmFieldLocalService.getDDMFormValues(
+			ddmStructure.getDDMForm(), _journalArticle.getId());
+
+		Document document = _getDocument();
+
+		Assert.assertEquals(
+			LocaleUtil.toLanguageId(ddmFormValues.getDefaultLocale()),
+			document.get("defaultLanguageId"));
 	}
 
 	@Test
@@ -108,35 +134,10 @@ public class JournalArticleModelDocumentContributorTest {
 
 		Assert.assertEquals(
 			journalArticle.getArticleId(), documentImpl.get(Field.ARTICLE_ID));
+
 		Assert.assertNotNull(documentImpl.getField(Field.UID));
 		Assert.assertEquals(
 			StringPool.BLANK, documentImpl.get(LocaleUtil.US, Field.CONTENT));
-	}
-
-	@Test
-	public void testFieldContent() throws Exception {
-		Document document = _getDocument();
-
-		for (String languageId : _journalArticle.getAvailableLanguageIds()) {
-			Assert.assertEquals(
-				_getDDMIndexerContent(languageId),
-				document.get(
-					LocaleUtil.fromLanguageId(languageId), Field.CONTENT));
-		}
-	}
-
-	@Test
-	public void testFieldDefaultLanguageId() throws Exception {
-		DDMStructure ddmStructure = _journalArticle.getDDMStructure();
-
-		DDMFormValues ddmFormValues = _ddmFieldLocalService.getDDMFormValues(
-			ddmStructure.getDDMForm(), _journalArticle.getId());
-
-		Document document = _getDocument();
-
-		Assert.assertEquals(
-			LocaleUtil.toLanguageId(ddmFormValues.getDefaultLocale()),
-			document.get("defaultLanguageId"));
 	}
 
 	private JournalArticle _addArticleWithSeparatorContentField()

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
@@ -101,9 +101,8 @@ public class JournalArticleModelDocumentContributorTest {
 	public void testContributeArticleWithSeparatorContentField()
 		throws Exception {
 
-		JournalArticle journalArticle = _addArticleWithSeparatorContentField();
-
 		DocumentImpl documentImpl = new DocumentImpl();
+		JournalArticle journalArticle = _addArticleWithSeparatorContentField();
 
 		_modelDocumentContributor.contribute(documentImpl, journalArticle);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98921

## What Is Being Fixed

Indexing a web content article whose DDM structure carries a valueless field (for example a separator field named "content") threw a NullPointerException: the model document contributor called `getString(locale)` on a `Value` that was null.

## How It Is Being Fixed

`JournalArticleModelDocumentContributor` now returns `StringPool.BLANK` when the DDM form field value is null, so the article indexes with an empty content field instead of failing. The accompanying integration test exercises the separator-field case, and the remaining test methods were renamed to share the `testContributeArticle` stem (named for the document field each asserts) so they line up with the new test.

## Test Execution

`cd modules/apps/journal/journal-test && gradlew testIntegration --tests com.liferay.journal.internal.search.spi.model.index.contributor.test.JournalArticleModelDocumentContributorTest`

## PR Check

**pr-check: PASS** — tested on `aef2160da4805b7ecb4a155e1807750cd6488d3e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "aef2160da4805b7ecb4a155e1807750cd6488d3e"} -->

@brianikim 