### PR TITLE
LPD-98572 Fix category navigation vocabulary ordering for mixed-site configurations

### DIFF
--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -223,9 +223,27 @@ public class AssetCategoriesNavigationDisplayContext {
 	}
 
 	private String[] _getAssetVocabularyIds() {
-		List<Long> assetVocabularyIds = new ArrayList<>();
-
 		PortletPreferences portletPreferences = _renderRequest.getPreferences();
+
+		String[] orderedGroupExternalReferenceCodes =
+			portletPreferences.getValues(
+				"assetVocabularyOrderedGroupExternalReferenceCodes", null);
+		String[] orderedVocabularyExternalReferenceCodes =
+			portletPreferences.getValues(
+				"assetVocabularyOrderedVocabularyExternalReferenceCodes", null);
+
+		if ((orderedGroupExternalReferenceCodes != null) &&
+			(orderedVocabularyExternalReferenceCodes != null) &&
+			(orderedGroupExternalReferenceCodes.length ==
+				orderedVocabularyExternalReferenceCodes.length)) {
+
+			return ArrayUtil.toStringArray(
+				_getOrderedAssetVocabularyIds(
+					orderedGroupExternalReferenceCodes,
+					orderedVocabularyExternalReferenceCodes));
+		}
+
+		List<Long> assetVocabularyIds = new ArrayList<>();
 
 		assetVocabularyIds.addAll(
 			_getExternalAssetVocabularyIds(portletPreferences));
@@ -308,6 +326,38 @@ public class AssetCategoriesNavigationDisplayContext {
 
 				return assetVocabulary.getVocabularyId();
 			});
+	}
+
+	private List<Long> _getOrderedAssetVocabularyIds(
+		String[] orderedGroupExternalReferenceCodes,
+		String[] orderedVocabularyExternalReferenceCodes) {
+
+		List<Long> assetVocabularyIds = new ArrayList<>();
+
+		for (int i = 0; i < orderedGroupExternalReferenceCodes.length; i++) {
+			Group group =
+				GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+					orderedGroupExternalReferenceCodes[i],
+					_themeDisplay.getCompanyId());
+
+			if (group == null) {
+				continue;
+			}
+
+			AssetVocabulary assetVocabulary =
+				AssetVocabularyLocalServiceUtil.
+					fetchAssetVocabularyByExternalReferenceCode(
+						orderedVocabularyExternalReferenceCodes[i],
+						group.getGroupId());
+
+			if (assetVocabulary == null) {
+				continue;
+			}
+
+			assetVocabularyIds.add(assetVocabulary.getVocabularyId());
+		}
+
+		return assetVocabularyIds;
 	}
 
 	private String _getTitle(AssetVocabulary assetVocabulary) {

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationAction.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationAction.java
@@ -72,18 +72,26 @@ public class AssetCategoriesNavigationConfigurationAction
 			return;
 		}
 
-		long[] assetVocabularyIds = GetterUtil.getLongValues(
-			StringUtil.split(assetVocabularyIdsString, ','));
+		Map<Long, Group> groupsMap = new HashMap<>();
+		List<String> orderedGroupExternalReferenceCodes = new ArrayList<>();
+		List<String> orderedVocabularyExternalReferenceCodes =
+			new ArrayList<>();
 
 		Map<Long, List<String>> groupAssetVocabularyIdsMap =
 			_getGroupAssetVocabularyExternalReferenceCodesMap(
-				assetVocabularyIds);
+				GetterUtil.getLongValues(
+					StringUtil.split(assetVocabularyIdsString, ',')),
+				groupsMap, orderedGroupExternalReferenceCodes,
+				orderedVocabularyExternalReferenceCodes);
 
 		try {
 			_resetPortletPreferences(portletPreferences);
 
 			_setPortletPreferences(
-				portletPreferences, portletRequest, groupAssetVocabularyIdsMap);
+				groupAssetVocabularyIdsMap, groupsMap,
+				orderedGroupExternalReferenceCodes,
+				orderedVocabularyExternalReferenceCodes, portletPreferences,
+				portletRequest);
 
 			portletPreferences.reset("assetVocabularyIds");
 			portletPreferences.reset("displayStyleGroupId");
