### PR TITLE
LPD-99367 Fix Asset Publisher metadata move box test in French

### DIFF
--- a/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherConfiguration.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherConfiguration.spec.ts
@@ -283,6 +283,12 @@ test(
 			.getByRole('tab', {name: "Paramètres d'affichage"})
 			.click();
 
+		// Expand the metadata section, which is collapsed by default
+
+		await assetPublisherPage.configurationIframe
+			.locator('[aria-controls="metadataContent"]')
+			.click();
+
 		// Assert a move button rendered in the metadata section
 
 		await expect(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99367

## What Is Being Fixed

The Playwright test "Metadata move boxes render when configuring an Asset Publisher on a widget page in French" (LPD-97436) fails in the daily. In the Asset Publisher configuration's Display Settings, the metadata dual-list-box move button lives inside the "Métadonnées" section, which is a collapsed accordion panel (#metadataContent) by default. The test asserts the move button is visible without first expanding that panel, so the button is present but hidden and the assertion times out.

## How It Is Being Fixed

Before asserting the move button, the test now expands the metadata section by clicking its toggle, located by the locale-independent selector [aria-controls="metadataContent"] rather than the French label. This is a test-only change; the Asset Publisher configuration itself renders correctly.

## How to Run the Test

cd modules/test/playwright && PORTAL_URL=<portal-url> yarn test tests/asset-publisher-web/main/assetPublisherConfiguration.spec.ts -g "Metadata move boxes render when configuring an Asset Publisher on a widget page in French"

Verified locally with 4 consecutive passing runs.

## Why Are There No Tests?

This PR only fixes an existing Playwright test assertion and introduces no product code, so no new test coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `b7b7f6a3ab59c9ad4bf13328b62173f224304cde`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "b7b7f6a3ab59c9ad4bf13328b62173f224304cde"} -->
