### PR TITLE
LPD-99356 Fix AM image export import test after fetchFileEntry switch

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/test/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/test/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessorTest.java
@@ -12,7 +12,6 @@ import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -293,11 +292,11 @@ public class AMImageHTMLExportImportContentProcessorTest {
 
 	@Test
 	public void testImportContentIgnoresInvalidReferences() throws Exception {
-		Mockito.doThrow(
-			PortalException.class
+		Mockito.doReturn(
+			null
 		).when(
 			_dlAppLocalService
-		).getFileEntry(
+		).fetchFileEntry(
 			_FILE_ENTRY_ID_1
 		);
 
@@ -443,7 +442,7 @@ public class AMImageHTMLExportImportContentProcessorTest {
 			fileEntry
 		).when(
 			_dlAppLocalService
-		).getFileEntry(
+		).fetchFileEntry(
 			fileEntryId
 		);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99356

## What Is Being Fixed

AMImageHTMLExportImportContentProcessorTest failed with six ComparisonFailures on its export/import round-trip tests. The imported output kept export-import-path="PATH_..." instead of being converted back to data-fileentryid="..." and dropped the <source /> element, so the round-trip did not return the original content. The tests passed on the 16/07 CI run and failed on the 23/07 run even though the test itself did not change.

## How It Is Being Fixed

LPD-98534 refactored the import path of AMImageHTMLExportImportContentProcessor from the private _getFileEntry helper (which called DLAppLocalService.getFileEntry and caught PortalException) to a direct DLAppLocalService.fetchFileEntry call, while the export path still uses getFileEntry. The test only stubbed getFileEntry, so after the refactor fetchFileEntry returned the mock default null, the import hit the null guard and skipped the reference conversion, and the tag factory that adds <source /> was never invoked. The test now stubs fetchFileEntry in the import setup to match the import path, and testImportContentIgnoresInvalidReferences simulates the missing entry by returning null from fetchFileEntry rather than throwing from getFileEntry. Production code is unchanged because it was never at fault.

## Why Are There No Tests?

This change fixes the existing unit tests themselves; there is no production behavior change to cover with a new test.

## PR Check

**pr-check: PASS** — tested on `e57b370ea355bd931bef89209a003a1b6f5fd9c0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e57b370ea355bd931bef89209a003a1b6f5fd9c0"} -->
