### PR TITLE
LPD-100131 Wait for the CMS folder rename to be stored

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/folder/renameFolder.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/folder/renameFolder.spec.ts
@@ -20,8 +20,8 @@ import {AssetsPage} from '../../../site-cms-site-initializer/main/pages/AssetsPa
 import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
 import {
 	addSpaceUserWithSession,
-	clickItemAction,
-	openFolder,
+	gotoAndOpenFolder,
+	renameFolder,
 } from './utils/folders';
 
 const test = mergeTests(
@@ -176,41 +176,37 @@ test(
 			await test.step('The Space Administrator renames the populated folders', async () => {
 				await spaContentsPage.goto();
 
-				await clickItemAction(spaPage, contentFolderName, 'Edit');
-
-				await spaPage
-					.getByLabel('NameRequired')
-					.fill(renamedContentFolderName);
-
-				await spaPage.getByRole('button', {name: 'Save'}).click();
-
-				await spaPage.waitForURL('**/web/cms/contents**');
+				await renameFolder(
+					spaPage,
+					contentFolderName,
+					renamedContentFolderName
+				);
 
 				await spaAssetsPage.gotoFiles();
 
-				await clickItemAction(spaPage, fileFolderName, 'Edit');
-
-				await spaPage
-					.getByLabel('NameRequired')
-					.fill(renamedFileFolderName);
-
-				await spaPage.getByRole('button', {name: 'Save'}).click();
-
-				await spaPage.waitForURL('**/web/cms/files**');
+				await renameFolder(
+					spaPage,
+					fileFolderName,
+					renamedFileFolderName
+				);
 			});
 
 			await test.step('The items remain accessible inside the renamed folders', async () => {
-				await spaContentsPage.goto();
-
-				await openFolder(spaPage, renamedContentFolderName);
+				await gotoAndOpenFolder(
+					spaPage,
+					() => spaContentsPage.goto(),
+					renamedContentFolderName
+				);
 
 				await expect(
 					spaPage.getByRole('link', {exact: true, name: contentTitle})
 				).toBeVisible({timeout: 5000});
 
-				await spaAssetsPage.gotoFiles();
-
-				await openFolder(spaPage, renamedFileFolderName);
+				await gotoAndOpenFolder(
+					spaPage,
+					() => spaAssetsPage.gotoFiles(),
+					renamedFileFolderName
+				);
 
 				await expect(
 					spaPage.getByRole('button', {

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/folder/utils/folders.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/folder/utils/folders.ts
@@ -56,12 +56,48 @@ export async function deletePopulatedFolder(page: Page, folderName: string) {
 	});
 }
 
+export async function gotoAndOpenFolder(
+	page: Page,
+	gotoList: () => Promise<void>,
+	folderName: string
+) {
+	await expect(async () => {
+		await gotoList();
+
+		await expect(
+			page.getByRole('link', {exact: true, name: folderName})
+		).toBeVisible({timeout: 5000});
+	}).toPass({timeout: 60000});
+
+	await openFolder(page, folderName);
+}
+
 export async function openFolder(page: Page, folderName: string) {
 	await page.getByRole('link', {exact: true, name: folderName}).click();
 
 	await page.waitForURL('**/view-folder/**');
 
 	await page.locator('.fds').waitFor();
+}
+
+export async function renameFolder(
+	page: Page,
+	folderName: string,
+	newName: string
+) {
+	await clickItemAction(page, folderName, 'Edit');
+
+	const nameInput = page.getByLabel('NameRequired');
+
+	await expect(nameInput).toHaveValue(folderName);
+
+	await nameInput.fill(newName);
+
+	await expect(nameInput).toHaveValue(newName);
+
+	await page.getByRole('button', {name: 'Save'}).click();
+
+	await page.waitForURL((url) => !url.pathname.includes('/edit-folder/'));
 }
 
 export async function searchContentList(page: Page, title: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100131

## What Is Being Fixed

The test "Renaming a populated folder keeps its items accessible and mapped page references intact" hung for its full 480 second timeout waiting for the renamed Files folder to show up in the list.

Two independent races were at play. First, the step relied on `waitForURL('**/web/cms/files**')` after clicking Save, but the edit route is `/web/cms/e/edit-folder/<groupId>/<folderId>?redirect=/en/web/cms/files`, so the glob matched the edit URL itself through its `redirect` query parameter and the wait returned immediately. The test navigated away 30 milliseconds after the click and the `PATCH` on the folder was aborted mid flight (`status -1` in the trace), so the folder kept its old name. The Contents folder survived only because the next navigation gave it 240 milliseconds of slack.

Second, `EditFolder.tsx` fills the form from a `useEffect` that runs when the folder data arrives, so a value typed before that hydration is overwritten with the original title. The form then submits the old name and the server answers 200 without changing anything, which reads exactly like a working save.

## How It Is Being Fixed

Both call sites were identical, so the flow moved into a shared `renameFolder` helper in `utils/folders.ts`. It waits for the name field to hold the current folder name, which proves the form is hydrated, fills the new name, verifies the new value survived, and then waits to leave the edit route, which the product only does after the save resolves without error. Opening a renamed folder goes through `gotoAndOpenFolder`, which re-navigates to the list until the renamed folder is listed, since that list is served by `/o/search`.

Verified locally with 20 consecutive passes of the test (`--repeat-each=5` twice and `--repeat-each=10` once, all with `--workers=1`); before the change it failed on every run.

## Why Are There No Tests?

The whole change is test code: it repairs an existing Playwright test and its helper, which are themselves the coverage.

## PR Check

**pr-check: PASS** — tested on `b621a7b886b4ba56862690e81873741e6039e30c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "b621a7b886b4ba56862690e81873741e6039e30c"} -->
