### PR TITLE
LPD-97867 Add text similarity detection for CMS content

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityCluster.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityCluster.java
@@ -1,0 +1,304 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A group of CMS content assets detected as near-duplicates of one another for a given similarity dimension.",
+	value = "SimilarityCluster"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A group of CMS content assets detected as near-duplicates of one another for a given similarity dimension."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarityCluster")
+public class SimilarityCluster implements Serializable {
+
+	public static SimilarityCluster toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarityCluster.class, json);
+	}
+
+	public static SimilarityCluster unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(SimilarityCluster.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public SimilarityClusterAsset[] getSimilarityClusterAssets() {
+		if (_similarityClusterAssetsSupplier != null) {
+			similarityClusterAssets = _similarityClusterAssetsSupplier.get();
+
+			_similarityClusterAssetsSupplier = null;
+		}
+
+		return similarityClusterAssets;
+	}
+
+	public void setSimilarityClusterAssets(
+		SimilarityClusterAsset[] similarityClusterAssets) {
+
+		this.similarityClusterAssets = similarityClusterAssets;
+
+		_similarityClusterAssetsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSimilarityClusterAssets(
+		UnsafeSupplier<SimilarityClusterAsset[], Exception>
+			similarityClusterAssetsUnsafeSupplier) {
+
+		_similarityClusterAssetsSupplier = () -> {
+			try {
+				return similarityClusterAssetsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected SimilarityClusterAsset[] similarityClusterAssets;
+
+	@JsonIgnore
+	private Supplier<SimilarityClusterAsset[]> _similarityClusterAssetsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Integer getSize() {
+		if (_sizeSupplier != null) {
+			size = _sizeSupplier.get();
+
+			_sizeSupplier = null;
+		}
+
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+
+		_sizeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		_sizeSupplier = () -> {
+			try {
+				return sizeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Integer size;
+
+	@JsonIgnore
+	private Supplier<Integer> _sizeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityCluster)) {
+			return false;
+		}
+
+		SimilarityCluster similarityCluster = (SimilarityCluster)object;
+
+		return Objects.equals(toString(), similarityCluster.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		SimilarityClusterAsset[] similarityClusterAssets =
+			getSimilarityClusterAssets();
+
+		if (similarityClusterAssets != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusterAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarityClusterAssets.length; i++) {
+				sb.append(String.valueOf(similarityClusterAssets[i]));
+
+				if ((i + 1) < similarityClusterAssets.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Integer size = getSize();
+
+		if (size != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(size);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarityCluster",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-2017814595

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterAsset.java
@@ -1,0 +1,589 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A CMS content asset that belongs to a similarity cluster.",
+	value = "SimilarityClusterAsset"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A CMS content asset that belongs to a similarity cluster."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarityClusterAsset")
+public class SimilarityClusterAsset implements Serializable {
+
+	public static SimilarityClusterAsset toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarityClusterAsset.class, json);
+	}
+
+	public static SimilarityClusterAsset unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			SimilarityClusterAsset.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The localized label of the asset's content type (object definition), for display and iconography."
+	)
+	public String getContentType() {
+		if (_contentTypeSupplier != null) {
+			contentType = _contentTypeSupplier.get();
+
+			_contentTypeSupplier = null;
+		}
+
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+
+		_contentTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		_contentTypeSupplier = () -> {
+			try {
+				return contentTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The localized label of the asset's content type (object definition), for display and iconography."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String contentType;
+
+	@JsonIgnore
+	private Supplier<String> _contentTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getItemURL() {
+		if (_itemURLSupplier != null) {
+			itemURL = _itemURLSupplier.get();
+
+			_itemURLSupplier = null;
+		}
+
+		return itemURL;
+	}
+
+	public void setItemURL(String itemURL) {
+		this.itemURL = itemURL;
+
+		_itemURLSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setItemURL(
+		UnsafeSupplier<String, Exception> itemURLUnsafeSupplier) {
+
+		_itemURLSupplier = () -> {
+			try {
+				return itemURLUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String itemURL;
+
+	@JsonIgnore
+	private Supplier<String> _itemURLSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Estimated text similarity of this asset to the cluster's top asset, as a percentage from 0 to 100. Null when the asset is the top asset or has no indexed signature yet."
+	)
+	public Double getSimilarityPercent() {
+		if (_similarityPercentSupplier != null) {
+			similarityPercent = _similarityPercentSupplier.get();
+
+			_similarityPercentSupplier = null;
+		}
+
+		return similarityPercent;
+	}
+
+	public void setSimilarityPercent(Double similarityPercent) {
+		this.similarityPercent = similarityPercent;
+
+		_similarityPercentSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSimilarityPercent(
+		UnsafeSupplier<Double, Exception> similarityPercentUnsafeSupplier) {
+
+		_similarityPercentSupplier = () -> {
+			try {
+				return similarityPercentUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Estimated text similarity of this asset to the cluster's top asset, as a percentage from 0 to 100. Null when the asset is the top asset or has no indexed signature yet."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Double similarityPercent;
+
+	@JsonIgnore
+	private Supplier<Double> _similarityPercentSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Whether this asset is the cluster's representative (top) asset that the others are compared against."
+	)
+	public Boolean getTopAsset() {
+		if (_topAssetSupplier != null) {
+			topAsset = _topAssetSupplier.get();
+
+			_topAssetSupplier = null;
+		}
+
+		return topAsset;
+	}
+
+	public void setTopAsset(Boolean topAsset) {
+		this.topAsset = topAsset;
+
+		_topAssetSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTopAsset(
+		UnsafeSupplier<Boolean, Exception> topAssetUnsafeSupplier) {
+
+		_topAssetSupplier = () -> {
+			try {
+				return topAssetUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Whether this asset is the cluster's representative (top) asset that the others are compared against."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Boolean topAsset;
+
+	@JsonIgnore
+	private Supplier<Boolean> _topAssetSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterAsset)) {
+			return false;
+		}
+
+		SimilarityClusterAsset similarityClusterAsset =
+			(SimilarityClusterAsset)object;
+
+		return Objects.equals(toString(), similarityClusterAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		String contentType = getContentType();
+
+		if (contentType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentType));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String itemURL = getItemURL();
+
+		if (itemURL != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"itemURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(itemURL));
+
+			sb.append("\"");
+		}
+
+		Double similarityPercent = getSimilarityPercent();
+
+		if (similarityPercent != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityPercent\": ");
+
+			sb.append(similarityPercent);
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		Boolean topAsset = getTopAsset();
+
+		if (topAsset != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"topAsset\": ");
+
+			sb.append(topAsset);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarityClusterAsset",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:265489035

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterResult.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterResult.java
@@ -1,0 +1,305 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Near-duplicate clusters for the selected space and similarity dimension. Feeds the Content Governance Dashboard's Duplication and Similarity widgets - totalCount backs the card, items back the modal.",
+	value = "SimilarityClusterResult"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "Near-duplicate clusters for the selected space and similarity dimension. Feeds the Content Governance Dashboard's Duplication and Similarity widgets - totalCount backs the card, items back the modal."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarityClusterResult")
+public class SimilarityClusterResult implements Serializable {
+
+	public static SimilarityClusterResult toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarityClusterResult.class, json);
+	}
+
+	public static SimilarityClusterResult unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			SimilarityClusterResult.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public SimilarityCluster[] getSimilarityClusters() {
+		if (_similarityClustersSupplier != null) {
+			similarityClusters = _similarityClustersSupplier.get();
+
+			_similarityClustersSupplier = null;
+		}
+
+		return similarityClusters;
+	}
+
+	public void setSimilarityClusters(SimilarityCluster[] similarityClusters) {
+		this.similarityClusters = similarityClusters;
+
+		_similarityClustersSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSimilarityClusters(
+		UnsafeSupplier<SimilarityCluster[], Exception>
+			similarityClustersUnsafeSupplier) {
+
+		_similarityClustersSupplier = () -> {
+			try {
+				return similarityClustersUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected SimilarityCluster[] similarityClusters;
+
+	@JsonIgnore
+	private Supplier<SimilarityCluster[]> _similarityClustersSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getTotalCount() {
+		if (_totalCountSupplier != null) {
+			totalCount = _totalCountSupplier.get();
+
+			_totalCountSupplier = null;
+		}
+
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+
+		_totalCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		_totalCountSupplier = () -> {
+			try {
+				return totalCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long totalCount;
+
+	@JsonIgnore
+	private Supplier<Long> _totalCountSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterResult)) {
+			return false;
+		}
+
+		SimilarityClusterResult similarityClusterResult =
+			(SimilarityClusterResult)object;
+
+		return Objects.equals(toString(), similarityClusterResult.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		SimilarityCluster[] similarityClusters = getSimilarityClusters();
+
+		if (similarityClusters != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusters\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarityClusters.length; i++) {
+				sb.append(String.valueOf(similarityClusters[i]));
+
+				if ((i + 1) < similarityClusters.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Long totalCount = getTotalCount();
+
+		if (totalCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(totalCount);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1219068382

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarityClusterResultResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarityClusterResultResource.java
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-cms/v1.0
+ *
+ * @author Crescenzo Rega
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface SimilarityClusterResultResource {
+
+	public SimilarityClusterResult getSimilarityCluster(
+			Long assetLibraryId, String dimension)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public SimilarityClusterResultResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-934385707

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityCluster.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityCluster.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityCluster implements Cloneable, Serializable {
+
+	public static SimilarityCluster toDTO(String json) {
+		return SimilarityClusterSerDes.toDTO(json);
+	}
+
+	public SimilarityClusterAsset[] getSimilarityClusterAssets() {
+		return similarityClusterAssets;
+	}
+
+	public void setSimilarityClusterAssets(
+		SimilarityClusterAsset[] similarityClusterAssets) {
+
+		this.similarityClusterAssets = similarityClusterAssets;
+	}
+
+	public void setSimilarityClusterAssets(
+		UnsafeSupplier<SimilarityClusterAsset[], Exception>
+			similarityClusterAssetsUnsafeSupplier) {
+
+		try {
+			similarityClusterAssets =
+				similarityClusterAssetsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected SimilarityClusterAsset[] similarityClusterAssets;
+
+	public Integer getSize() {
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+	}
+
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		try {
+			size = sizeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer size;
+
+	@Override
+	public SimilarityCluster clone() throws CloneNotSupportedException {
+		return (SimilarityCluster)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityCluster)) {
+			return false;
+		}
+
+		SimilarityCluster similarityCluster = (SimilarityCluster)object;
+
+		return Objects.equals(toString(), similarityCluster.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarityClusterSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1638321847

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterAsset.java
@@ -1,0 +1,207 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterAsset implements Cloneable, Serializable {
+
+	public static SimilarityClusterAsset toDTO(String json) {
+		return SimilarityClusterAssetSerDes.toDTO(json);
+	}
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		try {
+			contentType = contentTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String contentType;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getItemURL() {
+		return itemURL;
+	}
+
+	public void setItemURL(String itemURL) {
+		this.itemURL = itemURL;
+	}
+
+	public void setItemURL(
+		UnsafeSupplier<String, Exception> itemURLUnsafeSupplier) {
+
+		try {
+			itemURL = itemURLUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String itemURL;
+
+	public Double getSimilarityPercent() {
+		return similarityPercent;
+	}
+
+	public void setSimilarityPercent(Double similarityPercent) {
+		this.similarityPercent = similarityPercent;
+	}
+
+	public void setSimilarityPercent(
+		UnsafeSupplier<Double, Exception> similarityPercentUnsafeSupplier) {
+
+		try {
+			similarityPercent = similarityPercentUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Double similarityPercent;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	public Boolean getTopAsset() {
+		return topAsset;
+	}
+
+	public void setTopAsset(Boolean topAsset) {
+		this.topAsset = topAsset;
+	}
+
+	public void setTopAsset(
+		UnsafeSupplier<Boolean, Exception> topAssetUnsafeSupplier) {
+
+		try {
+			topAsset = topAssetUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean topAsset;
+
+	@Override
+	public SimilarityClusterAsset clone() throws CloneNotSupportedException {
+		return (SimilarityClusterAsset)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterAsset)) {
+			return false;
+		}
+
+		SimilarityClusterAsset similarityClusterAsset =
+			(SimilarityClusterAsset)object;
+
+		return Objects.equals(toString(), similarityClusterAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarityClusterAssetSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1896341102

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterResult.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterResult.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterResultSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterResult implements Cloneable, Serializable {
+
+	public static SimilarityClusterResult toDTO(String json) {
+		return SimilarityClusterResultSerDes.toDTO(json);
+	}
+
+	public SimilarityCluster[] getSimilarityClusters() {
+		return similarityClusters;
+	}
+
+	public void setSimilarityClusters(SimilarityCluster[] similarityClusters) {
+		this.similarityClusters = similarityClusters;
+	}
+
+	public void setSimilarityClusters(
+		UnsafeSupplier<SimilarityCluster[], Exception>
+			similarityClustersUnsafeSupplier) {
+
+		try {
+			similarityClusters = similarityClustersUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected SimilarityCluster[] similarityClusters;
+
+	public Long getTotalCount() {
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+	}
+
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		try {
+			totalCount = totalCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long totalCount;
+
+	@Override
+	public SimilarityClusterResult clone() throws CloneNotSupportedException {
+		return (SimilarityClusterResult)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterResult)) {
+			return false;
+		}
+
+		SimilarityClusterResult similarityClusterResult =
+			(SimilarityClusterResult)object;
+
+		return Objects.equals(toString(), similarityClusterResult.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarityClusterResultSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1869469088

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarityClusterResultResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarityClusterResultResource.java
@@ -1,0 +1,277 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.resource.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterResultSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public interface SimilarityClusterResultResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public SimilarityClusterResult getSimilarityCluster(
+			Long assetLibraryId, String dimension)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSimilarityClusterHttpResponse(
+			Long assetLibraryId, String dimension)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public SimilarityClusterResultResource build() {
+			return new SimilarityClusterResultResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class SimilarityClusterResultResourceImpl
+		implements SimilarityClusterResultResource {
+
+		public SimilarityClusterResult getSimilarityCluster(
+				Long assetLibraryId, String dimension)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSimilarityClusterHttpResponse(assetLibraryId, dimension);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return SimilarityClusterResultSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSimilarityClusterHttpResponse(
+				Long assetLibraryId, String dimension)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetLibraryId != null) {
+				httpInvoker.parameter(
+					"assetLibraryId", String.valueOf(assetLibraryId));
+			}
+
+			if (dimension != null) {
+				httpInvoker.parameter("dimension", String.valueOf(dimension));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cms/v1.0/similarity-clusters");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private SimilarityClusterResultResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			SimilarityClusterResultResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1241507368

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterAssetSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterAssetSerDes.java
@@ -1,0 +1,397 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterAssetSerDes {
+
+	public static SimilarityClusterAsset toDTO(String json) {
+		SimilarityClusterAssetJSONParser similarityClusterAssetJSONParser =
+			new SimilarityClusterAssetJSONParser();
+
+		return similarityClusterAssetJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarityClusterAsset[] toDTOs(String json) {
+		SimilarityClusterAssetJSONParser similarityClusterAssetJSONParser =
+			new SimilarityClusterAssetJSONParser();
+
+		return similarityClusterAssetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarityClusterAsset similarityClusterAsset) {
+		if (similarityClusterAsset == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarityClusterAsset.getContentType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarityClusterAsset.getContentType()));
+
+			sb.append("\"");
+		}
+
+		if (similarityClusterAsset.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					similarityClusterAsset.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (similarityClusterAsset.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(similarityClusterAsset.getId());
+		}
+
+		if (similarityClusterAsset.getItemURL() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"itemURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarityClusterAsset.getItemURL()));
+
+			sb.append("\"");
+		}
+
+		if (similarityClusterAsset.getSimilarityPercent() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityPercent\": ");
+
+			sb.append(similarityClusterAsset.getSimilarityPercent());
+		}
+
+		if (similarityClusterAsset.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarityClusterAsset.getTitle()));
+
+			sb.append("\"");
+		}
+
+		if (similarityClusterAsset.getTopAsset() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"topAsset\": ");
+
+			sb.append(similarityClusterAsset.getTopAsset());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarityClusterAssetJSONParser similarityClusterAssetJSONParser =
+			new SimilarityClusterAssetJSONParser();
+
+		return similarityClusterAssetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		SimilarityClusterAsset similarityClusterAsset) {
+
+		if (similarityClusterAsset == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarityClusterAsset.getContentType() == null) {
+			map.put("contentType", null);
+		}
+		else {
+			map.put(
+				"contentType",
+				String.valueOf(similarityClusterAsset.getContentType()));
+		}
+
+		if (similarityClusterAsset.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(
+					similarityClusterAsset.getDateModified()));
+		}
+
+		if (similarityClusterAsset.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(similarityClusterAsset.getId()));
+		}
+
+		if (similarityClusterAsset.getItemURL() == null) {
+			map.put("itemURL", null);
+		}
+		else {
+			map.put(
+				"itemURL", String.valueOf(similarityClusterAsset.getItemURL()));
+		}
+
+		if (similarityClusterAsset.getSimilarityPercent() == null) {
+			map.put("similarityPercent", null);
+		}
+		else {
+			map.put(
+				"similarityPercent",
+				String.valueOf(similarityClusterAsset.getSimilarityPercent()));
+		}
+
+		if (similarityClusterAsset.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(similarityClusterAsset.getTitle()));
+		}
+
+		if (similarityClusterAsset.getTopAsset() == null) {
+			map.put("topAsset", null);
+		}
+		else {
+			map.put(
+				"topAsset",
+				String.valueOf(similarityClusterAsset.getTopAsset()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarityClusterAssetJSONParser
+		extends BaseJSONParser<SimilarityClusterAsset> {
+
+		@Override
+		protected SimilarityClusterAsset createDTO() {
+			return new SimilarityClusterAsset();
+		}
+
+		@Override
+		protected SimilarityClusterAsset[] createDTOArray(int size) {
+			return new SimilarityClusterAsset[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "itemURL")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "similarityPercent")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "topAsset")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarityClusterAsset similarityClusterAsset,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setContentType(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "itemURL")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setItemURL(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "similarityPercent")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setSimilarityPercent(
+						Double.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setTitle(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "topAsset")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setTopAsset(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-656064115

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterResultSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterResultSerDes.java
@@ -1,0 +1,268 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterResultSerDes {
+
+	public static SimilarityClusterResult toDTO(String json) {
+		SimilarityClusterResultJSONParser similarityClusterResultJSONParser =
+			new SimilarityClusterResultJSONParser();
+
+		return similarityClusterResultJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarityClusterResult[] toDTOs(String json) {
+		SimilarityClusterResultJSONParser similarityClusterResultJSONParser =
+			new SimilarityClusterResultJSONParser();
+
+		return similarityClusterResultJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(
+		SimilarityClusterResult similarityClusterResult) {
+
+		if (similarityClusterResult == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (similarityClusterResult.getSimilarityClusters() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusters\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < similarityClusterResult.getSimilarityClusters().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(
+						similarityClusterResult.getSimilarityClusters()[i]));
+
+				if ((i + 1) <
+						similarityClusterResult.
+							getSimilarityClusters().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (similarityClusterResult.getTotalCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(similarityClusterResult.getTotalCount());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarityClusterResultJSONParser similarityClusterResultJSONParser =
+			new SimilarityClusterResultJSONParser();
+
+		return similarityClusterResultJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		SimilarityClusterResult similarityClusterResult) {
+
+		if (similarityClusterResult == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (similarityClusterResult.getSimilarityClusters() == null) {
+			map.put("similarityClusters", null);
+		}
+		else {
+			map.put(
+				"similarityClusters",
+				String.valueOf(
+					similarityClusterResult.getSimilarityClusters()));
+		}
+
+		if (similarityClusterResult.getTotalCount() == null) {
+			map.put("totalCount", null);
+		}
+		else {
+			map.put(
+				"totalCount",
+				String.valueOf(similarityClusterResult.getTotalCount()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarityClusterResultJSONParser
+		extends BaseJSONParser<SimilarityClusterResult> {
+
+		@Override
+		protected SimilarityClusterResult createDTO() {
+			return new SimilarityClusterResult();
+		}
+
+		@Override
+		protected SimilarityClusterResult[] createDTOArray(int size) {
+			return new SimilarityClusterResult[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "similarityClusters")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarityClusterResult similarityClusterResult,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "similarityClusters")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					SimilarityCluster[] similarityClustersArray =
+						new SimilarityCluster[jsonParserFieldValues.length];
+
+					for (int i = 0; i < similarityClustersArray.length; i++) {
+						similarityClustersArray[i] =
+							SimilarityClusterSerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					similarityClusterResult.setSimilarityClusters(
+						similarityClustersArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterResult.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-266726700

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterSerDes.java
@@ -1,0 +1,269 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterSerDes {
+
+	public static SimilarityCluster toDTO(String json) {
+		SimilarityClusterJSONParser similarityClusterJSONParser =
+			new SimilarityClusterJSONParser();
+
+		return similarityClusterJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarityCluster[] toDTOs(String json) {
+		SimilarityClusterJSONParser similarityClusterJSONParser =
+			new SimilarityClusterJSONParser();
+
+		return similarityClusterJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarityCluster similarityCluster) {
+		if (similarityCluster == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (similarityCluster.getSimilarityClusterAssets() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusterAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < similarityCluster.getSimilarityClusterAssets().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(
+						similarityCluster.getSimilarityClusterAssets()[i]));
+
+				if ((i + 1) <
+						similarityCluster.getSimilarityClusterAssets().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (similarityCluster.getSize() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(similarityCluster.getSize());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarityClusterJSONParser similarityClusterJSONParser =
+			new SimilarityClusterJSONParser();
+
+		return similarityClusterJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		SimilarityCluster similarityCluster) {
+
+		if (similarityCluster == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (similarityCluster.getSimilarityClusterAssets() == null) {
+			map.put("similarityClusterAssets", null);
+		}
+		else {
+			map.put(
+				"similarityClusterAssets",
+				String.valueOf(similarityCluster.getSimilarityClusterAssets()));
+		}
+
+		if (similarityCluster.getSize() == null) {
+			map.put("size", null);
+		}
+		else {
+			map.put("size", String.valueOf(similarityCluster.getSize()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarityClusterJSONParser
+		extends BaseJSONParser<SimilarityCluster> {
+
+		@Override
+		protected SimilarityCluster createDTO() {
+			return new SimilarityCluster();
+		}
+
+		@Override
+		protected SimilarityCluster[] createDTOArray(int size) {
+			return new SimilarityCluster[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(
+					jsonParserFieldName, "similarityClusterAssets")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarityCluster similarityCluster, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(
+					jsonParserFieldName, "similarityClusterAssets")) {
+
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					SimilarityClusterAsset[] similarityClusterAssetsArray =
+						new SimilarityClusterAsset
+							[jsonParserFieldValues.length];
+
+					for (int i = 0; i < similarityClusterAssetsArray.length;
+						 i++) {
+
+						similarityClusterAssetsArray[i] =
+							SimilarityClusterAssetSerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					similarityCluster.setSimilarityClusterAssets(
+						similarityClusterAssetsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				if (jsonParserFieldValue != null) {
+					similarityCluster.setSize(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1026318494

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -64,6 +64,65 @@ components:
         ResetAssetPermissionAction:
             allOf:
                 -   $ref: "#/components/schemas/AssetPermissionAction"
+        SimilarityCluster:
+            description:
+                A group of CMS content assets detected as near-duplicates of one another for a given similarity dimension.
+            properties:
+                similarityClusterAssets:
+                    items:
+                        $ref: "#/components/schemas/SimilarityClusterAsset"
+                    readOnly: true
+                    type: array
+                size:
+                    readOnly: true
+                    type: integer
+        SimilarityClusterAsset:
+            description:
+                A CMS content asset that belongs to a similarity cluster.
+            properties:
+                contentType:
+                    description:
+                        The localized label of the asset's content type (object definition), for display and iconography.
+                    readOnly: true
+                    type: string
+                dateModified:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                itemURL:
+                    readOnly: true
+                    type: string
+                similarityPercent:
+                    description:
+                        Estimated text similarity of this asset to the cluster's top asset, as a percentage from 0 to 100. Null when the asset is the top asset or has no indexed signature yet.
+                    format: double
+                    readOnly: true
+                    type: number
+                title:
+                    readOnly: true
+                    type: string
+                topAsset:
+                    description:
+                        Whether this asset is the cluster's representative (top) asset that the others are compared against.
+                    readOnly: true
+                    type: boolean
+        SimilarityClusterResult:
+            description:
+                Near-duplicate clusters for the selected space and similarity dimension. Feeds the Content Governance Dashboard's Duplication and Similarity widgets - totalCount backs the card, items back the modal.
+            properties:
+                similarityClusters:
+                    items:
+                        $ref: "#/components/schemas/SimilarityCluster"
+                    readOnly: true
+                    type: array
+                totalCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
 info:
     license:
         name: Apache 2.0
@@ -154,3 +213,28 @@ paths:
                                     $ref: "#/components/schemas/AssetUsage"
                                 type: array
             tags: ["AssetUsage"]
+    "/similarity-clusters":
+        get:
+            description:
+                List near-duplicate clusters of CMS content in a space for a similarity dimension (currently TEXT - overlap in main text fields). Backs the Duplication and Similarity widgets. Omit assetLibraryId to span all accessible spaces.
+            operationId: getSimilarityCluster
+            parameters:
+                -   in: query
+                    name: assetLibraryId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: dimension
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/SimilarityClusterResult"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/SimilarityClusterResult"
+            tags: ["SimilarityClusterResult"]

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -7,8 +7,10 @@ package com.liferay.headless.cms.internal.graphql.query.v1_0;
 
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -58,6 +60,15 @@ public class Query {
 			assetUsageResourceComponentServiceObjects;
 	}
 
+	public static void
+		setSimilarityClusterResultResourceComponentServiceObjects(
+			ComponentServiceObjects<SimilarityClusterResultResource>
+				similarityClusterResultResourceComponentServiceObjects) {
+
+		_similarityClusterResultResourceComponentServiceObjects =
+			similarityClusterResultResourceComponentServiceObjects;
+	}
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -97,6 +108,27 @@ public class Query {
 				assetUsageResource.getAssetUsagesAssetPage(
 					assetId, search, Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(assetUsageResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {similarityCluster(assetLibraryId: ___, dimension: ___){similarityClusters, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "List near-duplicate clusters of CMS content in a space for a similarity dimension (currently TEXT - overlap in main text fields). Backs the Duplication and Similarity widgets. Omit assetLibraryId to span all accessible spaces."
+	)
+	public SimilarityClusterResult similarityCluster(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("dimension") String dimension)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_similarityClusterResultResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			similarityClusterResultResource ->
+				similarityClusterResultResource.getSimilarityCluster(
+					Long.valueOf(assetLibraryId), dimension));
 	}
 
 	@GraphQLName("AssetStatisticsPage")
@@ -150,6 +182,39 @@ public class Query {
 
 		@GraphQLField
 		protected java.util.Collection<AssetUsage> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("SimilarityClusterResultPage")
+	public class SimilarityClusterResultPage {
+
+		public SimilarityClusterResultPage(Page similarityClusterResultPage) {
+			actions = similarityClusterResultPage.getActions();
+
+			items = similarityClusterResultPage.getItems();
+			lastPage = similarityClusterResultPage.getLastPage();
+			page = similarityClusterResultPage.getPage();
+			pageSize = similarityClusterResultPage.getPageSize();
+			totalCount = similarityClusterResultPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<SimilarityClusterResult> items;
 
 		@GraphQLField
 		protected long lastPage;
@@ -221,10 +286,34 @@ public class Query {
 		assetUsageResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private void _populateResourceContext(
+			SimilarityClusterResultResource similarityClusterResultResource)
+		throws Exception {
+
+		similarityClusterResultResource.setContextAcceptLanguage(
+			_acceptLanguage);
+		similarityClusterResultResource.setContextCompany(_company);
+		similarityClusterResultResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		similarityClusterResultResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		similarityClusterResultResource.setContextUriInfo(_uriInfo);
+		similarityClusterResultResource.setContextUser(_user);
+		similarityClusterResultResource.setGroupLocalService(
+			_groupLocalService);
+		similarityClusterResultResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarityClusterResultResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarityClusterResultResource.setRoleLocalService(_roleLocalService);
+	}
+
 	private static ComponentServiceObjects<AssetStatisticsResource>
 		_assetStatisticsResourceComponentServiceObjects;
 	private static ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
+	private static ComponentServiceObjects<SimilarityClusterResultResource>
+		_similarityClusterResultResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
 	private com.liferay.portal.kernel.model.Company _company;
@@ -243,4 +332,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1260038530
+// LIFERAY-REST-BUILDER-HASH:845430397

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -10,9 +10,11 @@ import com.liferay.headless.cms.internal.graphql.query.v1_0.Query;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetPermissionActionResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetStatisticsResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetUsageResourceImpl;
+import com.liferay.headless.cms.internal.resource.v1_0.SimilarityClusterResultResourceImpl;
 import com.liferay.headless.cms.resource.v1_0.AssetPermissionActionResource;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 
@@ -45,6 +47,8 @@ public class ServletDataImpl implements ServletData {
 			_assetStatisticsResourceComponentServiceObjects);
 		Query.setAssetUsageResourceComponentServiceObjects(
 			_assetUsageResourceComponentServiceObjects);
+		Query.setSimilarityClusterResultResourceComponentServiceObjects(
+			_similarityClusterResultResourceComponentServiceObjects);
 	}
 
 	public String getApplicationName() {
@@ -97,6 +101,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							AssetUsageResourceImpl.class,
 							"getAssetUsagesAssetPage"));
+					put(
+						"query#similarityCluster",
+						new ObjectValuePair<>(
+							SimilarityClusterResultResourceImpl.class,
+							"getSimilarityCluster"));
 				}
 			};
 
@@ -112,5 +121,9 @@ public class ServletDataImpl implements ServletData {
 	private ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
 
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarityClusterResultResource>
+		_similarityClusterResultResourceComponentServiceObjects;
+
 }
-// LIFERAY-REST-BUILDER-HASH:-1043047869
+// LIFERAY-REST-BUILDER-HASH:-1811138682

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarityClusterResultResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarityClusterResultResourceImpl.java
@@ -1,0 +1,533 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseSimilarityClusterResultResourceImpl
+	implements SimilarityClusterResultResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-cms/v1.0/similarity-clusters'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "List near-duplicate clusters of CMS content in a space for a similarity dimension (currently TEXT - overlap in main text fields). Backs the Duplication and Similarity widgets. Omit assetLibraryId to span all accessible spaces."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "dimension"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "SimilarityClusterResult"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/similarity-clusters")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public SimilarityClusterResult getSimilarityCluster(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("dimension")
+			String dimension)
+		throws Exception {
+
+		return new SimilarityClusterResult();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-cms";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSimilarityClusterResultResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:792375779

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -91,9 +91,11 @@ public class OpenAPIResourceImpl {
 
 			add(AssetUsageResourceImpl.class);
 
+			add(SimilarityClusterResultResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1867425424
+// LIFERAY-REST-BUILDER-HASH:143483010

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarityClusterResultResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarityClusterResultResourceImpl.java
@@ -1,0 +1,588 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.headless.cms.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.vulcan.util.GroupUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/similarity-cluster-result.properties",
+	scope = ServiceScope.PROTOTYPE,
+	service = SimilarityClusterResultResource.class
+)
+public class SimilarityClusterResultResourceImpl
+	extends BaseSimilarityClusterResultResourceImpl {
+
+	@Override
+	public SimilarityClusterResult getSimilarityCluster(
+			Long assetLibraryId, String dimension)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		String field = _getBandField(dimension);
+
+		List<ObjectDefinition> objectDefinitions = _getCMSObjectDefinitions();
+
+		Long[] groupIds = _getGroupIds(assetLibraryId);
+
+		if ((field == null) || ArrayUtil.isEmpty(groupIds) ||
+			objectDefinitions.isEmpty()) {
+
+			return _toSimilarityClusterResult(
+				new ArrayList<>(), new HashMap<>(), new HashMap<>());
+		}
+
+		String[] entryClassNames = ArrayUtil.toStringArray(
+			ListUtil.toList(objectDefinitions, ObjectDefinition::getClassName));
+
+		List<List<Long>> clusters = _getClusters(
+			_search(field, groupIds, entryClassNames));
+
+		Map<Long, ObjectDefinition> objectDefinitionsMap = new HashMap<>();
+
+		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			objectDefinitionsMap.put(
+				objectDefinition.getObjectDefinitionId(), objectDefinition);
+		}
+
+		return _toSimilarityClusterResult(
+			clusters, objectDefinitionsMap,
+			_getSignatures(clusters, groupIds, entryClassNames));
+	}
+
+	private Long _find(Map<Long, Long> parents, Long objectEntryId) {
+		Long parent = parents.get(objectEntryId);
+
+		while (!parent.equals(objectEntryId)) {
+			objectEntryId = parent;
+
+			parent = parents.get(objectEntryId);
+		}
+
+		return objectEntryId;
+	}
+
+	private String _getBandField(String dimension) {
+		if ((dimension == null) || dimension.equals("TEXT")) {
+			return "textSimilarityBands";
+		}
+
+		// Other dimensions (TITLE, METADATA) require their own indexed
+		// signature fields, which do not exist yet.
+
+		return null;
+	}
+
+	private List<List<Long>> _getClusters(SearchResponse searchResponse) {
+		TermsAggregationResult termsAggregationResult =
+			(TermsAggregationResult)searchResponse.getAggregationResult(
+				_BANDS_AGGREGATION_NAME);
+
+		if (termsAggregationResult == null) {
+			return new ArrayList<>();
+		}
+
+		Map<Long, Long> parents = new LinkedHashMap<>();
+
+		for (Bucket bucket : termsAggregationResult.getBuckets()) {
+			TermsAggregationResult objectEntryIdsTermsAggregationResult =
+				(TermsAggregationResult)bucket.getChildAggregationResult(
+					_OBJECT_ENTRY_IDS_AGGREGATION_NAME);
+
+			if (objectEntryIdsTermsAggregationResult == null) {
+				continue;
+			}
+
+			Long representativeObjectEntryId = null;
+
+			for (Bucket objectEntryIdBucket :
+					objectEntryIdsTermsAggregationResult.getBuckets()) {
+
+				long objectEntryId = GetterUtil.getLong(
+					objectEntryIdBucket.getKey());
+
+				parents.putIfAbsent(objectEntryId, objectEntryId);
+
+				if (representativeObjectEntryId == null) {
+					representativeObjectEntryId = objectEntryId;
+				}
+				else {
+					_union(parents, representativeObjectEntryId, objectEntryId);
+				}
+			}
+		}
+
+		Map<Long, List<Long>> clusters = new LinkedHashMap<>();
+
+		for (Long objectEntryId : parents.keySet()) {
+			Long root = _find(parents, objectEntryId);
+
+			List<Long> cluster = clusters.computeIfAbsent(
+				root, key -> new ArrayList<>());
+
+			cluster.add(objectEntryId);
+		}
+
+		List<List<Long>> similarityClusters = new ArrayList<>();
+
+		for (List<Long> cluster : clusters.values()) {
+			if (cluster.size() >= 2) {
+				similarityClusters.add(cluster);
+			}
+		}
+
+		return similarityClusters;
+	}
+
+	private List<ObjectDefinition> _getCMSObjectDefinitions() throws Exception {
+		return _objectDefinitionService.getCMSObjectDefinitions(
+			contextCompany.getCompanyId(),
+			new String[] {
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+			});
+	}
+
+	private Long[] _getGroupIds(Long assetLibraryId) {
+		List<Long> depotEntryGroupIds =
+			_depotEntryService.getDepotEntryGroupIds(
+				contextCompany.getCompanyId(), contextUser.getUserId(),
+				DepotConstants.TYPE_SPACE);
+
+		if (assetLibraryId == null) {
+			return depotEntryGroupIds.toArray(new Long[0]);
+		}
+
+		Long groupId = GroupUtil.getDepotGroupId(
+			String.valueOf(assetLibraryId), contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService);
+
+		if ((groupId == null) || !depotEntryGroupIds.contains(groupId)) {
+			return new Long[0];
+		}
+
+		return new Long[] {groupId};
+	}
+
+	private Map<Long, long[]> _getSignatures(
+		List<List<Long>> clusters, Long[] groupIds, String[] entryClassNames) {
+
+		List<String> objectEntryIds = new ArrayList<>();
+
+		for (List<Long> cluster : clusters) {
+			for (Long objectEntryId : cluster) {
+				objectEntryIds.add(String.valueOf(objectEntryId));
+			}
+		}
+
+		if (objectEntryIds.isEmpty()) {
+			return new HashMap<>();
+		}
+
+		TermsQuery termsQuery = QueriesUtil.terms("objectEntryId");
+
+		termsQuery.addValues(objectEntryIds.toArray());
+
+		SearchRequestBuilder searchRequestBuilder =
+			_searchRequestBuilderFactory.builder();
+
+		long[] scopedGroupIds = _toPrimitiveArray(groupIds);
+
+		searchRequestBuilder.addComplexQueryPart(
+			_complexQueryPartBuilderFactory.builder(
+			).occur(
+				"must"
+			).query(
+				termsQuery
+			).build()
+		).companyId(
+			contextCompany.getCompanyId()
+		).emptySearchEnabled(
+			true
+		).entryClassNames(
+			entryClassNames
+		).size(
+			objectEntryIds.size()
+		).withSearchContext(
+			searchContext -> {
+				searchContext.setAttribute(
+					Field.STATUS, WorkflowConstants.STATUS_APPROVED);
+				searchContext.setGroupIds(scopedGroupIds);
+			}
+		);
+
+		SearchResponse searchResponse = _searcher.search(
+			searchRequestBuilder.build());
+
+		Map<Long, long[]> signaturesMap = new HashMap<>();
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		for (SearchHit searchHit : searchHits.getSearchHits()) {
+			Document document = searchHit.getDocument();
+
+			Long objectEntryId = document.getLong("objectEntryId");
+
+			if (objectEntryId == null) {
+				continue;
+			}
+
+			long[] signature = _parseSignature(
+				document.getStrings("textSimilaritySignature"));
+
+			if (signature != null) {
+				signaturesMap.put(objectEntryId, signature);
+			}
+		}
+
+		return signaturesMap;
+	}
+
+	private double _getSimilarity(long[] signature1, long[] signature2) {
+		int matches = 0;
+
+		for (int i = 0; i < _SIGNATURE_SIZE; i++) {
+			if (signature1[i] == signature2[i]) {
+				matches++;
+			}
+		}
+
+		return (double)matches / _SIGNATURE_SIZE;
+	}
+
+	private Long _getTopObjectEntryId(
+		List<Long> cluster, Map<Long, long[]> signaturesMap) {
+
+		Long topObjectEntryId = null;
+
+		double topMeanSimilarity = -1;
+
+		for (Long objectEntryId : cluster) {
+			long[] signature = signaturesMap.get(objectEntryId);
+
+			if (signature == null) {
+				continue;
+			}
+
+			double totalSimilarity = 0;
+			int count = 0;
+
+			for (Long otherObjectEntryId : cluster) {
+				if (otherObjectEntryId.equals(objectEntryId)) {
+					continue;
+				}
+
+				long[] otherSignature = signaturesMap.get(otherObjectEntryId);
+
+				if (otherSignature == null) {
+					continue;
+				}
+
+				totalSimilarity += _getSimilarity(signature, otherSignature);
+				count++;
+			}
+
+			double meanSimilarity = 0;
+
+			if (count > 0) {
+				meanSimilarity = totalSimilarity / count;
+			}
+
+			if (meanSimilarity > topMeanSimilarity) {
+				topMeanSimilarity = meanSimilarity;
+				topObjectEntryId = objectEntryId;
+			}
+		}
+
+		return topObjectEntryId;
+	}
+
+	private long[] _parseSignature(List<String> tokens) {
+		if ((tokens == null) || (tokens.size() != _SIGNATURE_SIZE)) {
+			return null;
+		}
+
+		long[] signature = new long[_SIGNATURE_SIZE];
+		boolean[] filled = new boolean[_SIGNATURE_SIZE];
+		int count = 0;
+
+		for (String token : tokens) {
+			int index = token.indexOf('_');
+
+			if ((index <= 1) || (token.charAt(0) != 'p')) {
+				continue;
+			}
+
+			int position = GetterUtil.getInteger(token.substring(1, index));
+
+			if ((position < 0) || (position >= _SIGNATURE_SIZE) ||
+				filled[position]) {
+
+				continue;
+			}
+
+			signature[position] = GetterUtil.getLong(
+				token.substring(index + 1));
+			filled[position] = true;
+
+			count++;
+		}
+
+		if (count != _SIGNATURE_SIZE) {
+			return null;
+		}
+
+		return signature;
+	}
+
+	private SearchResponse _search(
+		String field, Long[] groupIds, String[] entryClassNames) {
+
+		TermsAggregation termsAggregation = _aggregations.terms(
+			_BANDS_AGGREGATION_NAME, field);
+
+		termsAggregation.setMinDocCount(2);
+		termsAggregation.setSize(_MAX_BANDS);
+
+		TermsAggregation objectEntryIdsTermsAggregation = _aggregations.terms(
+			_OBJECT_ENTRY_IDS_AGGREGATION_NAME, "objectEntryId");
+
+		objectEntryIdsTermsAggregation.setSize(_MAX_CLUSTER_SIZE);
+
+		termsAggregation.addChildAggregation(objectEntryIdsTermsAggregation);
+
+		SearchRequestBuilder searchRequestBuilder =
+			_searchRequestBuilderFactory.builder();
+
+		long[] scopedGroupIds = _toPrimitiveArray(groupIds);
+
+		searchRequestBuilder.addAggregation(
+			termsAggregation
+		).companyId(
+			contextCompany.getCompanyId()
+		).emptySearchEnabled(
+			true
+		).entryClassNames(
+			entryClassNames
+		).size(
+			0
+		).withSearchContext(
+			searchContext -> {
+				searchContext.setAttribute(
+					Field.STATUS, WorkflowConstants.STATUS_APPROVED);
+				searchContext.setGroupIds(scopedGroupIds);
+			}
+		);
+
+		return _searcher.search(searchRequestBuilder.build());
+	}
+
+	private long[] _toPrimitiveArray(Long[] groupIds) {
+		long[] scopedGroupIds = new long[groupIds.length];
+
+		for (int i = 0; i < groupIds.length; i++) {
+			scopedGroupIds[i] = groupIds[i];
+		}
+
+		return scopedGroupIds;
+	}
+
+	private SimilarityClusterResult _toSimilarityClusterResult(
+			List<List<Long>> clusters,
+			Map<Long, ObjectDefinition> objectDefinitionsMap,
+			Map<Long, long[]> signaturesMap)
+		throws Exception {
+
+		List<SimilarityCluster> similarityClusters = new ArrayList<>();
+
+		long totalCount = 0;
+
+		String languageId = contextAcceptLanguage.getPreferredLanguageId();
+
+		for (List<Long> cluster : clusters) {
+			Long topObjectEntryId = _getTopObjectEntryId(
+				cluster, signaturesMap);
+
+			long[] topSignature = null;
+
+			if (topObjectEntryId != null) {
+				topSignature = signaturesMap.get(topObjectEntryId);
+			}
+
+			List<SimilarityClusterAsset> similarityClusterAssets =
+				new ArrayList<>();
+
+			for (Long objectEntryId : cluster) {
+				SimilarityClusterAsset similarityClusterAsset =
+					new SimilarityClusterAsset();
+
+				similarityClusterAsset.setId(() -> objectEntryId);
+
+				ObjectEntry objectEntry =
+					_objectEntryLocalService.fetchObjectEntry(objectEntryId);
+
+				if (objectEntry != null) {
+					similarityClusterAsset.setDateModified(
+						objectEntry::getModifiedDate);
+					similarityClusterAsset.setTitle(
+						() -> objectEntry.getTitleValue(languageId, true));
+
+					ObjectDefinition objectDefinition =
+						objectDefinitionsMap.get(
+							objectEntry.getObjectDefinitionId());
+
+					if (objectDefinition != null) {
+						similarityClusterAsset.setContentType(
+							() -> objectDefinition.getLabel(languageId, true));
+					}
+				}
+
+				boolean topAsset = objectEntryId.equals(topObjectEntryId);
+
+				similarityClusterAsset.setTopAsset(() -> topAsset);
+
+				if (!topAsset && (topSignature != null)) {
+					long[] signature = signaturesMap.get(objectEntryId);
+
+					if (signature != null) {
+						double similarityPercent = Math.round(
+							_getSimilarity(signature, topSignature) * 100.0);
+
+						similarityClusterAsset.setSimilarityPercent(
+							() -> similarityPercent);
+					}
+				}
+
+				similarityClusterAssets.add(similarityClusterAsset);
+			}
+
+			SimilarityClusterAsset[] similarityClusterAssetsArray =
+				similarityClusterAssets.toArray(new SimilarityClusterAsset[0]);
+
+			SimilarityCluster similarityCluster = new SimilarityCluster();
+
+			similarityCluster.setSimilarityClusterAssets(
+				() -> similarityClusterAssetsArray);
+			similarityCluster.setSize(
+				() -> similarityClusterAssetsArray.length);
+
+			similarityClusters.add(similarityCluster);
+
+			totalCount += cluster.size();
+		}
+
+		SimilarityCluster[] similarityClustersArray =
+			similarityClusters.toArray(new SimilarityCluster[0]);
+
+		long totalCountValue = totalCount;
+
+		SimilarityClusterResult similarityClusterResult =
+			new SimilarityClusterResult();
+
+		similarityClusterResult.setSimilarityClusters(
+			() -> similarityClustersArray);
+		similarityClusterResult.setTotalCount(() -> totalCountValue);
+
+		return similarityClusterResult;
+	}
+
+	private void _union(
+		Map<Long, Long> parents, Long objectEntryId1, Long objectEntryId2) {
+
+		Long root1 = _find(parents, objectEntryId1);
+		Long root2 = _find(parents, objectEntryId2);
+
+		if (!root1.equals(root2)) {
+			parents.put(root1, root2);
+		}
+	}
+
+	private static final String _BANDS_AGGREGATION_NAME = "bands";
+
+	private static final int _MAX_BANDS = 10000;
+
+	private static final int _MAX_CLUSTER_SIZE = 1000;
+
+	private static final String _OBJECT_ENTRY_IDS_AGGREGATION_NAME =
+		"objectEntryIds";
+
+	private static final int _SIGNATURE_SIZE = 128;
+
+	@Reference
+	private Aggregations _aggregations;
+
+	@Reference
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private DepotEntryService _depotEntryService;
+
+	@Reference
+	private ObjectDefinitionService _objectDefinitionService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarityClusterResultResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarityClusterResultResourceFactoryImpl.java
@@ -1,0 +1,343 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0.factory;
+
+import com.liferay.headless.cms.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-cms/v1.0/SimilarityClusterResult",
+	service = SimilarityClusterResultResource.Factory.class
+)
+@Generated("")
+public class SimilarityClusterResultResourceFactoryImpl
+	implements SimilarityClusterResultResource.Factory {
+
+	@Override
+	public SimilarityClusterResultResource.Builder create() {
+		return new SimilarityClusterResultResource.Builder() {
+
+			@Override
+			public SimilarityClusterResultResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, SimilarityClusterResultResource>
+					similarityClusterResultResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_similarityClusterResultResourceProxyProviderFunction;
+
+				return similarityClusterResultResourceProxyProviderFunction.
+					apply(
+						(proxy, method, arguments) -> _invoke(
+							method, arguments, _checkPermissions,
+							_httpServletRequest, _httpServletResponse,
+							_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder uriInfo(
+				UriInfo uriInfo) {
+
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, SimilarityClusterResultResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			SimilarityClusterResultResource.class.getClassLoader(),
+			SimilarityClusterResultResource.class);
+
+		try {
+			Constructor<SimilarityClusterResultResource> constructor =
+				(Constructor<SimilarityClusterResultResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		SimilarityClusterResultResource similarityClusterResultResource =
+			_componentServiceObjects.getService();
+
+		similarityClusterResultResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		similarityClusterResultResource.setContextCompany(company);
+
+		similarityClusterResultResource.setContextHttpServletRequest(
+			httpServletRequest);
+		similarityClusterResultResource.setContextHttpServletResponse(
+			httpServletResponse);
+		similarityClusterResultResource.setContextUriInfo(uriInfo);
+		similarityClusterResultResource.setContextUser(user);
+		similarityClusterResultResource.setExpressionConvert(
+			_expressionConvert);
+		similarityClusterResultResource.setFilterParserProvider(
+			_filterParserProvider);
+		similarityClusterResultResource.setGroupLocalService(
+			_groupLocalService);
+		similarityClusterResultResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarityClusterResultResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarityClusterResultResource.setRoleLocalService(_roleLocalService);
+		similarityClusterResultResource.setSortParserProvider(
+			_sortParserProvider);
+
+		try {
+			return method.invoke(similarityClusterResultResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(
+				similarityClusterResultResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarityClusterResultResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, SimilarityClusterResultResource>
+				_similarityClusterResultResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:127491409

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similarity-cluster-result.properties
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similarity-cluster-result.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.CMS)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarityClusterResultResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarityClusterResultResourceTestCase.java
@@ -1,0 +1,858 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterResultSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public abstract class BaseSimilarityClusterResultResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_similarityClusterResultResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		similarityClusterResultResource =
+			SimilarityClusterResultResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarityClusterResult similarityClusterResult1 =
+			randomSimilarityClusterResult();
+
+		String json = objectMapper.writeValueAsString(similarityClusterResult1);
+
+		SimilarityClusterResult similarityClusterResult2 =
+			SimilarityClusterResultSerDes.toDTO(json);
+
+		Assert.assertTrue(
+			equals(similarityClusterResult1, similarityClusterResult2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarityClusterResult similarityClusterResult =
+			randomSimilarityClusterResult();
+
+		String json1 = objectMapper.writeValueAsString(similarityClusterResult);
+		String json2 = SimilarityClusterResultSerDes.toJSON(
+			similarityClusterResult);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		SimilarityClusterResult similarityClusterResult =
+			randomSimilarityClusterResult();
+
+		String json = SimilarityClusterResultSerDes.toJSON(
+			similarityClusterResult);
+
+		Assert.assertFalse(json.contains(regex));
+
+		similarityClusterResult = SimilarityClusterResultSerDes.toDTO(json);
+	}
+
+	@Test
+	public void testGetSimilarityCluster() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGraphQLGetSimilarityCluster() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGraphQLGetSimilarityClusterNotFound() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	protected void assertContains(
+		SimilarityClusterResult similarityClusterResult,
+		List<SimilarityClusterResult> similarityClusterResults) {
+
+		boolean contains = false;
+
+		for (SimilarityClusterResult item : similarityClusterResults) {
+			if (equals(similarityClusterResult, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			similarityClusterResults + " does not contain " +
+				similarityClusterResult,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		SimilarityClusterResult similarityClusterResult1,
+		SimilarityClusterResult similarityClusterResult2) {
+
+		Assert.assertTrue(
+			similarityClusterResult1 + " does not equal " +
+				similarityClusterResult2,
+			equals(similarityClusterResult1, similarityClusterResult2));
+	}
+
+	protected void assertEquals(
+		List<SimilarityClusterResult> similarityClusterResults1,
+		List<SimilarityClusterResult> similarityClusterResults2) {
+
+		Assert.assertEquals(
+			similarityClusterResults1.size(), similarityClusterResults2.size());
+
+		for (int i = 0; i < similarityClusterResults1.size(); i++) {
+			SimilarityClusterResult similarityClusterResult1 =
+				similarityClusterResults1.get(i);
+			SimilarityClusterResult similarityClusterResult2 =
+				similarityClusterResults2.get(i);
+
+			assertEquals(similarityClusterResult1, similarityClusterResult2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<SimilarityClusterResult> similarityClusterResults1,
+		List<SimilarityClusterResult> similarityClusterResults2) {
+
+		Assert.assertEquals(
+			similarityClusterResults1.size(), similarityClusterResults2.size());
+
+		for (SimilarityClusterResult similarityClusterResult1 :
+				similarityClusterResults1) {
+
+			boolean contains = false;
+
+			for (SimilarityClusterResult similarityClusterResult2 :
+					similarityClusterResults2) {
+
+				if (equals(
+						similarityClusterResult1, similarityClusterResult2)) {
+
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				similarityClusterResults2 + " does not contain " +
+					similarityClusterResult1,
+				contains);
+		}
+	}
+
+	protected void assertValid(SimilarityClusterResult similarityClusterResult)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"similarityClusters", additionalAssertFieldName)) {
+
+				if (similarityClusterResult.getSimilarityClusters() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (similarityClusterResult.getTotalCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<SimilarityClusterResult> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<SimilarityClusterResult> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<SimilarityClusterResult> similarityClusterResults =
+			page.getItems();
+
+		int size = similarityClusterResults.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		SimilarityClusterResult similarityClusterResult1,
+		SimilarityClusterResult similarityClusterResult2) {
+
+		if (similarityClusterResult1 == similarityClusterResult2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"similarityClusters", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						similarityClusterResult1.getSimilarityClusters(),
+						similarityClusterResult2.getSimilarityClusters())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						similarityClusterResult1.getTotalCount(),
+						similarityClusterResult2.getTotalCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_similarityClusterResultResource instanceof
+				EntityModelResource)) {
+
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_similarityClusterResultResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		SimilarityClusterResult similarityClusterResult) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("similarityClusters")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("totalCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected SimilarityClusterResult randomSimilarityClusterResult()
+		throws Exception {
+
+		return new SimilarityClusterResult() {
+			{
+				totalCount = RandomTestUtil.randomLong();
+			}
+		};
+	}
+
+	protected SimilarityClusterResult randomIrrelevantSimilarityClusterResult()
+		throws Exception {
+
+		SimilarityClusterResult randomIrrelevantSimilarityClusterResult =
+			randomSimilarityClusterResult();
+
+		return randomIrrelevantSimilarityClusterResult;
+	}
+
+	protected SimilarityClusterResult randomPatchSimilarityClusterResult()
+		throws Exception {
+
+		return randomSimilarityClusterResult();
+	}
+
+	protected SimilarityClusterResultResource similarityClusterResultResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(
+			BaseSimilarityClusterResultResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private
+		com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource
+			_similarityClusterResultResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:2093497348

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarityClusterResultResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarityClusterResultResourceTest.java
@@ -1,0 +1,248 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class SimilarityClusterResultResourceTest
+	extends BaseSimilarityClusterResultResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetSimilarityCluster() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		// No content yet
+
+		SimilarityClusterResult similarityClusterResult =
+			similarityClusterResultResource.getSimilarityCluster(
+				groupId, "TEXT");
+
+		Assert.assertEquals(
+			0, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		SimilarityCluster[] similarityClusters =
+			similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 0, similarityClusters.length);
+
+		// Two near-duplicate assets and one distinct asset
+
+		ObjectEntry nearDuplicateObjectEntry1 = _addObjectEntry(
+			depotEntry, objectDefinition, "Reset Your Password",
+			_NEAR_DUPLICATE_CONTENT);
+		ObjectEntry nearDuplicateObjectEntry2 = _addObjectEntry(
+			depotEntry, objectDefinition, "Reset Your Password",
+			_NEAR_DUPLICATE_CONTENT +
+				" You can also contact support for help.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Quarterly Sales Report",
+			_DISTINCT_CONTENT);
+
+		similarityClusterResult =
+			similarityClusterResultResource.getSimilarityCluster(
+				groupId, "TEXT");
+
+		Assert.assertEquals(
+			2, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		similarityClusters = similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 1, similarityClusters.length);
+
+		SimilarityCluster similarityCluster = similarityClusters[0];
+
+		Assert.assertEquals(
+			2, GetterUtil.getInteger(similarityCluster.getSize()));
+
+		SimilarityClusterAsset[] similarityClusterAssets =
+			similarityCluster.getSimilarityClusterAssets();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusterAssets), 2,
+			similarityClusterAssets.length);
+
+		List<Long> objectEntryIds = new ArrayList<>();
+
+		int topAssetCount = 0;
+
+		for (SimilarityClusterAsset similarityClusterAsset :
+				similarityClusterAssets) {
+
+			objectEntryIds.add(similarityClusterAsset.getId());
+
+			Assert.assertEquals(
+				"Reset Your Password", similarityClusterAsset.getTitle());
+			Assert.assertNotNull(similarityClusterAsset.getContentType());
+			Assert.assertNotNull(similarityClusterAsset.getDateModified());
+
+			if (GetterUtil.getBoolean(similarityClusterAsset.getTopAsset())) {
+				topAssetCount++;
+
+				Assert.assertNull(
+					similarityClusterAsset.getSimilarityPercent());
+			}
+			else {
+				double similarityPercent = GetterUtil.getDouble(
+					similarityClusterAsset.getSimilarityPercent());
+
+				Assert.assertTrue(
+					"Similarity percent must be in (0, 100], was " +
+						similarityPercent,
+					(similarityPercent > 0) && (similarityPercent <= 100));
+			}
+		}
+
+		Assert.assertEquals(1, topAssetCount);
+		Assert.assertTrue(
+			objectEntryIds.contains(
+				nearDuplicateObjectEntry1.getObjectEntryId()));
+		Assert.assertTrue(
+			objectEntryIds.contains(
+				nearDuplicateObjectEntry2.getObjectEntryId()));
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetSimilarityCluster() throws Exception {
+	}
+
+	private ObjectEntry _addObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)content
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)title
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private DepotEntry _addSpaceDepotEntry(ServiceContext serviceContext)
+		throws Exception {
+
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+	}
+
+	private ObjectDefinition _getBasicWebContentObjectDefinition()
+		throws Exception {
+
+		Group cmsGroup = CMSTestUtil.getOrAddGroup(
+			SimilarityClusterResultResourceTest.class);
+
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+	}
+
+	private static final String _DISTINCT_CONTENT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market with product categories in retail and wholesale " +
+				"increasing during the last fiscal period.";
+
+	private static final String _NEAR_DUPLICATE_CONTENT =
+		"If you forgot your password go to the login page and click the " +
+			"forgot password link enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-rest-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtil.java
@@ -1,0 +1,233 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similarity;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Computes MinHash/LSH band signatures for a text so that near-duplicate
+ * content can be grouped by an aggregation over an indexed keyword field,
+ * without any per-document similarity query at read time.
+ *
+ * <p>
+ * The text is reduced to a set of word shingles, condensed to a fixed-length
+ * MinHash signature (an estimator of the Jaccard similarity between two shingle
+ * sets), and split into LSH bands. Two texts that share at least one band token
+ * are near-duplicate candidates; the higher their overlap, the more bands they
+ * share. The {@code (bands, rows)} split controls the overlap threshold at which
+ * two texts start sharing a band.
+ * </p>
+ *
+ * <p>
+ * The computation is deterministic: the same text always yields the same band
+ * tokens across nodes and across reindexes, which is required for the tokens to
+ * be comparable in the index.
+ * </p>
+ *
+ * @author Mikel Lorza
+ */
+public class TextSimilaritySignatureUtil {
+
+	/**
+	 * Returns the LSH band tokens for the given text, to be indexed as a
+	 * multi-valued keyword field. Returns an empty array when the text is blank
+	 * or too short to yield any shingle.
+	 */
+	public static String[] getBandSignatures(String text) {
+		if (text == null) {
+			return new String[0];
+		}
+
+		Set<String> shingles = _getShingles(text);
+
+		if (shingles.isEmpty()) {
+			return new String[0];
+		}
+
+		long[] signature = _getMinHashSignature(shingles);
+
+		String[] bands = new String[_BANDS];
+
+		for (int band = 0; band < _BANDS; band++) {
+			long bandHash = _FNV_OFFSET_BASIS;
+
+			for (int row = 0; row < _ROWS; row++) {
+				bandHash = _mix(bandHash, signature[(band * _ROWS) + row]);
+			}
+
+			bands[band] = StringBundler.concat(
+				"b", band, "_", Long.toHexString(bandHash));
+		}
+
+		return bands;
+	}
+
+	/**
+	 * Returns the raw MinHash signature for the given text as position-prefixed
+	 * keyword tokens ({@code "p" + position + "_" + value}), to be indexed as a
+	 * multi-valued keyword field. The prefix keeps each position identifiable
+	 * regardless of
+	 * the order the index returns the values in, so the fraction of matching
+	 * positions between two signatures estimates their Jaccard similarity.
+	 * Returns an empty array when the text is blank or too short to yield any
+	 * shingle.
+	 */
+	public static String[] getSignature(String text) {
+		if (text == null) {
+			return new String[0];
+		}
+
+		Set<String> shingles = _getShingles(text);
+
+		if (shingles.isEmpty()) {
+			return new String[0];
+		}
+
+		long[] signature = _getMinHashSignature(shingles);
+
+		String[] tokens = new String[_HASH_COUNT];
+
+		for (int i = 0; i < _HASH_COUNT; i++) {
+			tokens[i] = StringBundler.concat("p", i, "_", signature[i]);
+		}
+
+		return tokens;
+	}
+
+	private static long _fnv1a(String value) {
+		long hash = _FNV_OFFSET_BASIS;
+
+		for (int i = 0; i < value.length(); i++) {
+			hash ^= value.charAt(i);
+			hash *= _FNV_PRIME;
+		}
+
+		return hash & Long.MAX_VALUE;
+	}
+
+	private static long[] _getMinHashSignature(Set<String> shingles) {
+		long[] signature = new long[_HASH_COUNT];
+
+		for (int i = 0; i < _HASH_COUNT; i++) {
+			signature[i] = Long.MAX_VALUE;
+		}
+
+		for (String shingle : shingles) {
+			long baseHash = _fnv1a(shingle);
+
+			for (int i = 0; i < _HASH_COUNT; i++) {
+
+				// Derive each permutation from one base hash via a distinct
+				// linear transform (a * h + b) mod prime, instead of hashing
+				// every shingle once per permutation.
+
+				long permuted =
+					((_PERMUTATION_A[i] * baseHash) + _PERMUTATION_B[i]) %
+						_MERSENNE_PRIME;
+
+				if (permuted < 0) {
+					permuted += _MERSENNE_PRIME;
+				}
+
+				if (permuted < signature[i]) {
+					signature[i] = permuted;
+				}
+			}
+		}
+
+		return signature;
+	}
+
+	private static Set<String> _getShingles(String text) {
+		Set<String> shingles = new HashSet<>();
+
+		String[] tokens = text.toLowerCase(
+		).replaceAll(
+			"[^\\p{L}\\p{Nd}]+", " "
+		).trim(
+		).split(
+			"\\s+"
+		);
+
+		if ((tokens.length == 1) && tokens[0].isEmpty()) {
+			return shingles;
+		}
+
+		if (tokens.length < _SHINGLE_SIZE) {
+			for (String token : tokens) {
+				shingles.add(token);
+			}
+
+			return shingles;
+		}
+
+		for (int i = 0; i <= (tokens.length - _SHINGLE_SIZE); i++) {
+			StringBuilder sb = new StringBuilder();
+
+			for (int j = 0; j < _SHINGLE_SIZE; j++) {
+				if (j > 0) {
+					sb.append(' ');
+				}
+
+				sb.append(tokens[i + j]);
+			}
+
+			shingles.add(sb.toString());
+		}
+
+		return shingles;
+	}
+
+	private static long _mix(long hash, long value) {
+		for (int shift = 0; shift < 64; shift += 8) {
+			hash ^= (value >>> shift) & 0xff;
+			hash *= _FNV_PRIME;
+		}
+
+		return hash;
+	}
+
+	private static final int _BANDS = 32;
+
+	private static final long _FNV_OFFSET_BASIS = 0xcbf29ce484222325L;
+
+	private static final long _FNV_PRIME = 0x100000001b3L;
+
+	private static final int _HASH_COUNT = 128;
+
+	private static final long _MERSENNE_PRIME = (1L << 61) - 1;
+
+	private static final long[] _PERMUTATION_A = new long[_HASH_COUNT];
+
+	private static final long[] _PERMUTATION_B = new long[_HASH_COUNT];
+
+	private static final int _ROWS = 4;
+
+	private static final int _SHINGLE_SIZE = 3;
+
+	static {
+
+		// Deterministically seed the permutation coefficients with a fixed
+		// linear congruential generator so the signature is stable across nodes
+		// and reindexes.
+
+		long state = 0x9e3779b97f4a7c15L;
+
+		for (int i = 0; i < _HASH_COUNT; i++) {
+			state = (state * 6364136223846793005L) + 1442695040888963407L;
+
+			_PERMUTATION_A[i] = ((state >>> 1) % (_MERSENNE_PRIME - 1)) + 1;
+
+			state = (state * 6364136223846793005L) + 1442695040888963407L;
+
+			_PERMUTATION_B[i] = (state >>> 1) % _MERSENNE_PRIME;
+		}
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSTextSimilarityCompanyIndexConfigurationContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSTextSimilarityCompanyIndexConfigurationContributor.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.CompanyIndexConfigurationContributor;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.SettingsHelper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Declares the CMS content text-similarity band field as a keyword so it is
+ * aggregatable. Without an explicit declaration the catch-all dynamic template
+ * maps string fields to text, which cannot back a terms aggregation.
+ *
+ * @author Mikel Lorza
+ */
+@Component(service = CompanyIndexConfigurationContributor.class)
+public class CMSTextSimilarityCompanyIndexConfigurationContributor
+	implements CompanyIndexConfigurationContributor {
+
+	@Override
+	public void contributeMappings(
+		long companyId, MappingsHelper mappingsHelper) {
+
+		mappingsHelper.putMappings(
+			StringUtil.read(
+				getClass(), "dependencies/text-similarity-type-mappings.json"));
+	}
+
+	@Override
+	public void contributeSettings(
+		long companyId, SettingsHelper settingsHelper) {
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentTextSimilarityContributorRegistrar.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentTextSimilarityContributorRegistrar.java
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * Registers {@link CMSContentTextSimilarityModelDocumentContributor} under each
+ * object definition's own class name.
+ *
+ * <p>
+ * Object entries are indexed at create/update time by a per-object-definition
+ * indexer keyed on {@code objectDefinition.getClassName()} (a generated
+ * {@code com.liferay.object.model.ObjectDefinition#...} class name), not by the
+ * static {@code com.liferay.object.model.ObjectEntry} indexer. A
+ * {@code ModelDocumentContributor} registered only under
+ * {@code com.liferay.object.model.ObjectEntry} therefore runs on full reindex
+ * but never at write time. This registrar tracks the per-definition indexers and
+ * mirror-registers the text similarity contributor under each definition's class
+ * name so the band signatures are also written when content is created or
+ * updated. The contributor itself only contributes for CMS content entries.
+ * </p>
+ *
+ * @author Mikel Lorza
+ */
+@Component(service = {})
+public class CMSContentTextSimilarityContributorRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext)
+		throws InvalidSyntaxException {
+
+		_bundleContext = bundleContext;
+
+		_serviceTracker = new ServiceTracker<>(
+			bundleContext,
+			bundleContext.createFilter(
+				StringBundler.concat(
+					"(&(objectClass=", Indexer.class.getName(),
+					")(indexer.class.name=",
+					ObjectDefinitionConstants.
+						CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION,
+					"*))")),
+			new IndexerServiceTrackerCustomizer());
+
+		_serviceTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceTracker != null) {
+			_serviceTracker.close();
+		}
+	}
+
+	private BundleContext _bundleContext;
+	private final CMSContentTextSimilarityModelDocumentContributor
+		_modelDocumentContributor =
+			new CMSContentTextSimilarityModelDocumentContributor();
+	private ServiceTracker
+		<Indexer<?>, ServiceRegistration<ModelDocumentContributor<?>>>
+			_serviceTracker;
+
+	private class IndexerServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<Indexer<?>, ServiceRegistration<ModelDocumentContributor<?>>> {
+
+		@Override
+		public ServiceRegistration<ModelDocumentContributor<?>> addingService(
+			ServiceReference<Indexer<?>> serviceReference) {
+
+			Object className = serviceReference.getProperty(
+				"indexer.class.name");
+
+			if (className == null) {
+				return null;
+			}
+
+			return _bundleContext.registerService(
+				(Class<ModelDocumentContributor<?>>)
+					(Class<?>)ModelDocumentContributor.class,
+				_modelDocumentContributor,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"indexer.class.name", className
+				).build());
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<Indexer<?>> serviceReference,
+			ServiceRegistration<ModelDocumentContributor<?>>
+				serviceRegistration) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<Indexer<?>> serviceReference,
+			ServiceRegistration<ModelDocumentContributor<?>>
+				serviceRegistration) {
+
+			if (serviceRegistration != null) {
+				serviceRegistration.unregister();
+			}
+
+			_bundleContext.ungetService(serviceReference);
+		}
+
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentTextSimilarityModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentTextSimilarityModelDocumentContributor.java
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.util.HtmlParserUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.site.cms.site.initializer.internal.search.similarity.TextSimilaritySignatureUtil;
+
+import java.io.Serializable;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Adds the near-duplicate band signatures of a CMS content's main text fields
+ * as a keyword field, so the Content Governance Dashboard's Text Similarity
+ * widget can group near-duplicate content through a single aggregation, without
+ * a per-document similarity query at read time.
+ *
+ * <p>
+ * Runs alongside the core {@code ObjectEntryModelDocumentContributor} on the
+ * same document and only contributes for CMS content object entries.
+ * </p>
+ *
+ * @author Mikel Lorza
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.object.model.ObjectEntry",
+	service = ModelDocumentContributor.class
+)
+public class CMSContentTextSimilarityModelDocumentContributor
+	implements ModelDocumentContributor<ObjectEntry> {
+
+	@Override
+	public void contribute(Document document, ObjectEntry objectEntry) {
+		try {
+			if (!_isCMSContent(objectEntry)) {
+				return;
+			}
+
+			String text = _getText(objectEntry);
+
+			String[] bandSignatures =
+				TextSimilaritySignatureUtil.getBandSignatures(text);
+
+			if (bandSignatures.length > 0) {
+				document.addKeyword("textSimilarityBands", bandSignatures);
+			}
+
+			String[] signature = TextSimilaritySignatureUtil.getSignature(text);
+
+			if (signature.length > 0) {
+				document.addKeyword("textSimilaritySignature", signature);
+			}
+		}
+		catch (Exception exception) {
+
+			// Never break indexing of the object entry because of the
+			// similarity signature.
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to contribute text similarity bands for object " +
+						"entry " + objectEntry.getObjectEntryId(),
+					exception);
+			}
+		}
+	}
+
+	private String _getText(ObjectEntry objectEntry) throws Exception {
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		Map<String, Serializable> indexedValues =
+			objectEntry.getIndexedValues();
+
+		String defaultLanguageId = objectEntry.getDefaultLanguageId();
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		StringBundler sb = new StringBundler();
+
+		for (ObjectField objectField :
+				objectFieldBag.getIndexedObjectFields()) {
+
+			String businessType = objectField.getBusinessType();
+
+			if (!businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_TEXT) &&
+				!businessType.equals(
+					ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) &&
+				!businessType.equals(
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+				continue;
+			}
+
+			Object value = null;
+
+			if (objectField.isLocalized()) {
+				Object localizedValues = indexedValues.get(
+					objectField.getI18nObjectFieldName());
+
+				if (localizedValues instanceof Map) {
+					Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+					value = localizedValuesMap.get(defaultLanguageId);
+				}
+			}
+			else {
+				value = indexedValues.get(objectField.getName());
+			}
+
+			if (value == null) {
+				continue;
+			}
+
+			String valueString = String.valueOf(value);
+
+			if (businessType.equals(
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+				valueString = HtmlParserUtil.extractText(valueString);
+			}
+
+			sb.append(valueString);
+			sb.append(CharPool.SPACE);
+		}
+
+		return sb.toString();
+	}
+
+	private boolean _isCMSContent(ObjectEntry objectEntry) throws Exception {
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
+
+		if (objectFolder == null) {
+			return false;
+		}
+
+		String externalReferenceCode = objectFolder.getExternalReferenceCode();
+
+		if (Objects.equals(
+				externalReferenceCode,
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) ||
+			Objects.equals(
+				externalReferenceCode,
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CMSContentTextSimilarityModelDocumentContributor.class);
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/text-similarity-type-mappings.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/text-similarity-type-mappings.json
@@ -1,0 +1,10 @@
+{
+	"properties": {
+		"textSimilarityBands": {
+			"type": "keyword"
+		},
+		"textSimilaritySignature": {
+			"type": "keyword"
+		}
+	}
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtilTest.java
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similarity;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Mikel Lorza
+ */
+public class TextSimilaritySignatureUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBlankTextYieldsNoBands() {
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getBandSignatures(null).length);
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getBandSignatures("").length);
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getBandSignatures("   ").length);
+	}
+
+	@Test
+	public void testBlankTextYieldsNoSignature() {
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getSignature(null).length);
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getSignature("").length);
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getSignature("   ").length);
+	}
+
+	@Test
+	public void testDeterministic() {
+		Assert.assertArrayEquals(
+			TextSimilaritySignatureUtil.getBandSignatures(_A),
+			TextSimilaritySignatureUtil.getBandSignatures(_A));
+	}
+
+	@Test
+	public void testDistinctTextSharesNoBands() {
+		Assert.assertEquals(0, _sharedBandCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testNearDuplicateSharesMoreThanDistinct() {
+		Assert.assertTrue(
+			_sharedBandCount(_A, _A + " 2") > _sharedBandCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testNearDuplicateSharesMostBands() {
+
+		// "_A" and "_A" + a trailing token differ by one shingle only, so their
+		// signatures must collide in nearly every band. This is the case an
+		// exact fingerprint would miss.
+
+		int sharedBandCount = _sharedBandCount(_A, _A + " 2");
+
+		Assert.assertTrue(
+			"Near-duplicate texts must share most of the 32 bands, shared: " +
+				sharedBandCount,
+			sharedBandCount >= 20);
+	}
+
+	@Test
+	public void testSignatureDeterministic() {
+		Assert.assertArrayEquals(
+			TextSimilaritySignatureUtil.getSignature(_A),
+			TextSimilaritySignatureUtil.getSignature(_A));
+	}
+
+	@Test
+	public void testSignatureHasFixedSize() {
+		Assert.assertEquals(
+			128, TextSimilaritySignatureUtil.getSignature(_A).length);
+	}
+
+	@Test
+	public void testSignatureNearDuplicateMatchesMorePositionsThanDistinct() {
+		Assert.assertTrue(
+			_matchingPositionCount(_A, _A + " 2") > _matchingPositionCount(
+				_A, _DISTINCT));
+	}
+
+	private int _matchingPositionCount(String text1, String text2) {
+		Map<String, String> valuesByPosition = new HashMap<>();
+
+		for (String token : TextSimilaritySignatureUtil.getSignature(text1)) {
+			int index = token.indexOf('_');
+
+			valuesByPosition.put(
+				token.substring(0, index), token.substring(index + 1));
+		}
+
+		int count = 0;
+
+		for (String token : TextSimilaritySignatureUtil.getSignature(text2)) {
+			int index = token.indexOf('_');
+
+			String value = valuesByPosition.get(token.substring(0, index));
+
+			if ((value != null) && value.equals(token.substring(index + 1))) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	private int _sharedBandCount(String text1, String text2) {
+		Set<String> bands = new HashSet<>();
+
+		for (String band :
+				TextSimilaritySignatureUtil.getBandSignatures(text1)) {
+
+			bands.add(band);
+		}
+
+		int count = 0;
+
+		for (String band :
+				TextSimilaritySignatureUtil.getBandSignatures(text2)) {
+
+			if (bands.contains(band)) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	private static final String _A =
+		"If you forgot your password, go to the login page and click the " +
+			"forgot password link. Enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	private static final String _DISTINCT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market. Product categories in retail and wholesale " +
+				"increased during the last fiscal period.";
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97867

## What Is Being Fixed

The Content Governance dashboard needs a "Text Similarity" signal: per Space, how many assets share significant textual overlap (copy-paste, minor edits, added or removed sentences), plus the near-duplicate groups behind that number. The card and its drill-down must be seedless (no reference document) and stay fast and exact for Spaces of any size, from a thousand to a hundred thousand assets. A per-request `MoreLikeThis` sweep is O(N) queries and does not scale, and capping it turns the count into a meaningless sample.

## How It Is Being Fixed

The similarity signal is precomputed at index time so the endpoint can answer with a single aggregation.

A MinHash/LSH signature is computed for every CMS content asset from its indexed text fields (3-word shingles, 128 hashes, 32 bands x 4 rows). Two aggregatable keyword fields are added to the object entry document: `textSimilarityBands` (the LSH bands, used to group near-duplicates) and `textSimilaritySignature` (the raw MinHash values, used to estimate pairwise similarity). Both are declared as keyword via a `CompanyIndexConfigurationContributor`, populated by a `ModelDocumentContributor` gated to CMS content, and a contributor registrar mirrors the registration under each per-definition indexer class name so the fields are populated at write time (create/update), not only on full reindex.

A new headless-cms operation `GET /o/headless-cms/v1.0/similarity-clusters?assetLibraryId={groupId}&dimension=TEXT` runs a nested terms aggregation over `textSimilarityBands` (buckets with at least two entries), unions the shared-band buckets into connected components (clusters of size two or more), and returns `SimilarityClusterResult {totalCount, similarityClusters}`. Each `SimilarityClusterAsset` carries `id`, `title`, `contentType`, `dateModified`, `similarityPercent`, and `topAsset`; the Top Asset is the cluster medoid, and the percentage is the MinHash Jaccard estimate of each asset against it. The endpoint is gated behind the CMS feature flag.

The `dimension` parameter and the generic operation name are intentional so the same endpoint can later serve the Duplicate Topics (title) and Same Metadata (tag/category) dimensions tracked in LPD-98911.

## Endpoint

Request:

```
GET /o/headless-cms/v1.0/similarity-clusters?assetLibraryId={groupId}&dimension=TEXT
```

`assetLibraryId` is the Space group id (omit it to scan all of the user's Spaces). Response:

```json
{
	"totalCount": 2,
	"similarityClusters": [
		{
			"size": 2,
			"similarityClusterAssets": [
				{
					"id": 38316,
					"title": "Release Notes",
					"contentType": "Basic Web Content",
					"dateModified": "2026-07-24T11:28:00Z",
					"topAsset": true,
					"similarityPercent": null
				},
				{
					"id": 38321,
					"title": "Release Notes (copy)",
					"contentType": "Basic Web Content",
					"dateModified": "2026-07-24T11:29:00Z",
					"topAsset": false,
					"similarityPercent": 97.0
				}
			]
		}
	]
}
```

## API Contract

Request parameters:

| Parameter | In | Type | Required | Description |
| --- | --- | --- | --- | --- |
| `assetLibraryId` | query | int64 | No | Space group id to scope to. Omit to span every Space the user can access. |
| `dimension` | query | string | No | Similarity dimension. Defaults to `TEXT` (overlap in main text fields) when omitted; any other value currently returns no clusters. |

Response — `SimilarityClusterResult`:

| Field | Type | Nullable | Description |
| --- | --- | --- | --- |
| `totalCount` | int64 | No | Number of distinct assets that belong to a cluster (size >= 2). Backs the card count. |
| `similarityClusters` | `SimilarityCluster[]` | No | The near-duplicate clusters. Backs the modal. Empty when nothing overlaps. |

`SimilarityCluster`:

| Field | Type | Nullable | Description |
| --- | --- | --- | --- |
| `size` | int | No | Number of assets in the cluster. |
| `similarityClusterAssets` | `SimilarityClusterAsset[]` | No | The assets in the cluster. |

`SimilarityClusterAsset`:

| Field | Type | Nullable | Description |
| --- | --- | --- | --- |
| `id` | int64 | No | Object entry id of the asset. |
| `title` | string | No | Localized title (request locale, falling back to the default). |
| `contentType` | string | No | Localized label of the asset's content type (object definition). |
| `dateModified` | date-time | No | Last modification date. |
| `topAsset` | boolean | No | Whether this asset is the cluster's representative (the medoid the others are compared against). |
| `similarityPercent` | double | Yes | Estimated similarity to the top asset, 0–100. Null for the top asset and for assets with no indexed signature yet. |
| `itemURL` | string | Yes | Currently unpopulated (see MVP cuts below). |

Behavior:

- Only clusters of size >= 2 are returned; an asset with no near-duplicate is omitted.
- Only approved (published) CMS content is considered, scoped to the Spaces the user can access.
- "Similar" means a Jaccard overlap of roughly 0.42 or more over 3-word shingle sets (the current 32 bands x 4 rows tuning) — textual near-duplication, not semantic paraphrase.
- No pagination: the full result set is returned in one response. The per-band child aggregation caps at 1000 object entry ids.
- The endpoint is gated behind the CMS feature flag (LPD-17564); it is absent when the flag is off.

## Remaining Work (Handoff)

Deferred to product (escalated, awaiting answers) — the listing page from the LPD-97423 mockup: search field, pagination, and sort by title. These need product to decide the listing granularity (clusters vs flat assets), which filters the search applies, and what the card counts (assets vs clusters).

Known MVP cuts in this PR:

- `itemURL` is intentionally left unpopulated. A correct permission-aware Edit URL needs the search embedded-action machinery, which was deliberately not pulled in; the frontend routes Edit by id and content type like the existing listings do.
- Only the `TEXT` dimension is implemented. `dimension` is wired so `TITLE` and `METADATA` (LPD-98911) can reuse the same operation.
- Signatures are computed from the default-locale text of a content asset.
- The per-band child aggregation caps at 1000 object entry ids.
- `similarityPercent` is null for existing content until it is reindexed (new and updated content is signed at write time automatically).

## PR Check

**pr-check: PASS** — tested on `7f1b5ba7823a1f517b69d29ea0b04eec02f9c240`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Structural Smoke | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7f1b5ba7823a1f517b69d29ea0b04eec02f9c240"} -->
