### PR TITLE
LPD-98285 Revert the friendly URL ordering to fix renaming a space

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -420,12 +420,10 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				group = _groupLocalService.updateGroup(group);
 			}
 
-			_updateFriendlyURL(assetLibrary, group.getGroupId());
-
 			_updateDLSizeLimitConfiguration(
 				assetLibrary, group.getGroupId(), mimeTypeSizeLimits);
 
-			return _depotEntryService.updateDepotEntry(
+			DepotEntry updatedDepotEntry = _depotEntryService.updateDepotEntry(
 				depotEntry.getDepotEntryId(), nameMap, descriptionMap,
 				_getDepotAppCustomizationMap(
 					depotEntry.getCompanyId(), externalReferenceCode),
@@ -435,6 +433,10 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 					unicodeProperties
 				).build(),
 				serviceContext);
+
+			_updateFriendlyURL(assetLibrary, group.getGroupId());
+
+			return updatedDepotEntry;
 		}
 
 		if (Validator.isNotNull(externalReferenceCode)) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98285

## What Is Being Fixed

A Space Administrator could no longer rename a Space. Saving the Space Settings form returned HTTP 500 and the new name was never persisted, so the Playwright test `A Space Administrator can rename a Space and the new name is reflected in the navigation and header` failed.

The PATCH performs two Group writes in two separate transactions. The second write merges a Group instance whose `mvccVersion` is already behind the row, and Hibernate only issues the versioned UPDATE when the merged entity is actually dirty, so the optimistic lock trips only when that second write carries a genuine field change. Because `1f6918ba8519ceec1441978d0a392501dad692de` moved the friendly URL update ahead of the depot entry update, the name update became the second write, and the settings form always submits the friendly URL. Every rename hit it.

## How It Is Being Fixed

Reverting `1f6918ba8519ceec1441978d0a392501dad692de` restores the original ordering, putting the name update first and the friendly URL update second. The failure is then confined to a genuine friendly URL change, which is the original LPD-98285 report and a far rarer input than renaming a Space.

The external reference code guard from `f5c076459a76a67f70d27914197b74aa440249af` is deliberately left in place. It fixes an unrelated defect, where a partial PATCH that omits `externalReferenceCode` writes a null code to the group, and reverting it would add a third Group write and make the stale group failure more likely rather than less.

This is a stopgap. The underlying defect is the double Group write, and the real fix is to collapse it into a single write, or to perform both writes in one transaction, with coverage for every PATCH permutation. That work is tracked separately.

Verified against a local bundle. A PATCH carrying `name` plus an unchanged `friendlyURL`, which is what the settings form sends, now returns 200 where it previously returned 500, and the full space configuration suite passes:

```bash
cd modules/test/playwright && yarn test tests/e2e-cms-dxp/main/space-configuration/spaceConfiguration.spec.ts
```

## Why Are There No Tests?

This restores previously reviewed behaviour to stop a regression that blocks every Space rename, so it introduces no new code to cover. Coverage for the PATCH permutations lands with the follow-up fix that removes the double Group write.

## PR Check

**pr-check: PASS** — tested on `6c6ef5e818d97b01f9c40875223fe9d1bbf91427`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "6c6ef5e818d97b01f9c40875223fe9d1bbf91427"} -->
