### PR TITLE
LPD-98151 Require update permission to open the template edit view

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -678,8 +678,8 @@ public class JournalContentDisplayContext {
 			PortalUtil.getControlPanelPortletURL(
 				_portletRequest, JournalPortletKeys.JOURNAL,
 				PortletRequest.RENDER_PHASE)
-		).setMVCPath(
-			"/edit_ddm_template.jsp"
+		).setMVCRenderCommandName(
+			"/journal/edit_ddm_template"
 		).setRedirect(
 			_themeDisplay.getURLCurrent()
 		).setParameter(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditDDMTemplateDisplayContextTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditDDMTemplateDisplayContextTest.java
@@ -6,14 +6,21 @@
 package com.liferay.journal.web.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
@@ -25,6 +32,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -88,27 +96,162 @@ public class JournalEditDDMTemplateDisplayContextTest {
 		}
 	}
 
-	private MockLiferayPortletRenderRequest
-			_getMockLiferayPortletRenderRequest()
+	@Test
+	public void testRenderAddViewWithAddTemplatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		Assert.assertNotNull(
+			mockLiferayPortletRenderRequest.getAttribute(
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+		Assert.assertFalse(
+			SessionErrors.contains(
+				mockLiferayPortletRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	@Test
+	public void testRenderAddViewWithoutAddTemplatePermission()
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.addUser(_group.getGroupId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		_assertMustHavePermission(mockLiferayPortletRenderRequest);
+	}
+
+	@Test
+	public void testRenderEditViewWithoutUpdatePermission() throws Exception {
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.addUser(_group.getGroupId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		_assertMustHavePermission(mockLiferayPortletRenderRequest);
+	}
+
+	@Test
+	public void testRenderEditViewWithUpdatePermission() throws Exception {
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+
+		_render(mockLiferayPortletRenderRequest);
+
+		Assert.assertNotNull(
+			mockLiferayPortletRenderRequest.getAttribute(
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+		Assert.assertFalse(
+			SessionErrors.contains(
+				mockLiferayPortletRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	@Test
+	public void testRenderPropertiesViewWithoutUpdatePermission()
+		throws Exception {
+
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.addUser(_group.getGroupId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"editProperties", Boolean.TRUE.toString());
+
+		_render(mockLiferayPortletRenderRequest);
+
+		_assertMustHavePermission(mockLiferayPortletRenderRequest);
+	}
+
+	@Test
+	public void testRenderPropertiesViewWithUpdatePermission()
+		throws Exception {
+
+		DDMTemplate ddmTemplate = _addDDMTemplate();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"editProperties", Boolean.TRUE.toString());
+
+		_render(mockLiferayPortletRenderRequest);
+
+		Assert.assertNotNull(
+			mockLiferayPortletRenderRequest.getAttribute(
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+		Assert.assertFalse(
+			SessionErrors.contains(
+				mockLiferayPortletRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	private DDMTemplate _addDDMTemplate() throws Exception {
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		return DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), ddmStructure.getStructureId(),
+			_portal.getClassNameId(JournalArticle.class));
+	}
+
+	private void _assertMustHavePermission(RenderRequest renderRequest) {
+		Assert.assertTrue(
+			SessionErrors.contains(
+				renderRequest, PrincipalException.MustHavePermission.class));
+		Assert.assertNull(
+			renderRequest.getAttribute(_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+	}
+
+	private MockLiferayPortletRenderRequest _getMockLiferayPortletRenderRequest(
+			User user)
 		throws Exception {
 
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			new MockLiferayPortletRenderRequest();
 
-		String path = "/edit_ddm_template.jsp";
+		for (String path :
+				new String[] {
+					"/ddm_template/edit_properties.jsp",
+					"/edit_ddm_template.jsp", "/error.jsp"
+				}) {
 
-		mockLiferayPortletRenderRequest.setAttribute(
-			MVCRenderConstants.
-				PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX + path,
-			new MockLiferayPortletContext(path));
+			mockLiferayPortletRenderRequest.setAttribute(
+				MVCRenderConstants.
+					PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX +
+						path,
+				new MockLiferayPortletContext(path));
+		}
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(_group.getCompanyId()));
 		themeDisplay.setLocale(LocaleUtil.getDefault());
-
-		User user = UserTestUtil.getAdminUser(_group.getCompanyId());
 
 		themeDisplay.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(user));
@@ -119,36 +262,47 @@ public class JournalEditDDMTemplateDisplayContextTest {
 		mockLiferayPortletRenderRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 
-		mockLiferayPortletRenderRequest.setParameter("mvcPath", path);
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", "/journal/edit_ddm_template");
 
 		return mockLiferayPortletRenderRequest;
 	}
 
 	private boolean _isAutogenerateDDMTemplateKey() throws Exception {
 		RenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest();
+			_getMockLiferayPortletRenderRequest(
+				UserTestUtil.getAdminUser(_group.getCompanyId()));
 
-		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
-
-		mvcPortlet.render(
-			mockLiferayPortletRenderRequest,
-			new MockLiferayPortletRenderResponse());
+		_render(mockLiferayPortletRenderRequest);
 
 		Object journalEditDDMTemplateDisplayContext =
 			mockLiferayPortletRenderRequest.getAttribute(
-				"com.liferay.journal.web.internal.display.context." +
-					"JournalEditDDMTemplateDisplayContext");
+				_DISPLAY_CONTEXT_ATTRIBUTE_NAME);
 
 		return ReflectionTestUtil.invoke(
 			journalEditDDMTemplateDisplayContext, "autogenerateDDMTemplateKey",
 			new Class<?>[0]);
 	}
 
+	private void _render(RenderRequest renderRequest) throws Exception {
+		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
+
+		mvcPortlet.render(
+			renderRequest, new MockLiferayPortletRenderResponse());
+	}
+
+	private static final String _DISPLAY_CONTEXT_ATTRIBUTE_NAME =
+		"com.liferay.journal.web.internal.display.context." +
+			"JournalEditDDMTemplateDisplayContext";
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private Portal _portal;
 
 	@Inject(
 		filter = "component.name=com.liferay.journal.web.internal.portlet.JournalPortlet"

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditDDMTemplateDisplayContextTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditDDMTemplateDisplayContextTest.java
@@ -6,21 +6,14 @@
 package com.liferay.journal.web.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.model.DDMTemplate;
-import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
-import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
-import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
@@ -32,7 +25,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -96,162 +88,27 @@ public class JournalEditDDMTemplateDisplayContextTest {
 		}
 	}
 
-	@Test
-	public void testRenderAddViewWithAddTemplatePermission() throws Exception {
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest(
-				UserTestUtil.getAdminUser(_group.getCompanyId()));
-
-		_render(mockLiferayPortletRenderRequest);
-
-		Assert.assertNotNull(
-			mockLiferayPortletRenderRequest.getAttribute(
-				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
-		Assert.assertFalse(
-			SessionErrors.contains(
-				mockLiferayPortletRenderRequest,
-				PrincipalException.MustHavePermission.class));
-	}
-
-	@Test
-	public void testRenderAddViewWithoutAddTemplatePermission()
-		throws Exception {
-
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest(
-				UserTestUtil.addUser(_group.getGroupId()));
-
-		_render(mockLiferayPortletRenderRequest);
-
-		_assertMustHavePermission(mockLiferayPortletRenderRequest);
-	}
-
-	@Test
-	public void testRenderEditViewWithoutUpdatePermission() throws Exception {
-		DDMTemplate ddmTemplate = _addDDMTemplate();
-
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest(
-				UserTestUtil.addUser(_group.getGroupId()));
-
-		mockLiferayPortletRenderRequest.setParameter(
-			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
-
-		_render(mockLiferayPortletRenderRequest);
-
-		_assertMustHavePermission(mockLiferayPortletRenderRequest);
-	}
-
-	@Test
-	public void testRenderEditViewWithUpdatePermission() throws Exception {
-		DDMTemplate ddmTemplate = _addDDMTemplate();
-
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest(
-				UserTestUtil.getAdminUser(_group.getCompanyId()));
-
-		mockLiferayPortletRenderRequest.setParameter(
-			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
-
-		_render(mockLiferayPortletRenderRequest);
-
-		Assert.assertNotNull(
-			mockLiferayPortletRenderRequest.getAttribute(
-				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
-		Assert.assertFalse(
-			SessionErrors.contains(
-				mockLiferayPortletRenderRequest,
-				PrincipalException.MustHavePermission.class));
-	}
-
-	@Test
-	public void testRenderPropertiesViewWithoutUpdatePermission()
-		throws Exception {
-
-		DDMTemplate ddmTemplate = _addDDMTemplate();
-
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest(
-				UserTestUtil.addUser(_group.getGroupId()));
-
-		mockLiferayPortletRenderRequest.setParameter(
-			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
-		mockLiferayPortletRenderRequest.setParameter(
-			"editProperties", Boolean.TRUE.toString());
-
-		_render(mockLiferayPortletRenderRequest);
-
-		_assertMustHavePermission(mockLiferayPortletRenderRequest);
-	}
-
-	@Test
-	public void testRenderPropertiesViewWithUpdatePermission()
-		throws Exception {
-
-		DDMTemplate ddmTemplate = _addDDMTemplate();
-
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest(
-				UserTestUtil.getAdminUser(_group.getCompanyId()));
-
-		mockLiferayPortletRenderRequest.setParameter(
-			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
-		mockLiferayPortletRenderRequest.setParameter(
-			"editProperties", Boolean.TRUE.toString());
-
-		_render(mockLiferayPortletRenderRequest);
-
-		Assert.assertNotNull(
-			mockLiferayPortletRenderRequest.getAttribute(
-				_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
-		Assert.assertFalse(
-			SessionErrors.contains(
-				mockLiferayPortletRenderRequest,
-				PrincipalException.MustHavePermission.class));
-	}
-
-	private DDMTemplate _addDDMTemplate() throws Exception {
-		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
-			_group.getGroupId(), JournalArticle.class.getName());
-
-		return DDMTemplateTestUtil.addTemplate(
-			_group.getGroupId(), ddmStructure.getStructureId(),
-			_portal.getClassNameId(JournalArticle.class));
-	}
-
-	private void _assertMustHavePermission(RenderRequest renderRequest) {
-		Assert.assertTrue(
-			SessionErrors.contains(
-				renderRequest, PrincipalException.MustHavePermission.class));
-		Assert.assertNull(
-			renderRequest.getAttribute(_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
-	}
-
-	private MockLiferayPortletRenderRequest _getMockLiferayPortletRenderRequest(
-			User user)
+	private MockLiferayPortletRenderRequest
+			_getMockLiferayPortletRenderRequest()
 		throws Exception {
 
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			new MockLiferayPortletRenderRequest();
 
-		for (String path :
-				new String[] {
-					"/ddm_template/edit_properties.jsp",
-					"/edit_ddm_template.jsp", "/error.jsp"
-				}) {
+		String path = "/edit_ddm_template.jsp";
 
-			mockLiferayPortletRenderRequest.setAttribute(
-				MVCRenderConstants.
-					PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX +
-						path,
-				new MockLiferayPortletContext(path));
-		}
+		mockLiferayPortletRenderRequest.setAttribute(
+			MVCRenderConstants.
+				PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX + path,
+			new MockLiferayPortletContext(path));
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(_group.getCompanyId()));
 		themeDisplay.setLocale(LocaleUtil.getDefault());
+
+		User user = UserTestUtil.getAdminUser(_group.getCompanyId());
 
 		themeDisplay.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(user));
@@ -270,39 +127,29 @@ public class JournalEditDDMTemplateDisplayContextTest {
 
 	private boolean _isAutogenerateDDMTemplateKey() throws Exception {
 		RenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest(
-				UserTestUtil.getAdminUser(_group.getCompanyId()));
+			_getMockLiferayPortletRenderRequest();
 
-		_render(mockLiferayPortletRenderRequest);
+		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
+
+		mvcPortlet.render(
+			mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
 
 		Object journalEditDDMTemplateDisplayContext =
 			mockLiferayPortletRenderRequest.getAttribute(
-				_DISPLAY_CONTEXT_ATTRIBUTE_NAME);
+				"com.liferay.journal.web.internal.display.context." +
+					"JournalEditDDMTemplateDisplayContext");
 
 		return ReflectionTestUtil.invoke(
 			journalEditDDMTemplateDisplayContext, "autogenerateDDMTemplateKey",
 			new Class<?>[0]);
 	}
 
-	private void _render(RenderRequest renderRequest) throws Exception {
-		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
-
-		mvcPortlet.render(
-			renderRequest, new MockLiferayPortletRenderResponse());
-	}
-
-	private static final String _DISPLAY_CONTEXT_ATTRIBUTE_NAME =
-		"com.liferay.journal.web.internal.display.context." +
-			"JournalEditDDMTemplateDisplayContext";
-
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
-
-	@Inject
-	private Portal _portal;
 
 	@Inject(
 		filter = "component.name=com.liferay.journal.web.internal.portlet.JournalPortlet"

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/BaseDDMTemplateMVCRenderCommandTestCase.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/BaseDDMTemplateMVCRenderCommandTestCase.java
@@ -1,0 +1,226 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.dynamic.data.mapping.constants.DDMActionKeys;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
+import com.liferay.journal.constants.JournalConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.test.MockLiferayPortletContext;
+
+import jakarta.portlet.Portlet;
+import jakarta.portlet.RenderRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+/**
+ * @author Jürgen Kappler
+ */
+public abstract class BaseDDMTemplateMVCRenderCommandTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), ddmStructure.getStructureId(),
+			_portal.getClassNameId(JournalArticle.class));
+	}
+
+	protected User addUser() throws Exception {
+		User user = UserTestUtil.addUser(_group.getGroupId());
+
+		_users.add(user);
+
+		return user;
+	}
+
+	protected User addUserWithAddTemplatePermission() throws Exception {
+		return _addUser(
+			JournalConstants.RESOURCE_NAME, ResourceConstants.SCOPE_GROUP,
+			String.valueOf(_group.getGroupId()), DDMActionKeys.ADD_TEMPLATE);
+	}
+
+	protected User addUserWithUpdatePermission() throws Exception {
+		return _addUser(
+			ResourceActionsUtil.getCompositeModelName(
+				JournalArticle.class.getName(), DDMTemplate.class.getName()),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(ddmTemplate.getTemplateId()), ActionKeys.UPDATE);
+	}
+
+	protected void assertDDMTemplateDisplayContext(
+		RenderRequest renderRequest) {
+
+		Assert.assertNotNull(
+			renderRequest.getAttribute(_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+	}
+
+	protected void assertNoDDMTemplateDisplayContext(
+		RenderRequest renderRequest) {
+
+		Assert.assertNull(
+			renderRequest.getAttribute(_DISPLAY_CONTEXT_ATTRIBUTE_NAME));
+	}
+
+	protected void assertSessionError(
+		RenderRequest renderRequest, Class<?> clazz) {
+
+		Assert.assertTrue(SessionErrors.contains(renderRequest, clazz));
+	}
+
+	protected MockLiferayPortletRenderRequest
+			getMockLiferayPortletRenderRequest(User user)
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		for (String path :
+				new String[] {
+					"/ddm_template/edit_properties.jsp",
+					"/edit_ddm_template.jsp", "/error.jsp"
+				}) {
+
+			mockLiferayPortletRenderRequest.setAttribute(
+				MVCRenderConstants.
+					PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX +
+						path,
+				new MockLiferayPortletContext(path));
+		}
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setUser(user);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockLiferayPortletRenderRequest;
+	}
+
+	protected String render(RenderRequest renderRequest) throws Exception {
+		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
+
+		MockLiferayPortletRenderResponse mockLiferayPortletRenderResponse =
+			new MockLiferayPortletRenderResponse();
+
+		mvcPortlet.render(renderRequest, mockLiferayPortletRenderResponse);
+
+		return (String)renderRequest.getAttribute(
+			StringBundler.concat(
+				mockLiferayPortletRenderResponse.getNamespace(),
+				StringPool.PERIOD,
+				MVCRenderConstants.MVC_PATH_REQUEST_ATTRIBUTE_NAME));
+	}
+
+	protected DDMTemplate ddmTemplate;
+
+	private User _addUser(
+			String resourceName, int scope, String primKey, String actionId)
+		throws Exception {
+
+		User user = addUser();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), resourceName, scope, primKey,
+			role.getRoleId(), new String[] {actionId});
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return user;
+	}
+
+	private static final String _DISPLAY_CONTEXT_ATTRIBUTE_NAME =
+		"com.liferay.journal.web.internal.display.context." +
+			"JournalEditDDMTemplateDisplayContext";
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject(
+		filter = "component.name=com.liferay.journal.web.internal.portlet.JournalPortlet"
+	)
+	private Portlet _portlet;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@DeleteAfterTestRun
+	private final List<Role> _roles = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/EditDDMTemplateMVCRenderCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/EditDDMTemplateMVCRenderCommandTest.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.exception.NoSuchTemplateException;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class EditDDMTemplateMVCRenderCommandTest
+	extends BaseDDMTemplateMVCRenderCommandTestCase {
+
+	@Test
+	public void testRender() throws Exception {
+		_testRenderWithAddTemplatePermission();
+		_testRenderWithMVCPath();
+		_testRenderWithNonexistentDDMTemplate();
+		_testRenderWithoutAddTemplatePermission();
+		_testRenderWithoutUpdatePermission();
+		_testRenderWithUpdatePermission();
+	}
+
+	private void _testRenderWithAddTemplatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(
+				addUserWithAddTemplatePermission());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", _MVC_RENDER_COMMAND_NAME);
+
+		Assert.assertEquals(
+			"/edit_ddm_template.jsp", render(mockLiferayPortletRenderRequest));
+
+		assertDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private void _testRenderWithMVCPath() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(addUser());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcPath", "/edit_ddm_template.jsp");
+
+		Assert.assertNull(render(mockLiferayPortletRenderRequest));
+
+		assertNoDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private void _testRenderWithNonexistentDDMTemplate() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(addUser());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(RandomTestUtil.randomLong()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", _MVC_RENDER_COMMAND_NAME);
+
+		Assert.assertEquals(
+			"/error.jsp", render(mockLiferayPortletRenderRequest));
+
+		assertSessionError(
+			mockLiferayPortletRenderRequest, NoSuchTemplateException.class);
+
+		assertNoDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private void _testRenderWithoutAddTemplatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(addUser());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", _MVC_RENDER_COMMAND_NAME);
+
+		Assert.assertEquals(
+			"/error.jsp", render(mockLiferayPortletRenderRequest));
+
+		assertSessionError(
+			mockLiferayPortletRenderRequest,
+			PrincipalException.MustHavePermission.class);
+
+		assertNoDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private void _testRenderWithoutUpdatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(addUser());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", _MVC_RENDER_COMMAND_NAME);
+
+		Assert.assertEquals(
+			"/error.jsp", render(mockLiferayPortletRenderRequest));
+
+		assertSessionError(
+			mockLiferayPortletRenderRequest,
+			PrincipalException.MustHavePermission.class);
+
+		assertNoDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private void _testRenderWithUpdatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(addUserWithUpdatePermission());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", _MVC_RENDER_COMMAND_NAME);
+
+		Assert.assertEquals(
+			"/edit_ddm_template.jsp", render(mockLiferayPortletRenderRequest));
+
+		assertDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private static final String _MVC_RENDER_COMMAND_NAME =
+		"/journal/edit_ddm_template";
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/EditDDMTemplatePropertiesMVCRenderCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/EditDDMTemplatePropertiesMVCRenderCommandTest.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class EditDDMTemplatePropertiesMVCRenderCommandTest
+	extends BaseDDMTemplateMVCRenderCommandTestCase {
+
+	@Test
+	public void testRender() throws Exception {
+		_testRenderWithoutUpdatePermission();
+		_testRenderWithUpdatePermission();
+	}
+
+	private void _testRenderWithoutUpdatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(addUser());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", _MVC_RENDER_COMMAND_NAME);
+
+		Assert.assertEquals(
+			"/error.jsp", render(mockLiferayPortletRenderRequest));
+
+		assertSessionError(
+			mockLiferayPortletRenderRequest,
+			PrincipalException.MustHavePermission.class);
+
+		assertNoDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private void _testRenderWithUpdatePermission() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			getMockLiferayPortletRenderRequest(addUserWithUpdatePermission());
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"ddmTemplateId", String.valueOf(ddmTemplate.getTemplateId()));
+		mockLiferayPortletRenderRequest.setParameter(
+			"mvcRenderCommandName", _MVC_RENDER_COMMAND_NAME);
+
+		Assert.assertEquals(
+			"/ddm_template/edit_properties.jsp",
+			render(mockLiferayPortletRenderRequest));
+
+		assertDDMTemplateDisplayContext(mockLiferayPortletRenderRequest);
+	}
+
+	private static final String _MVC_RENDER_COMMAND_NAME =
+		"/journal/edit_ddm_template_properties";
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateManagementToolbarDisplayContext.java
@@ -116,9 +116,9 @@ public class JournalDDMTemplateManagementToolbarDisplayContext
 		return CreationMenuBuilder.addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setHref(
-					liferayPortletResponse.createRenderURL(), "mvcPath",
-					"/edit_ddm_template.jsp", "redirect",
-					themeDisplay.getURLCurrent(), "classPK",
+					liferayPortletResponse.createRenderURL(),
+					"mvcRenderCommandName", "/journal/edit_ddm_template",
+					"redirect", themeDisplay.getURLCurrent(), "classPK",
 					_journalDDMTemplateDisplayContext.getClassPK());
 				dropdownItem.setLabel(
 					LanguageUtil.format(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1280,8 +1280,8 @@ public class JournalEditArticleDisplayContext {
 			"editDDMTemplateURL",
 			() -> PortletURLBuilder.createRenderURL(
 				_liferayPortletResponse
-			).setMVCPath(
-				"/edit_ddm_template.jsp"
+			).setMVCRenderCommandName(
+				"/journal/edit_ddm_template"
 			).setRedirect(
 				_themeDisplay.getURLCurrent()
 			).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
@@ -151,12 +151,14 @@ public class JournalEditDDMTemplateDisplayContext {
 			"propertiesViewURL",
 			() -> PortletURLBuilder.createRenderURL(
 				_renderResponse
-			).setMVCPath(
-				"/ddm_template/edit_properties.jsp"
+			).setMVCRenderCommandName(
+				"/journal/edit_ddm_template"
 			).setParameter(
 				"classPK", getClassPK()
 			).setParameter(
 				"ddmTemplateId", getDDMTemplateId()
+			).setParameter(
+				"editProperties", true
 			).setWindowState(
 				LiferayWindowState.EXCLUSIVE
 			).buildString()

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
@@ -152,13 +152,11 @@ public class JournalEditDDMTemplateDisplayContext {
 			() -> PortletURLBuilder.createRenderURL(
 				_renderResponse
 			).setMVCRenderCommandName(
-				"/journal/edit_ddm_template"
+				"/journal/edit_ddm_template_properties"
 			).setParameter(
 				"classPK", getClassPK()
 			).setParameter(
 				"ddmTemplateId", getDDMTemplateId()
-			).setParameter(
-				"editProperties", true
 			).setWindowState(
 				LiferayWindowState.EXCLUSIVE
 			).buildString()

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalDDMTemplateVerticalCard.java
@@ -78,8 +78,8 @@ public class JournalDDMTemplateVerticalCard extends BaseVerticalCard {
 
 			return PortletURLBuilder.createRenderURL(
 				_renderResponse
-			).setMVCPath(
-				"/edit_ddm_template.jsp"
+			).setMVCRenderCommandName(
+				"/journal/edit_ddm_template"
 			).setRedirect(
 				themeDisplay.getURLCurrent()
 			).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
@@ -62,8 +62,6 @@ import com.liferay.journal.util.JournalHelper;
 import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
 import com.liferay.journal.web.internal.display.context.JournalDisplayContext;
 import com.liferay.journal.web.internal.display.context.JournalEditDDMStructuresDisplayContext;
-import com.liferay.journal.web.internal.display.context.JournalEditDDMTemplateDisplayContext;
-import com.liferay.journal.web.internal.helper.JournalDDMTemplateHelper;
 import com.liferay.journal.web.internal.portlet.action.ActionUtil;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.exception.LocaleException;
@@ -213,16 +211,6 @@ public class JournalPortlet extends MVCPortlet {
 					JournalEditDDMStructuresDisplayContext.class.getName(),
 					new JournalEditDDMStructuresDisplayContext(
 						_portal, renderRequest, renderResponse));
-			}
-			else if (Objects.equals(
-						path, "/ddm_template/edit_properties.jsp") ||
-					 Objects.equals(path, "/edit_ddm_template.jsp")) {
-
-				renderRequest.setAttribute(
-					JournalEditDDMTemplateDisplayContext.class.getName(),
-					new JournalEditDDMTemplateDisplayContext(
-						_ddmTemplateHelper, _journalDDMTemplateHelper, _portal,
-						renderRequest, renderResponse));
 			}
 		}
 		catch (ConfigurationException configurationException) {
@@ -438,9 +426,6 @@ public class JournalPortlet extends MVCPortlet {
 
 	@Reference
 	private JournalConverter _journalConverter;
-
-	@Reference
-	private JournalDDMTemplateHelper _journalDDMTemplateHelper;
 
 	@Reference
 	private JournalFolderService _journalFolderService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AddDDMTemplateMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AddDDMTemplateMVCActionCommand.java
@@ -156,8 +156,8 @@ public class AddDDMTemplateMVCActionCommand extends BaseMVCActionCommand {
 				WebKeys.REDIRECT,
 				PortletURLBuilder.createRenderURL(
 					_portal.getLiferayPortletResponse(actionResponse)
-				).setMVCPath(
-					"/edit_ddm_template.jsp"
+				).setMVCRenderCommandName(
+					"/journal/edit_ddm_template"
 				).setRedirect(
 					ParamUtil.getString(uploadPortletRequest, "redirect")
 				).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/BaseDDMTemplateMVCRenderCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/BaseDDMTemplateMVCRenderCommand.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action;
+
+import com.liferay.dynamic.data.mapping.constants.DDMActionKeys;
+import com.liferay.dynamic.data.mapping.exception.NoSuchTemplateException;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.util.DDMTemplateHelper;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.web.internal.display.context.JournalEditDDMTemplateDisplayContext;
+import com.liferay.journal.web.internal.helper.JournalDDMTemplateHelper;
+import com.liferay.journal.web.internal.security.permission.resource.DDMTemplatePermission;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletException;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Shakir Shamim
+ */
+public abstract class BaseDDMTemplateMVCRenderCommand
+	implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		try {
+			_checkDDMTemplatePermission(
+				portal.getHttpServletRequest(renderRequest));
+
+			renderRequest.setAttribute(
+				JournalEditDDMTemplateDisplayContext.class.getName(),
+				new JournalEditDDMTemplateDisplayContext(
+					ddmTemplateHelper, journalDDMTemplateHelper, portal,
+					renderRequest, renderResponse));
+		}
+		catch (Exception exception) {
+			if (exception instanceof NoSuchTemplateException ||
+				exception instanceof PrincipalException) {
+
+				SessionErrors.add(renderRequest, exception.getClass());
+
+				return "/error.jsp";
+			}
+
+			throw new PortletException(exception);
+		}
+
+		return getPath();
+	}
+
+	protected abstract String getPath();
+
+	@Reference
+	protected DDMTemplateHelper ddmTemplateHelper;
+
+	@Reference
+	protected JournalDDMTemplateHelper journalDDMTemplateHelper;
+
+	@Reference
+	protected Portal portal;
+
+	private void _checkDDMTemplatePermission(
+			HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		long ddmTemplateId = ParamUtil.getLong(
+			httpServletRequest, "ddmTemplateId");
+
+		if (ddmTemplateId > 0) {
+			if (!DDMTemplatePermission.contains(
+					themeDisplay.getPermissionChecker(), ddmTemplateId,
+					ActionKeys.UPDATE)) {
+
+				throw new PrincipalException.MustHavePermission(
+					themeDisplay.getPermissionChecker(),
+					DDMTemplate.class.getName(), ddmTemplateId,
+					ActionKeys.UPDATE);
+			}
+
+			return;
+		}
+
+		if (!DDMTemplatePermission.containsAddTemplatePermission(
+				themeDisplay.getPermissionChecker(),
+				themeDisplay.getScopeGroupId(),
+				portal.getClassNameId(DDMStructure.class),
+				portal.getClassNameId(JournalArticle.class))) {
+
+			throw new PrincipalException.MustHavePermission(
+				themeDisplay.getPermissionChecker(),
+				DDMActionKeys.ADD_TEMPLATE);
+		}
+	}
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditDDMTemplateMVCRenderCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditDDMTemplateMVCRenderCommand.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action;
+
+import com.liferay.dynamic.data.mapping.constants.DDMActionKeys;
+import com.liferay.dynamic.data.mapping.exception.NoSuchTemplateException;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.util.DDMTemplateHelper;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.web.internal.display.context.JournalEditDDMTemplateDisplayContext;
+import com.liferay.journal.web.internal.helper.JournalDDMTemplateHelper;
+import com.liferay.journal.web.internal.security.permission.resource.DDMTemplatePermission;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletException;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Shakir Shamim
+ */
+@Component(
+	property = {
+		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"mvc.command.name=/journal/edit_ddm_template"
+	},
+	service = MVCRenderCommand.class
+)
+public class EditDDMTemplateMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			renderRequest);
+
+		try {
+			_checkDDMTemplateUpdatePermission(httpServletRequest);
+
+			renderRequest.setAttribute(
+				JournalEditDDMTemplateDisplayContext.class.getName(),
+				new JournalEditDDMTemplateDisplayContext(
+					_ddmTemplateHelper, _journalDDMTemplateHelper, _portal,
+					renderRequest, renderResponse));
+		}
+		catch (Exception exception) {
+			if (exception instanceof NoSuchTemplateException ||
+				exception instanceof PrincipalException) {
+
+				SessionErrors.add(renderRequest, exception.getClass());
+
+				return "/error.jsp";
+			}
+
+			throw new PortletException(exception);
+		}
+
+		if (ParamUtil.getBoolean(httpServletRequest, "editProperties")) {
+			return "/ddm_template/edit_properties.jsp";
+		}
+
+		return "/edit_ddm_template.jsp";
+	}
+
+	private void _checkDDMTemplateUpdatePermission(
+			HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		long ddmTemplateId = ParamUtil.getLong(
+			httpServletRequest, "ddmTemplateId");
+
+		if (ddmTemplateId > 0) {
+			if (!DDMTemplatePermission.contains(
+					themeDisplay.getPermissionChecker(), ddmTemplateId,
+					ActionKeys.UPDATE)) {
+
+				throw new PrincipalException.MustHavePermission(
+					themeDisplay.getPermissionChecker(),
+					DDMTemplate.class.getName(), ddmTemplateId,
+					ActionKeys.UPDATE);
+			}
+
+			return;
+		}
+
+		if (!DDMTemplatePermission.containsAddTemplatePermission(
+				themeDisplay.getPermissionChecker(),
+				themeDisplay.getScopeGroupId(),
+				_portal.getClassNameId(DDMStructure.class),
+				_portal.getClassNameId(JournalArticle.class))) {
+
+			throw new PrincipalException.MustHavePermission(
+				themeDisplay.getPermissionChecker(),
+				DDMActionKeys.ADD_TEMPLATE);
+		}
+	}
+
+	@Reference
+	private DDMTemplateHelper _ddmTemplateHelper;
+
+	@Reference
+	private JournalDDMTemplateHelper _journalDDMTemplateHelper;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditDDMTemplatePropertiesMVCRenderCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditDDMTemplatePropertiesMVCRenderCommand.java
@@ -11,21 +11,21 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author Shakir Shamim
+ * @author Jürgen Kappler
  */
 @Component(
 	property = {
 		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
-		"mvc.command.name=/journal/edit_ddm_template"
+		"mvc.command.name=/journal/edit_ddm_template_properties"
 	},
 	service = MVCRenderCommand.class
 )
-public class EditDDMTemplateMVCRenderCommand
+public class EditDDMTemplatePropertiesMVCRenderCommand
 	extends BaseDDMTemplateMVCRenderCommand {
 
 	@Override
 	protected String getPath() {
-		return "/edit_ddm_template.jsp";
+		return "/ddm_template/edit_properties.jsp";
 	}
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDDMTemplateMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDDMTemplateMVCActionCommand.java
@@ -99,8 +99,8 @@ public class UpdateDDMTemplateMVCActionCommand extends BaseMVCActionCommand {
 				WebKeys.REDIRECT,
 				PortletURLBuilder.createRenderURL(
 					_portal.getLiferayPortletResponse(actionResponse)
-				).setMVCPath(
-					"/edit_ddm_template.jsp"
+				).setMVCRenderCommandName(
+					"/journal/edit_ddm_template"
 				).setRedirect(
 					ParamUtil.getString(uploadPortletRequest, "redirect")
 				).setParameter(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateExportScriptConfigurationIcon.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateExportScriptConfigurationIcon.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
-		"path=/edit_ddm_template.jsp"
+		"path=/journal/edit_ddm_template"
 	},
 	service = PortletConfigurationIcon.class
 )

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateImportScriptConfigurationIcon.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/JournalDDMTemplateImportScriptConfigurationIcon.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
-		"path=/edit_ddm_template.jsp"
+		"path=/journal/edit_ddm_template"
 	},
 	service = PortletConfigurationIcon.class
 )

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalDDMTemplateActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalDDMTemplateActionDropdownItemsProvider.java
@@ -152,8 +152,8 @@ public class JournalDDMTemplateActionDropdownItemsProvider {
 
 		return dropdownItem -> {
 			dropdownItem.setHref(
-				_renderResponse.createRenderURL(), "mvcPath",
-				"/edit_ddm_template.jsp", "redirect",
+				_renderResponse.createRenderURL(), "mvcRenderCommandName",
+				"/journal/edit_ddm_template", "redirect",
 				_themeDisplay.getURLCurrent(), "ddmTemplateId",
 				_ddmTemplate.getTemplateId());
 			dropdownItem.setIcon("pencil");

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/edit_properties.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/edit_properties.jsp
@@ -7,10 +7,14 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+JournalEditDDMTemplateDisplayContext journalEditDDMTemplateDisplayContext = (JournalEditDDMTemplateDisplayContext)request.getAttribute(JournalEditDDMTemplateDisplayContext.class.getName());
+%>
+
 <div class="journal-ddm-template-properties">
 	<liferay-frontend:form-navigator
 		fieldSetCssClass="form-group-sm mb-0 panel-group-flush"
-		formModelBean='<%= DDMTemplateLocalServiceUtil.fetchDDMTemplate(ParamUtil.getLong(request, "ddmTemplateId")) %>'
+		formModelBean="<%= journalEditDDMTemplateDisplayContext.getDDMTemplate() %>"
 		id="<%= JournalWebConstants.FORM_NAVIGATOR_ID_JOURNAL_DDM_TEMPLATE %>"
 		showButtons="<%= false %>"
 	/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -26,11 +26,11 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 %>
 
 <portlet:actionURL name="/journal/add_ddm_template" var="addDDMTemplateURL">
-	<portlet:param name="mvcPath" value="/edit_ddm_template.jsp" />
+	<portlet:param name="mvcRenderCommandName" value="/journal/edit_ddm_template" />
 </portlet:actionURL>
 
 <portlet:actionURL name="/journal/update_ddm_template" var="updateDDMTemplateURL">
-	<portlet:param name="mvcPath" value="/edit_ddm_template.jsp" />
+	<portlet:param name="mvcRenderCommandName" value="/journal/edit_ddm_template" />
 </portlet:actionURL>
 
 <aui:form action="<%= (ddmTemplate == null) ? addDDMTemplateURL : updateDDMTemplateURL %>" cssClass="edit-article-form" enctype="multipart/form-data" method="post" name="fm" onSubmit="event.preventDefault();">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
@@ -59,8 +59,8 @@ if (ddmStructure != null) {
 			if (DDMTemplatePermission.contains(permissionChecker, ddmTemplate, ActionKeys.UPDATE)) {
 				rowHREF = PortletURLBuilder.createRenderURL(
 					renderResponse
-				).setMVCPath(
-					"/edit_ddm_template.jsp"
+				).setMVCRenderCommandName(
+					"/journal/edit_ddm_template"
 				).setRedirect(
 					currentURL
 				).setParameter(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98151

Supersedes #8686, which could not be pushed to. The first five commits are @Shakir-Shamim's work, rebased onto master; the last two are mine.

## What Is Being Fixed

The web content template edit view and its properties panel were served without checking whether the current user is allowed to update the template. The save path already enforced this: `DDMTemplateServiceImpl.updateTemplate` requires `UPDATE`, and `addTemplate` calls `checkAddTemplatePermission`. The render path enforced nothing, so a user who could not save a template could still open its editor. This brings the render path in line with the save path.

## How It Is Being Fixed

Following `EditFolderMVCRenderCommand` in document-library and `EditNodeMVCRenderCommand` in wiki, the two views now have dedicated render commands that check before building the display context, over a shared `BaseDDMTemplateMVCRenderCommand`:

- `UPDATE` on the template when `ddmTemplateId` is given.
- `ADD_TEMPLATE` on the scope group otherwise. This closes the previous `ddmTemplateId <= 0` early return, which left the new-template path unchecked, since `ParamUtil.getLong` returns `0` for an absent value.

`NoSuchTemplateException` and `PrincipalException` route to `/error.jsp` with a session error, matching `EditNodeMVCRenderCommand`.

Two consequences worth a reviewer's attention:

**The properties panel moved onto its own command.** `/ddm_template/edit_properties.jsp` previously loaded the template through `DDMTemplateLocalServiceUtil.fetchDDMTemplate(ParamUtil.getLong(request, "ddmTemplateId"))`, unchecked and straight from a request parameter. It now reads the template from the display context, so it cannot render for a request that did not pass the check. It is served by `EditDDMTemplatePropertiesMVCRenderCommand` rather than by a flag on the edit command, because a boolean request parameter deciding which JSP a render command returns is not a pattern used elsewhere.

**The script icons were repointed.** `PortletConfigurationIconTracker` matches icons against the value of whichever path parameter the URL carries, so `JournalDDMTemplateImportScriptConfigurationIcon` and `JournalDDMTemplateExportScriptConfigurationIcon` moved from `path=/edit_ddm_template.jsp` to `path=/journal/edit_ddm_template`, matching the sibling `path=/journal/edit_article` icons. Without this the vertical-ellipsis menu disappears from the editor.

## Tests

```
gradlew -p modules/apps/journal/journal-test testIntegration --tests EditDDMTemplateMVCRenderCommandTest
gradlew -p modules/apps/journal/journal-test testIntegration --tests EditDDMTemplatePropertiesMVCRenderCommandTest
gradlew -p modules/apps/journal/journal-test testIntegration --tests JournalEditDDMTemplateDisplayContextTest
```

`EditDDMTemplateMVCRenderCommandTest` and `EditDDMTemplatePropertiesMVCRenderCommandTest` cover each view with and without the required permission, plus an unknown `ddmTemplateId` and a request that carries only `mvcPath`. Positive cases grant only the action under test to a fresh role rather than running as an administrator, and every case asserts which JSP was dispatched.

Gating the edit view on `DELETE` instead of `UPDATE` is a check an administrator still satisfies. Both `testRender` methods fail under it.

## PR Check

**pr-check: PASS** — tested on `4bb856d1948dbc9748e84447989bcecaad4e0ea4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Portlet Title | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4bb856d1948dbc9748e84447989bcecaad4e0ea4"} -->
