### PR TITLE
LPD-99381 Fix Spanish-only space test to use Liferay language IDs

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -189,8 +189,8 @@ test(
 		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
 			name: spaceName,
 			settings: {
-				availableLanguageIds: ['es-ES'],
-				defaultLanguageId: 'es-ES',
+				availableLanguageIds: ['es_ES'],
+				defaultLanguageId: 'es_ES',
 				useCustomLanguages: true,
 			},
 			type: 'Space',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99381

## What Is Being Fixed

The Playwright test "Can set Spanish as the only language and default language of a space" (LPD-84148) fails in the daily. It creates the space through the headless asset library API with the language settings in W3C form ("es-ES"). The availableLanguageIds and defaultLanguageId fields expect Liferay language IDs (underscore form, "es_ES"), so the mismatch makes GroupLocalServiceImpl.validateLanguageIds reject the locale, which surfaces as a 500 and fails the test.

## How It Is Being Fixed

The test now passes the space's language settings as Liferay language IDs ("es_ES"), matching the format the headless asset library API expects and that the API's own integration tests use. No product change is needed; creating a Spanish-only space already works with this format.

## How to Run the Test

cd modules/test/playwright && PORTAL_URL=<portal-url> yarn test tests/site-cms-site-initializer/main/contentEditor.spec.ts -g "Can set Spanish as the only language and default language of a space"

Verified locally with 3 consecutive passing runs.

## Why Are There No Tests?

This PR only fixes an existing Playwright test's input format and introduces no product code, so no new test coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `901b2eb192cdb1781f28849f4a4be86b31641f50`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "901b2eb192cdb1781f28849f4a4be86b31641f50"} -->