@@ -95,7 +103,9 @@ public class AssetCategoriesNavigationConfigurationAction
 
 	private Map<Long, List<String>>
 			_getGroupAssetVocabularyExternalReferenceCodesMap(
-				long[] assetVocabularyIds)
+				long[] assetVocabularyIds, Map<Long, Group> groupsMap,
+				List<String> orderedGroupExternalReferenceCodes,
+				List<String> orderedVocabularyExternalReferenceCodes)
 		throws PortalException {
 
 		Map<Long, List<String>> groupAssetVocabularyExternalReferenceCodesMap =
@@ -109,11 +119,26 @@ public class AssetCategoriesNavigationConfigurationAction
 				continue;
 			}
 
+			long groupId = assetVocabulary.getGroupId();
+
+			Group group = groupsMap.get(groupId);
+
+			if (group == null) {
+				group = _groupLocalService.getGroup(groupId);
+
+				groupsMap.put(groupId, group);
+			}
+
 			List<String> groupAssetVocabularyExternalReferenceCodes =
 				groupAssetVocabularyExternalReferenceCodesMap.computeIfAbsent(
-					assetVocabulary.getGroupId(), key -> new ArrayList<>());
+					groupId, key -> new ArrayList<>());
 
 			groupAssetVocabularyExternalReferenceCodes.add(
+				assetVocabulary.getExternalReferenceCode());
+
+			orderedGroupExternalReferenceCodes.add(
+				group.getExternalReferenceCode());
+			orderedVocabularyExternalReferenceCodes.add(
 				assetVocabulary.getExternalReferenceCode());
 		}
 
@@ -135,13 +160,21 @@ public class AssetCategoriesNavigationConfigurationAction
 				portletPreferences.reset(key);
 			}
 		}
