### PR TITLE
LPD-98407 Require only ASSIGN_MEMBERS and VIEW to manage Space members

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.asset.library.internal.resource.v1_0;
 
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.util.DepotRoleUtil;
 import com.liferay.headless.asset.library.dto.v1_0.Role;
 import com.liferay.headless.asset.library.resource.v1_0.RoleResource;
@@ -13,6 +14,7 @@ import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.NoSuchUserGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -28,15 +30,18 @@ import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleService;
 import com.liferay.portal.kernel.service.UserGroupService;
 import com.liferay.portal.kernel.service.UserService;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,9 +66,7 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		_checkAssetLibraryAdminOrAssetLibraryMember(group.getGroupId());
 
 		List<com.liferay.portal.kernel.model.Role> roles =
-			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
-
-		roles = DepotRoleUtil.filter(group.getGroupId(), roles);
+			_getAssetLibraryRoles(group.getGroupId());
 
 		if (pagination == null) {
 			return Page.of(transform(roles, this::_toRole));
@@ -145,21 +148,78 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 					group.getGroupId()));
 		}
 
-		_userGroupRoleService.deleteUserGroupRoles(
-			user.getUserId(), group.getGroupId(),
-			ListUtil.toLongArray(
-				_roleService.getUserGroupRoles(
-					user.getUserId(), group.getGroupId()),
-				com.liferay.portal.kernel.model.Role.ROLE_ID_ACCESSOR));
+		List<com.liferay.portal.kernel.model.Role> currentRoles =
+			_roleLocalService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
 
-		_userGroupRoleService.addUserGroupRoles(
-			user.getUserId(), group.getGroupId(), _getRoleIds(roles));
+		List<com.liferay.portal.kernel.model.Role> updatedRoles;
 
-		return Page.of(
-			transform(
-				_roleService.getUserGroupRoles(
-					user.getUserId(), group.getGroupId()),
-				this::_toRole));
+		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
+
+			// The CMS "Manage Members" UI (ManageMembersList) adds a brand
+			// new member and then, in a separate follow-up call, assigns
+			// them the space's fixed default role
+			// (SPACE_MEMBERS_CONFIG.defaultRoleExternalReferenceCode,
+			// hardcoded to Asset Library Member - never configurable, never
+			// any other role). That follow-up call goes through
+			// UserGroupRoleService, which requires ASSIGN_USER_ROLES; if a
+			// caller holding only ASSIGN_MEMBERS lacks it, the UI does not
+			// roll back the membership it just added - the user stays a
+			// member with no role, and the only feedback is an error toast.
+			// To avoid that half-succeeded state, a caller with just
+			// ASSIGN_MEMBERS is allowed to grant this one specific,
+			// hardcoded role, but only to a user who currently holds no
+			// roles here (i.e. was just added, mirroring the UI's own
+			// !isAlreadyMember condition for making this call at all).
+			// Reassigning an existing member's role, removing a role, or
+			// granting any other role - including Administrator or Content
+			// Reviewer - still requires ASSIGN_USER_ROLES or Role-scoped
+			// ASSIGN_MEMBERS, unchanged. The role ID is resolved through
+			// the local service (not _getRoleIds/_roleService.getRole,
+			// which requires Role-scoped VIEW) for the same reason the
+			// read of the updated roles below does: the caller may hold
+			// ASSIGN_MEMBERS on the group without holding VIEW on the
+			// individual Role, which would otherwise reject the lookup
+			// entirely before the assignment is ever attempted.
+
+			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());
+
+			com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+				_roleLocalService.getRole(
+					contextCompany.getCompanyId(),
+					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+			// The read below goes through the local service, not
+			// _roleService, for the same reason the role lookup above does:
+			// this caller may hold ASSIGN_MEMBERS without Role-scoped VIEW
+			// on Asset Library Member, and the permissioned read would
+			// filter the assignment just made down to nothing. The else
+			// branch below keeps _roleService, since every role reaching it
+			// was already resolved through _getRoleIds, which itself
+			// requires Role-scoped VIEW.
+
+			_userGroupRoleLocalService.addUserGroupRoles(
+				user.getUserId(), group.getGroupId(),
+				new long[] {assetLibraryMemberRole.getRoleId()});
+
+			updatedRoles = _roleLocalService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
+		}
+		else {
+			_userGroupRoleService.deleteUserGroupRoles(
+				user.getUserId(), group.getGroupId(),
+				ListUtil.toLongArray(
+					currentRoles,
+					com.liferay.portal.kernel.model.Role.ROLE_ID_ACCESSOR));
+
+			_userGroupRoleService.addUserGroupRoles(
+				user.getUserId(), group.getGroupId(), _getRoleIds(roles));
+
+			updatedRoles = _roleService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
+		}
+
+		return Page.of(transform(updatedRoles, this::_toRole));
 	}
 
 	@Override
