### PR TITLE
LPD-99742 Fix disappearing referenced structure field

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -172,6 +172,43 @@ public class UpdateStructureStrutsActionTest {
 				objectRelationship.getObjectRelationshipId()));
 	}
 
+	@Test
+	@TestInfo("LPD-99742")
+	public void testExecuteDoesNotDeleteReferencedStructureRelationship()
+		throws Exception {
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				_objectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertTrue(objectRelationship.isEdge());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			_getMockHttpServletRequest(_objectDefinition2),
+			mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+	}
+
 	private HttpServletRequest _getMockHttpServletRequest(
 			com.liferay.object.model.ObjectDefinition objectDefinition)
 		throws Exception {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -140,41 +140,9 @@ public class UpdateStructureStrutsActionTest {
 			serviceBuilderObjectDefinition2.getObjectDefinitionId());
 	}
 
-	@FeatureFlag("LPD-17564")
-	@Test
-	@TestInfo("LPD-92696")
-	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
-
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, _objectDefinition1,
-				_objectDefinition2);
-
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		_updateStructureStrutsAction.execute(
-			_getMockHttpServletRequest(_objectDefinition1),
-			mockHttpServletResponse);
-
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			mockHttpServletResponse.getContentAsString());
-
-		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
-
-		Assert.assertNotNull(
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationship.getObjectFieldId2()));
-		Assert.assertNotNull(
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
-	}
-
 	@Test
 	@TestInfo("LPD-99742")
-	public void testExecuteDoesNotDeleteReferencedStructureRelationship()
+	public void testExecuteDoesNotDeleteEdgeObjectRelationships()
 		throws Exception {
 
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
@@ -204,6 +172,38 @@ public class UpdateStructureStrutsActionTest {
 
 		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
 
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-92696")
+	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition2);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			_getMockHttpServletRequest(_objectDefinition1),
+			mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNotNull(
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationship.getObjectFieldId2()));
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
 				objectRelationship.getObjectRelationshipId()));

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -125,9 +125,8 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 
 		for (com.liferay.object.model.ObjectRelationship
 				serviceBuilderObjectRelationship :
-					_objectRelationshipLocalService.
-						getObjectRelationshipsByObjectDefinitionId2(
-							objectDefinitionId, true)) {
+					_objectRelationshipLocalService.getObjectRelationships(
+						objectDefinitionId, true)) {
 
 			if (serviceBuilderObjectRelationship.isReverse()) {
 				continue;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99742

## What Is Being Fixed

A structure with a "Referenced Content Structure" field pointing at another, already-published structure would silently lose that reference field after the referenced structure was edited and republished.

## How It Is Being Fixed

`UpdateStructureStrutsAction`'s relationship cleanup step queried edge relationships by the wrong side of the relationship (`objectDefinitionId2`, the referenced/target structure) instead of the side that owns the edge (`objectDefinitionId1`), so saving the referenced structure deleted every other structure's reference to it instead of only its own outgoing references. Querying by the owning side instead fixes this. A new integration test covers the scenario, since no existing test exercised an edge relationship where the edited structure is the target.

## PR Check

**pr-check: PASS** — tested on `22d107ddda93712cfdc794efbd7ceed40dc77d5f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "22d107ddda93712cfdc794efbd7ceed40dc77d5f"} -->
