### PR TITLE
LPD-99349 Fix AM editor config contributor varargs Mockito stub

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-editor-configuration/src/test/java/com/liferay/adaptive/media/editor/configuration/internal/BaseAMEditorConfigContributorTestCase.java
+++ b/modules/apps/adaptive-media/adaptive-media-editor-configuration/src/test/java/com/liferay/adaptive/media/editor/configuration/internal/BaseAMEditorConfigContributorTestCase.java
@@ -275,7 +275,7 @@ public abstract class BaseAMEditorConfigContributorTestCase {
 		Mockito.when(
 			_itemSelector.getItemSelectorURL(
 				Mockito.any(RequestBackedPortletURLFactory.class),
-				Mockito.anyString(), Mockito.<ItemSelectorCriterion>any())
+				Mockito.anyString(), Mockito.any(ItemSelectorCriterion[].class))
 		).thenReturn(
 			_portletURL
 		);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99349

## What Is Being Fixed

BlogsAMEditorConfigContributorTest and JournalAMEditorConfigContributorTest started failing on testAMReturnTypeIsAddedToAllItemSelectorCriteria with a NullPointerException at BaseAMEditorConfigContributor.java:98. The tests passed on the 16/07 CI run and failed on the 23/07 run even though neither the test nor the production code changed.

## How It Is Being Fixed

The regression was triggered by LPD-98410, which attached Mockito's inline mock-maker agent globally. Under the inline mock-maker a single Mockito.<ItemSelectorCriterion>any() matcher matches only one vararg element, so the production call that passes four criteria to ItemSelector.getItemSelectorURL no longer matched the stub and returned null, causing the NPE. The shared test in BaseAMEditorConfigContributorTestCase now matches the whole varargs array with Mockito.any(ItemSelectorCriterion[].class), which is independent of the number of criteria. Production code is unchanged because it was never at fault.

## Why Are There No Tests?

This change fixes the existing unit tests themselves; there is no production behavior change to cover with a new test.

## PR Check

**pr-check: PASS** — tested on `6e7815d8bc6967582c18b18f0a926e518906d6cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6e7815d8bc6967582c18b18f0a926e518906d6cf"} -->