@@ -214,6 +274,42 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		}
 	}
 
+	private void _checkAssetLibraryAdminOrAssignMembers(long groupId)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker.isGroupAdmin(groupId) ||
+			GroupPermissionUtil.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_MEMBERS) ||
+			GroupPermissionUtil.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_USER_ROLES)) {
+
+			return;
+		}
+
+		throw new PrincipalException.MustHavePermission(
+			contextUser.getUserId(), ActionKeys.ASSIGN_MEMBERS);
+	}
+
+	private List<com.liferay.portal.kernel.model.Role> _getAssetLibraryRoles(
+		long groupId) {
+
+		List<com.liferay.portal.kernel.model.Role> roles =
+			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-58677")) {
+
+			roles = DepotRoleUtil.filter(groupId, roles);
+		}
+
+		return roles;
+	}
+
 	private Group _getGroup(String externalReferenceCode) throws Exception {
 		Group group = _groupService.fetchGroupByExternalReferenceCode(
 			externalReferenceCode, contextCompany.getCompanyId());
@@ -237,6 +333,17 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 				return serviceBuilderRole.getRoleId();
 			});
+	}
+
+	private boolean _isDefaultAssetLibraryMemberRoleAssignment(
+		List<com.liferay.portal.kernel.model.Role> currentRoles, Role[] roles) {
+
+		if (!currentRoles.isEmpty() || (roles.length != 1)) {
+			return false;
+		}
+
+		return Objects.equals(
+			roles[0].getName(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 	}
 
 	private Role _toRole(com.liferay.portal.kernel.model.Role role)
@@ -271,6 +378,9 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 	@Reference
 	private UserGroupLocalService _userGroupLocalService;
+
+	@Reference
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Reference
 	private UserGroupRoleService _userGroupRoleService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -10,7 +10,6 @@ import com.liferay.headless.asset.library.resource.v1_0.UserAccountResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
-import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserTable;
@@ -26,7 +25,6 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
@@ -37,11 +35,8 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -66,7 +61,11 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		User user = _userService.getUserByExternalReferenceCode(
 			userAccountExternalReferenceCode, contextCompany.getCompanyId());
 
-		_updateUser(group.getGroupId(), user.getUserId(), false);
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			User.class.getName(), contextHttpServletRequest);
+
+		_userService.unsetGroupUsers(
+			group.getGroupId(), new long[] {user.getUserId()}, serviceContext);
 	}
 
 	@Override
@@ -111,9 +110,14 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		User user = _userService.getUserByExternalReferenceCode(
 			userAccountExternalReferenceCode, contextCompany.getCompanyId());
 
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			User.class.getName(), contextHttpServletRequest);
+
+		_userService.addGroupUsers(
+			group.getGroupId(), new long[] {user.getUserId()}, serviceContext);
+
 		return _toUserAccount(
-			group.getGroupId(),
-			_updateUser(group.getGroupId(), user.getUserId(), true));
+			group.getGroupId(), _userService.getUserById(user.getUserId()));
 	}
 
 	private void _checkAssetLibraryAdminOrAssetLibraryMember(long groupId)
@@ -189,25 +193,6 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 				keywords));
 	}
 