+
+		portletPreferences.reset(
+			"assetVocabularyOrderedGroupExternalReferenceCodes");
+		portletPreferences.reset(
+			"assetVocabularyOrderedVocabularyExternalReferenceCodes");
 	}
 
 	private void _setPortletPreferences(
+			Map<Long, List<String>> groupAssetVocabularyIdsMap,
+			Map<Long, Group> groupsMap,
+			List<String> orderedGroupExternalReferenceCodes,
+			List<String> orderedVocabularyExternalReferenceCodes,
 			PortletPreferences portletPreferences,
-			PortletRequest portletRequest,
-			Map<Long, List<String>> groupAssetVocabularyIdsMap)
-		throws PortalException, ReadOnlyException {
+			PortletRequest portletRequest)
+		throws ReadOnlyException {
 
 		List<String> groupExternalReferenceCodes = new ArrayList<>();
 
@@ -151,7 +184,7 @@ public class AssetCategoriesNavigationConfigurationAction
 		for (Map.Entry<Long, List<String>> entries :
 				groupAssetVocabularyIdsMap.entrySet()) {
 
-			Group group = _groupLocalService.getGroup(entries.getKey());
+			Group group = groupsMap.get(entries.getKey());
 
 			if (group.getGroupId() == themeDisplay.getScopeGroupId()) {
 				portletPreferences.setValues(
@@ -172,6 +205,12 @@ public class AssetCategoriesNavigationConfigurationAction
 		portletPreferences.setValues(
 			"assetVocabularyGroupExternalReferenceCodes",
 			ArrayUtil.toStringArray(groupExternalReferenceCodes));
+		portletPreferences.setValues(
+			"assetVocabularyOrderedGroupExternalReferenceCodes",
+			ArrayUtil.toStringArray(orderedGroupExternalReferenceCodes));
+		portletPreferences.setValues(
+			"assetVocabularyOrderedVocabularyExternalReferenceCodes",
+			ArrayUtil.toStringArray(orderedVocabularyExternalReferenceCodes));
 	}
 
 	@Reference

--- a/modules/apps/asset/asset-categories-navigation-web/src/test/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContextTest.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/test/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContextTest.java
@@ -1,0 +1,267 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.navigation.web.internal.display.context;
+
+import com.liferay.asset.categories.navigation.web.internal.configuration.AssetCategoriesNavigationPortletInstanceConfiguration;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+import jakarta.portlet.RenderRequest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Aswin Narayanadas
+ */
+public class AssetCategoriesNavigationDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_assetVocabularyLocalServiceUtilMockedStatic.close();
+		_assetVocabularyServiceUtilMockedStatic.close();
+		_configurationProviderUtilMockedStatic.close();
+		_groupLocalServiceUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_companyId = RandomTestUtil.randomLong();
+		_scopeGroupId = RandomTestUtil.randomLong();
+
+		_setUpThemeDisplay();
+		_setUpConfigurationProviderUtil();
+	}
+
+	@Test
+	public void testGetDDMTemplateAssetVocabulariesWithOrderedPreferences()
+		throws Exception {
+
+		String childGroupERC = RandomTestUtil.randomString();
+
+		Group childGroup = _mockGroup(_scopeGroupId, childGroupERC);
+
+		_groupLocalServiceUtilMockedStatic.when(
+			() -> GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+				childGroupERC, _companyId)
+		).thenReturn(
+			childGroup
+		);
+
+		String parentGroupERC = RandomTestUtil.randomString();
+
+		Group parentGroup = _mockGroup(
+			RandomTestUtil.randomLong(), parentGroupERC);
+
+		_groupLocalServiceUtilMockedStatic.when(
+			() -> GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+				parentGroupERC, _companyId)
+		).thenReturn(
+			parentGroup
+		);
+
+		AssetVocabulary vocabulary1 = _mockVocabulary(
+			RandomTestUtil.randomLong());
+		String childVocERC = RandomTestUtil.randomString();
+
+		_assetVocabularyLocalServiceUtilMockedStatic.when(
+			() ->
+				AssetVocabularyLocalServiceUtil.
+					fetchAssetVocabularyByExternalReferenceCode(
+						childVocERC, childGroup.getGroupId())
+		).thenReturn(
+			vocabulary1
+		);
+
+		_assetVocabularyServiceUtilMockedStatic.when(
+			() -> AssetVocabularyServiceUtil.fetchVocabulary(
+				vocabulary1.getVocabularyId())
+		).thenReturn(
+			vocabulary1
+		);
+
+		AssetVocabulary vocabulary2 = _mockVocabulary(
+			RandomTestUtil.randomLong());
+		String parentVocERC = RandomTestUtil.randomString();
+
+		_assetVocabularyLocalServiceUtilMockedStatic.when(
+			() ->
+				AssetVocabularyLocalServiceUtil.
+					fetchAssetVocabularyByExternalReferenceCode(
+						parentVocERC, parentGroup.getGroupId())
+		).thenReturn(
+			vocabulary2
+		);
+
+		_assetVocabularyServiceUtilMockedStatic.when(
+			() -> AssetVocabularyServiceUtil.fetchVocabulary(
+				vocabulary2.getVocabularyId())
+		).thenReturn(
+			vocabulary2
+		);
+
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		Mockito.when(
+			portletPreferences.getValues(
+				"assetVocabularyOrderedGroupExternalReferenceCodes", null)
+		).thenReturn(
+			new String[] {childGroupERC, parentGroupERC}
+		);
+
+		Mockito.when(
+			portletPreferences.getValues(
+				"assetVocabularyOrderedVocabularyExternalReferenceCodes", null)
+		).thenReturn(
+			new String[] {childVocERC, parentVocERC}
+		);
+
+		AssetCategoriesNavigationDisplayContext displayContext =
+			_createDisplayContext(portletPreferences);
+
+		List<AssetVocabulary> vocabularies =
+			displayContext.getDDMTemplateAssetVocabularies();
+
+		Assert.assertEquals(
+			Arrays.asList(vocabulary1, vocabulary2), vocabularies);
+	}
+
+	private AssetCategoriesNavigationDisplayContext _createDisplayContext(
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
+
+		Mockito.when(
+			renderRequest.getPreferences()
+		).thenReturn(
+			portletPreferences
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+
+		return new AssetCategoriesNavigationDisplayContext(
+			mockHttpServletRequest, renderRequest);
+	}
+
+	private Group _mockGroup(long groupId, String externalReferenceCode) {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		Mockito.when(
+			group.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		return group;
+	}
+
+	private AssetVocabulary _mockVocabulary(long vocabularyId) {
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		Mockito.when(
+			assetVocabulary.getVocabularyId()
+		).thenReturn(
+			vocabularyId
+		);
+
+		return assetVocabulary;
+	}
+
+	private void _setUpConfigurationProviderUtil() throws Exception {
+		AssetCategoriesNavigationPortletInstanceConfiguration
+			assetCategoriesNavigationPortletInstanceConfiguration =
+				Mockito.mock(
+					AssetCategoriesNavigationPortletInstanceConfiguration.
+						class);
+
+		Mockito.when(
+			assetCategoriesNavigationPortletInstanceConfiguration.
+				allAssetVocabularies()
+		).thenReturn(
+			false
+		);
+
+		_configurationProviderUtilMockedStatic.when(
+			() -> ConfigurationProviderUtil.getPortletInstanceConfiguration(
+				AssetCategoriesNavigationPortletInstanceConfiguration.class,
+				_themeDisplay)
+		).thenReturn(
+			assetCategoriesNavigationPortletInstanceConfiguration
+		);
+	}
+
+	private void _setUpThemeDisplay() {
+		_themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			_themeDisplay.getCompanyId()
+		).thenReturn(
+			_companyId
+		);
+
+		Mockito.when(
+			_themeDisplay.getScopeGroupId()
+		).thenReturn(
+			_scopeGroupId
+		);
+	}
+
+	private static final MockedStatic<AssetVocabularyLocalServiceUtil>
+		_assetVocabularyLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			AssetVocabularyLocalServiceUtil.class);
+	private static final MockedStatic<AssetVocabularyServiceUtil>
+		_assetVocabularyServiceUtilMockedStatic = Mockito.mockStatic(
+			AssetVocabularyServiceUtil.class);
+	private static final MockedStatic<ConfigurationProviderUtil>
+		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
+			ConfigurationProviderUtil.class);
+	private static final MockedStatic<GroupLocalServiceUtil>
+		_groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			GroupLocalServiceUtil.class);
+
+	private long _companyId;
+	private long _scopeGroupId;
+	private ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/asset/asset-categories-navigation-web/src/test/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationActionTest.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/test/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationActionTest.java
@@ -1,0 +1,264 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.navigation.web.internal.portlet.action;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.portlet.MockActionRequest;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.lang.reflect.Field;
+
+import java.util.HashMap;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Aswin Narayanadas
+ */
+public class AssetCategoriesNavigationConfigurationActionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_groupLocalServiceUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_childSiteGroupId = RandomTestUtil.randomLong();
+		_companyId = RandomTestUtil.randomLong();
+
+		_setUpGroupLocalServiceUtil();
+	}
+
+	@Test
+	public void testPostProcessWithMixedSiteVocabularies() throws Exception {
+		AssetVocabularyService assetVocabularyService = Mockito.mock(
+			AssetVocabularyService.class);
+
+		AssetVocabulary childVocabulary = _mockVocabulary(
+			RandomTestUtil.randomLong(), _childSiteGroupId,
+			RandomTestUtil.randomString());
+		long childVocabularyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			assetVocabularyService.fetchVocabulary(childVocabularyId)
+		).thenReturn(
+			childVocabulary
+		);
+
+		AssetVocabulary parentVocabulary = _mockVocabulary(
+			RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
+			RandomTestUtil.randomString());
+		long parentVocabularyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			assetVocabularyService.fetchVocabulary(parentVocabularyId)
+		).thenReturn(
+			parentVocabulary
+		);
+
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		String childGroupERC = RandomTestUtil.randomString();
+
+		Group childGroup = _mockGroup(_childSiteGroupId, childGroupERC);
+
+		Mockito.when(
+			groupLocalService.getGroup(_childSiteGroupId)
+		).thenReturn(
+			childGroup
+		);
+
+		long parentGroupId = parentVocabulary.getGroupId();
+		String parentGroupERC = RandomTestUtil.randomString();
+
+		Group parentGroup = _mockGroup(parentGroupId, parentGroupERC);
+
+		Mockito.when(
+			groupLocalService.getGroup(parentGroupId)
+		).thenReturn(
+			parentGroup
+		);
+
+		AssetCategoriesNavigationConfigurationAction configurationAction =
+			_createConfigurationAction(
+				assetVocabularyService, groupLocalService);
+
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		Mockito.when(
+			portletPreferences.getValue("allAssetVocabularies", null)
+		).thenReturn(
+			"false"
+		);
+
+		Mockito.when(
+			portletPreferences.getValue("assetVocabularyIds", null)
+		).thenReturn(
+			StringBundler.concat(childVocabularyId, ",", parentVocabularyId)
+		);
+
+		Mockito.when(
+			portletPreferences.getMap()
+		).thenReturn(
+			new HashMap<>()
+		);
+
+		configurationAction.postProcess(
+			_companyId, _buildMockActionRequest(), portletPreferences);
+
+		Mockito.verify(
+			portletPreferences
+		).setValues(
+			"assetVocabularyOrderedGroupExternalReferenceCodes", childGroupERC,
+			parentGroupERC
+		);
+
+		Mockito.verify(
+			portletPreferences
+		).setValues(
+			"assetVocabularyOrderedVocabularyExternalReferenceCodes",
+			childVocabulary.getExternalReferenceCode(),
+			parentVocabulary.getExternalReferenceCode()
+		);
+	}
+
+	private MockActionRequest _buildMockActionRequest() {
+		MockActionRequest mockActionRequest = new MockActionRequest();
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getCompanyId()
+		).thenReturn(
+			_companyId
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroupId()
+		).thenReturn(
+			_childSiteGroupId
+		);
+
+		mockActionRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockActionRequest;
+	}
+
+	private AssetCategoriesNavigationConfigurationAction
+			_createConfigurationAction(
+				AssetVocabularyService assetVocabularyService,
+				GroupLocalService groupLocalService)
+		throws Exception {
+
+		AssetCategoriesNavigationConfigurationAction configurationAction =
+			new AssetCategoriesNavigationConfigurationAction();
+
+		_setField(
+			configurationAction, "_assetVocabularyService",
+			assetVocabularyService);
+		_setField(configurationAction, "_groupLocalService", groupLocalService);
+
+		return configurationAction;
+	}
+
+	private Group _mockGroup(long groupId, String externalReferenceCode) {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		Mockito.when(
+			group.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		return group;
+	}
+
+	private AssetVocabulary _mockVocabulary(
+		long vocabularyId, long groupId, String externalReferenceCode) {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		Mockito.when(
+			assetVocabulary.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		Mockito.when(
+			assetVocabulary.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Mockito.when(
+			assetVocabulary.getVocabularyId()
+		).thenReturn(
+			vocabularyId
+		);
+
+		return assetVocabulary;
+	}
+
+	private void _setField(Object target, String fieldName, Object value)
+		throws Exception {
+
+		Field field = target.getClass(
+		).getDeclaredField(
+			fieldName
+		);
+
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	private void _setUpGroupLocalServiceUtil() {
+		_groupLocalServiceUtilMockedStatic.when(
+			() -> GroupLocalServiceUtil.fetchGroup(
+				Mockito.anyLong(), Mockito.any())
+		).thenReturn(
+			null
+		);
+	}
+
+	private static final MockedStatic<GroupLocalServiceUtil>
+		_groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			GroupLocalServiceUtil.class);
+
+	private long _childSiteGroupId;
+	private long _companyId;
+
+}


### PR DESCRIPTION
### **What is this trying to solve?**
Ticket: https://liferay.atlassian.net/browse/LPD-98572

When configuring the Category Navigation widget on a child site with vocabularies from both the child site and its parent site, the user-configured vocabulary order is not preserved after saving. The widget always displays parent-site vocabularies before child-site ones, regardless of the order set in the configuration panel.

### **How am I fixing it?**
The bug is in `AssetCategoriesNavigationDisplayContext._getAssetVocabularyIds`. It always reconstructs the vocabulary list in two fixed phases — external-site vocabularies first, then local-site vocabularies — regardless of the order the user originally configured.

For example, when a user configures **[B, A, C]** where B and C are on the child site and A is on the parent site, `_setPortletPreferences` splits them into two buckets — child: [B, C], parent: [A]. On read, `_getAssetVocabularyIds` always returns external first → [A], then local → [B, C], giving [A, B, C] instead of [B, A, C].

The fix stores two parallel ordered arrays (`assetVocabularyOrderedGroupExternalReferenceCodes` and `assetVocabularyOrderedVocabularyExternalReferenceCodes`) at save time, recording the exact configured order via external reference codes. On load, the display context checks for these arrays first and uses them to reconstruct the vocabulary list in the original sequence. Portlets configured before this fix fall back gracefully to the old external-then-local behavior.

### **How can you verify that it works?**
Run the included unit tests:

```
cd modules/apps/asset/asset-categories-navigation-web && ../../../../gradlew test
```

Manually, on a child site that has a parent site with vocabularies in both:

1. Add the Category Navigation widget to a child site page.
2. Open the widget configuration and select vocabularies from both the child and parent sites in a specific mixed order (e.g., child vocab 1, parent vocab, child vocab 2).
3. Save the configuration.
4. Verify the widget displays vocabularies in the configured order — not with parent-site vocabularies forced to the top.