### PR TITLE
LPD-99512 Follow-up LPD-98411: upgrade URL titles regardless of trailing slash

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
@@ -13,6 +13,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -52,12 +53,18 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 
 				String urlTitle = resultSet.getString("urlTitle");
 
+				String originalUrlTitle = urlTitle;
+
 				while (urlTitle.endsWith(StringPool.SLASH)) {
 					urlTitle = urlTitle.substring(0, urlTitle.length() - 1);
 				}
 
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 					groupId, classNameId, classPK, urlTitle, languageId);
+
+				if (StringUtil.equals(originalUrlTitle, urlTitle)) {
+					continue;
+				}
 
 				_updateURLTitle(
 					classPK, resultSet.getLong("ctCollectionId"), groupId,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
@@ -36,8 +36,7 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 				StringBundler.concat(
 					"select distinct ctCollectionId, friendlyURLEntryId, ",
 					"languageId, urlTitle, groupId, classPK from ",
-					"FriendlyURLEntryLocalization where urlTitle like '%/' ",
-					"and classNameId = ?"))) {
+					"FriendlyURLEntryLocalization where classNameId = ?"));
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				BlogsEntry.class);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
@@ -10,6 +10,7 @@ import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -38,6 +39,11 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 					"select distinct ctCollectionId, friendlyURLEntryId, ",
 					"languageId, urlTitle, groupId, classPK from ",
 					"FriendlyURLEntryLocalization where classNameId = ?"));
+			PreparedStatement updatePreparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update BlogsEntry set urlTitle = ? where ctCollectionId " +
+						"= ? and entryId = ? and groupId = ?")) {
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				BlogsEntry.class);
@@ -68,12 +74,14 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 
 				_updateURLTitle(
 					classPK, resultSet.getLong("ctCollectionId"), groupId,
-					urlTitle);
+					updatePreparedStatement, urlTitle);
 
 				_updateFriendlyURLEntry(
 					resultSet.getLong("friendlyURLEntryId"), languageId,
 					urlTitle);
 			}
+
+			updatePreparedStatement.executeBatch();
 		}
 	}
 
@@ -90,20 +98,16 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 	}
 
 	private void _updateURLTitle(
-			long classPK, long ctCollectionId, long groupId, String urlTitle)
+			long classPK, long ctCollectionId, long groupId,
+			PreparedStatement preparedStatement, String urlTitle)
 		throws Exception {
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"update BlogsEntry set urlTitle = ? where ctCollectionId = ? " +
-					"and entryId = ? and groupId = ?")) {
+		preparedStatement.setString(1, urlTitle);
+		preparedStatement.setLong(2, ctCollectionId);
+		preparedStatement.setLong(3, classPK);
+		preparedStatement.setLong(4, groupId);
 
-			preparedStatement.setString(1, urlTitle);
-			preparedStatement.setLong(2, ctCollectionId);
-			preparedStatement.setLong(3, classPK);
-			preparedStatement.setLong(4, groupId);
-
-			preparedStatement.executeUpdate();
-		}
+		preparedStatement.addBatch();
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/upgrade/v3_1_1/test/BlogsFriendlyURLFormatUpgradeProcessTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/upgrade/v3_1_1/test/BlogsFriendlyURLFormatUpgradeProcessTest.java
@@ -14,6 +14,7 @@ import com.liferay.friendly.url.test.util.BaseFriendlyURLFormatUpgradeProcessTes
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
@@ -59,6 +60,35 @@ public class BlogsFriendlyURLFormatUpgradeProcessTest
 		_runUpgrade();
 
 		_assertURLTitle("test/test");
+	}
+
+	@Test
+	public void testUpgradeForCapitalSpecialCharacter() throws Exception {
+		_addBlogsEntry("test001óóóÓ");
+
+		_runUpgrade();
+
+		_assertURLTitle(
+			_friendlyURLNormalizer.normalizeWithEncoding("test001óóóó"));
+	}
+
+	@Test
+	public void testUpgradeKeepsAlreadyNormalizedURLTitleWithDuplicateSibling()
+		throws Exception {
+
+		_addBlogsEntry("test");
+
+		BlogsEntry blogsEntry = _blogsEntry;
+
+		_addBlogsEntry("Test");
+
+		_runUpgrade();
+
+		_assertURLTitle("test-1");
+
+		_blogsEntry = blogsEntry;
+
+		_assertURLTitle("test");
 	}
 
 	@Test
@@ -150,6 +180,9 @@ public class BlogsFriendlyURLFormatUpgradeProcessTest
 	private BlogsEntryLocalService _blogsEntryLocalService;
 
 	private long _classNameId;
+
+	@Inject
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
 
 	@Inject
 	private MultiVMPool _multiVMPool;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99512

## What Is Being Fixed

The blogs friendly URL format upgrade process (`v3_1_1`) only normalized URL titles that ended with a trailing slash, because its query filtered `FriendlyURLEntryLocalization` rows with `urlTitle like '%/'`. Titles malformed in other ways — for example those containing capital letters or special characters such as `test001óóóÓ` — were left untouched and never brought into the normalized format.

## How It Is Being Fixed

The trailing-slash filter is removed from the query so every `BlogsEntry` friendly URL localization is examined. Each `urlTitle` is normalized (trailing slashes stripped, then run through `getUniqueUrlTitle`); when the result equals the original the row is skipped, otherwise both the `BlogsEntry` and its `FriendlyURLEntry` are updated. The `BlogsEntry` updates are now batched through `AutoBatchPreparedStatementUtil` and flushed once at the end instead of one statement per row.

## PR Check

**pr-check: PASS** — tested on `6b157fe36b1a16336e06366d8472d4a23b19f5d1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6b157fe36b1a16336e06366d8472d4a23b19f5d1"} -->