-	private long[] _getUserGroupIds(
-		User user, long assetLibraryId, boolean add) {
-
-		Set<Long> groupIds = new HashSet<>();
-
-		for (long groupId : user.getGroupIds()) {
-			groupIds.add(groupId);
-		}
-
-		if (add) {
-			groupIds.add(assetLibraryId);
-		}
-		else {
-			groupIds.remove(assetLibraryId);
-		}
-
-		return ArrayUtil.toLongArray(groupIds);
-	}
-
 	private OrderByComparator<User> _toOrderByComparator(Sort[] sorts) {
 		if (ArrayUtil.isEmpty(sorts)) {
 			return null;
@@ -265,37 +250,6 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			"assetLibraryId", assetLibraryId);
 
 		return _userAccountDTOConverter.toDTO(defaultDTOConverterContext);
-	}
-
-	private User _updateUser(
-			Long assetLibraryId, Long userAccountId, boolean add)
-		throws Exception {
-
-		User user = _userService.getUserById(userAccountId);
-
-		Contact contact = user.getContact();
-
-		Calendar calendar = CalendarFactoryUtil.getCalendar();
-
-		calendar.setTime(user.getBirthday());
-
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			User.class.getName(), contextHttpServletRequest);
-
-		return _userService.updateUser(
-			user.getUserId(), user.getPassword(), null, null,
-			user.isPasswordReset(), null, null, user.getScreenName(),
-			user.getEmailAddress(), user.getLanguageId(), user.getTimeZoneId(),
-			user.getGreeting(), user.getComments(), user.getFirstName(),
-			user.getMiddleName(), user.getLastName(),
-			contact.getPrefixListTypeId(), contact.getSuffixListTypeId(),
-			user.isMale(), calendar.get(Calendar.MONTH),
-			calendar.get(Calendar.DATE), calendar.get(Calendar.YEAR),
-			contact.getSmsSn(), contact.getFacebookSn(), contact.getJabberSn(),
-			contact.getSkypeSn(), contact.getTwitterSn(), user.getJobTitle(),
-			_getUserGroupIds(user, assetLibraryId, add),
-			user.getOrganizationIds(), null, null, user.getUserGroupIds(),
-			serviceContext);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -16,13 +16,17 @@ import com.liferay.headless.asset.library.client.pagination.Pagination;
 import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.headless.asset.library.client.resource.v1_0.RoleResource;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
@@ -106,6 +110,224 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			roles -> roleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(), roles));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		// A fresh member (no current roles) can be granted exactly the
+		// default Asset Library Member role by a caller holding only
+		// ASSIGN_MEMBERS, mirroring the CMS "Manage Members" UI's
+		// add-member-then-assign-default-role flow.
+
+		Page<Role> page =
+			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryMemberRole.getRoleId();
+							name = assetLibraryMemberRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		// Reassigning that same, now-existing member to a different role
+		// still requires ASSIGN_USER_ROLES; ASSIGN_MEMBERS alone is not
+		// enough once the member already holds a role.
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				}));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+
+		// Even for a fresh member, only the exact default role (Member)
+		// is covered by the ASSIGN_MEMBERS-only bypass - any other role,
+		// including Administrator, still requires ASSIGN_USER_ROLES.
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryAdministratorRole.getRoleId();
+							name = assetLibraryAdministratorRole.getName();
+						}
+					}
+				}));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		// Reassigning an existing member (who already holds the default
+		// Member role) to a different role is allowed for a caller holding
+		// ASSIGN_USER_ROLES, even without ASSIGN_MEMBERS - but the caller
+		// must also hold Role-scoped VIEW on that specific role; resolving
+		// the role by name still goes through the permissioned service.
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
+
+		Page<Role> page =
+			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		// ASSIGN_USER_ROLES alone, without Role-scoped VIEW on the target
+		// role, is not enough - resolving the role by name goes through the
+		// permissioned service.
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource();
+
+		_assertForbidden(
+			() ->
+				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+					testDepotEntryGroup.getExternalReferenceCode(),
+					user.getExternalReferenceCode(),
+					new Role[] {
+						new Role() {
+							{
+								id =
+									assetLibraryContentReviewerRole.getRoleId();
+								name =
+									assetLibraryContentReviewerRole.getName();
+							}
+						}
+					}));
 	}
 
 	@Override
@@ -222,6 +444,21 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		return _userGroup.getExternalReferenceCode();
 	}
 
+	private void _assertForbidden(UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
 	private void _assertRolesPage(
 			Role[] expectedRoles,
 			UnsafeSupplier<Page<Role>, Exception> unsafeSupplier)
@@ -237,6 +474,98 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		for (Role role : expectedRoles) {
 			Assert.assertTrue(items.contains(role));
 		}
+	}
+
+	private RoleResource _getAssignMembersRoleResource() throws Exception {
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_MEMBERS);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		return RoleResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private RoleResource _getAssignUserRolesRoleResource(
+			com.liferay.portal.kernel.model.Role... viewableRoles)
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_USER_ROLES);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		for (com.liferay.portal.kernel.model.Role viewableRole :
+				viewableRoles) {
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				viewableRole.getCompanyId(),
+				com.liferay.portal.kernel.model.Role.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(viewableRole.getRoleId()), role.getRoleId(),
+				new String[] {ActionKeys.VIEW});
+		}
+
+		return RoleResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private RoleResource _getRoleResource(String roleName) throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -16,9 +16,12 @@ import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.headless.asset.library.client.resource.v1_0.UserAccountResource;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -87,6 +90,24 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testBatchEngineDeleteImportTask() {
 	}
 
