### PR TITLE
LPD-99949 Fix flaky CMS categorization and members tests

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -756,7 +756,7 @@ systemCategoryTest.describe('System category tests', () => {
 					assetLibraries: [{id: -1}],
 					assetTypes: [
 						{
-							required: true,
+							required: false,
 							subtype: 'AllAssetSubtypes',
 							type: 'AllAssetTypes',
 						},

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -896,7 +896,7 @@ systemVocabularyTest.describe('System vocabulary tests', () => {
 				assetLibraries: [{id: -1}],
 				assetTypes: [
 					{
-						required: true,
+						required: false,
 						subtype: 'AllAssetSubtypes',
 						type: 'AllAssetTypes',
 					},

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -79,6 +79,13 @@ export class SpaceSummaryPage {
 		}).toPass();
 	}
 
+	async closeMembersDialog() {
+		await Promise.all([
+			this.page.waitForEvent('load', {timeout: 15000}),
+			this.closeButton.click(),
+		]);
+	}
+
 	async openMembersDialog() {
 		await clickAndExpectToBeVisible({
 			target: this.page.getByRole('dialog'),
@@ -174,7 +181,7 @@ export class SpaceSummaryPage {
 			{autoClose: false}
 		);
 
-		await this.closeButton.click();
+		await this.closeMembersDialog();
 	}
 
 	async createContentFolder(name: string) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/members.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/members.spec.ts
@@ -83,7 +83,7 @@ test(
 			page.getByRole('listitem').filter({hasText: userFullName})
 		).toHaveCount(1);
 
-		await spaceSummaryPage.closeButton.click();
+		await spaceSummaryPage.closeMembersDialog();
 
 		await spaceSummaryPage.removeUserOrUserGroup(userFullName, 'users');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99949

## What Is Being Fixed

Two CMS test failures that only reproduce once other tests have run first.

The System category and System vocabulary fixtures in the categorization specs created their vocabulary with a required asset type. Neither a system category nor a system vocabulary can be deleted, so the automatic cleanup of the vocabulary fails silently and the vocabulary outlives the run. Because it covers all asset types in all Spaces and demands a category, every later test that publishes content in the CMS is rejected with "Please enter at least one category for all mandatory vocabularies". That is what broke "Hide a Space-restricted vocabulary from content in another Space" and "Hide an asset-type-restricted vocabulary from content of another asset type", which publish content without selecting a category, and it explains why they only fail on some runs: the leftover vocabularies are only present when the categories spec ran earlier in the same batch.

Separately, closing the Space members dialog reloads the page, so clicking the close button and acting on the page straight afterwards raced with that navigation.

## How It Is Being Fixed

The two fixtures now create their vocabulary without the required asset type. No test in those describes ever asserted the flag — they cover system behaviour such as the lock icon, the disabled fields and the hidden actions — and the vocabularies the product itself seeds for system use are not required either, so dropping it also brings the fixtures closer to real data. The leftover vocabularies still survive, because a system category and a system vocabulary cannot be deleted by design, but they are now inert.

The members dialog gains a `closeMembersDialog` helper that waits for the reload alongside the close click, and the spec calls it instead of clicking the close button directly.

## Why Are There No Tests?

These commits only change Playwright tests in order to fix flaky failures, so there is no product change to cover.

## PR Check

**pr-check: PASS** — tested on `60e2b91cf789d25c1e5834449677d3b8cd769946`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "60e2b91cf789d25c1e5834449677d3b8cd769946"} -->
