### PR TITLE
LPD-98562 Fetch the guest download from the page origin

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/getAsGuest.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/getAsGuest.ts
@@ -5,14 +5,14 @@
 
 import {Browser} from '@playwright/test';
 
-// Sends a GET request as an anonymous client (no credentials). The request runs
-// inside a fresh browser context with an empty storage state, from the portal
-// origin so relative paths resolve. redirect: 'manual' keeps an authentication
-// redirect from being silently followed into a 200.
+// Sends a GET request as an anonymous client, from a fresh browser context with
+// an empty storage state. An absolute URL is reduced to its path to keep the
+// request same-origin, and redirect: 'manual' keeps an authentication redirect
+// from being followed into a 200.
 
 export async function getAsGuest(
 	browser: Browser,
-	path: string
+	url: string
 ): Promise<{body: Record<string, unknown> | null; status: number}> {
 	const context = await browser.newContext({
 		storageState: {cookies: [], origins: []},
@@ -23,8 +23,10 @@ export async function getAsGuest(
 
 		await page.goto('/');
 
-		return await page.evaluate(async (url) => {
-			const response = await fetch(url, {redirect: 'manual'});
+		const {pathname, search} = new URL(url, page.url());
+
+		return await page.evaluate(async (path) => {
+			const response = await fetch(path, {redirect: 'manual'});
 
 			const contentType = response.headers.get('content-type') || '';
 
@@ -36,7 +38,7 @@ export async function getAsGuest(
 				: null;
 
 			return {body, status: response.status};
-		}, path);
+		}, pathname + search);
 	}
 	finally {
 		await context.close();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98562

## What Is Being Fixed

The test "An anonymous client can read a published Structured Content entry with all field values through the headless API" fails in CI with `TypeError: Failed to fetch` on the attachment download, while it passes locally.

The `fileURL` of an attachment field is absolute and built server side from the company virtual hostname (`ExportImportAttachmentManagerImpl._getURL` calls `Portal.getPortalURL(company.getVirtualHostname(), ...)`), so it always points at `localhost`. CI reaches the portal through the node hostname instead (`PORTAL_URL=http://$(hostname):8080` in `modules/test/playwright/env/set_up.sh`, `PORTAL_URL=http://${env.NODE_NAME}:8080` in `build-test.xml`), so the `fetch` issued from inside the page was cross origin. The portal sends no CORS headers for `/documents`, the browser blocked the response, and the promise rejected. Locally both sides are `localhost:8080`, the request stays same origin, and the test always passed. The first call of the test is unaffected because it uses a relative path.

## How It Is Being Fixed

`getAsGuest` now reduces the URL it receives to its path and query string before handing it to the page, so the request always goes to the origin the page is already on, whatever host the portal advertises for itself. Relative paths behave as before. The request still runs inside a fresh browser context with an empty storage state, and `redirect: 'manual'` still keeps a redirect from being read as a 200. Playwright's own request context would also sidestep CORS, but `maxRedirects: 0` throws instead of returning the status, which would drop that check.

## Why Are There No Tests?

The whole change is test code: it repairs the helper of an existing Playwright test, which is itself the coverage.

## PR Check

**pr-check: PASS** — tested on `458ca2987d76eee7c43a68ec927af6a800a42919`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "458ca2987d76eee7c43a68ec927af6a800a42919"} -->