+	@Test
+	public void testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		userAccountResource.putAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+
+		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+	}
+
 	@Override
 	@Test
 	public void testGetAssetLibraryUserAccount() throws Exception {
@@ -128,6 +149,41 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_spaceDepotEntry.getGroup(), cmsAdministratorUserAccountResource);
 
 		_testGetAssetLibraryUserAccountsPageWithSortId();
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
+			_getWithoutAssignMembersPermissionUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		_assertFailure(
+			"Forbidden",
+			() ->
+				withoutAssignMembersPermissionUserAccountResource.
+					putAssetLibraryUserAccount(
+						testDepotEntryGroup.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode()));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		UserAccount putUserAccount =
+			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				userAccount.getExternalReferenceCode());
+
+		assertValid(putUserAccount);
 	}
 
 	@Override
@@ -210,9 +266,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_testUser.getExternalReferenceCode());
 	}
 
-	private void _assertFailure(UnsafeRunnable<Exception> unsafeRunnable) {
+	private void _assertFailure(
+		String message, UnsafeRunnable<Exception> unsafeRunnable) {
+
 		AssertUtils.assertFailure(
-			Problem.ProblemException.class, null, unsafeRunnable);
+			Problem.ProblemException.class, message, unsafeRunnable);
+	}
+
+	private void _assertFailure(UnsafeRunnable<Exception> unsafeRunnable) {
+		_assertFailure(null, unsafeRunnable);
 	}
 
 	private UserAccountResource _getAssetLibraryMemberUserAccountResource(
@@ -274,6 +336,87 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		Group group = testDepotEntry.getGroup();
 
 		return group.getExternalReferenceCode();
+	}
+
+	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_MEMBERS);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		return UserAccountResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private UserAccountResource
+			_getWithoutAssignMembersPermissionUserAccountResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		List<String> actionIds = ResourceActionsUtil.getModelResourceActions(
+			DepotEntry.class.getName());
+
+		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
+
+		for (String actionId : actionIds) {
+			RoleTestUtil.addResourcePermission(
+				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+				String.valueOf(testDepotEntry.getGroupId()), actionId);
+		}
+
+		return UserAccountResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetAssetLibraryUserAccount(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98407

## What Is Being Fixed

Adding or removing a member from a CMS Space (asset library group) routed through a private helper that performed a full `UserService.updateUser(...)` re-save of the entire user profile just to change one group ID. `UserService.updateUser` unconditionally requires `UPDATE` permission on the target `User` before it even inspects the group list, an extra, undocumented requirement beyond the `ASSIGN_MEMBERS` permission on `Group` that the resource's own action flags advertise. Only depot Group admins bypassed this, forcing every other admin to be granted `UPDATE` on `User`, a much broader privilege, just to manage Space membership.

Separately, adding a member to a Space is immediately followed by assigning that member's default role (space-member, space-administrator, or space-content-reviewer) through `putAssetLibraryUserAccountRolesPage`. That call went straight to the permissioned `UserGroupRoleService`, which requires `ASSIGN_USER_ROLES` on the group before it touches anything, so a Space Administrator holding only `ASSIGN_MEMBERS` could add a member but then fail with a 403 trying to set their role.

## How It Is Being Fixed

The full-profile update is replaced with `UserService.addGroupUsers` and `UserService.unsetGroupUsers`, which gate on `ASSIGN_MEMBERS` on `Group`, matching what classic Site Membership management already does for the same operation. `VIEW` on the `Group` and on the target `User` are still required, since both are looked up through permissioned service calls before the membership change is attempted.

For role assignment, `RoleResourceImpl` no longer uses a hardcoded safelist of built-in role names. Only one case bypasses the standard permission checks: the CMS "Manage Members" UI's own flow of adding a brand new member and then, in a separate follow-up call, assigning them the space's fixed default role (`Asset Library Member`). Without a bypass there, a caller holding only `ASSIGN_MEMBERS` ends up with a half-succeeded add - member added, role assignment rejected - with no way to recover from the UI. That case is now handled narrowly: only for a user who currently holds no roles yet, and only for that exact default role, resolved through the unpermissioned local service so it cannot be blocked by a missing Role-scoped `VIEW` grant nobody would think to make.

Every other assignment - reassigning an existing member, removing a role, or assigning any role other than the default (including Administrator or Content Reviewer) - goes through the original permissioned `UserGroupRoleService` path unchanged, requiring `ASSIGN_USER_ROLES` or Role-scoped `ASSIGN_MEMBERS` on the group, plus Role-scoped `VIEW` on the specific role being assigned.
