### PR TITLE
LPD-99547 Preserve Root Folder when selectedRepositoryId is missing

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
@@ -154,6 +154,22 @@ public class UpgradePortletPreferencesTest {
 	}
 
 	@Test
+	public void testUpgradeSubfolderSelectedMissingRepository()
+		throws Exception {
+
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		_testUpgrade(
+			HashMapBuilder.put(
+				"rootFolderExternalReferenceCode",
+				folder.getExternalReferenceCode()
+			).build(),
+			HashMapBuilder.put(
+				"rootFolderId", String.valueOf(folder.getFolderId())
+			).build());
+	}
+
+	@Test
 	public void testUpgradeWithoutSelectedFolder() throws Exception {
 		_testUpgrade(Collections.emptyMap(), Collections.emptyMap());
 	}

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/test/UpgradePortletPreferencesTest.java
@@ -154,6 +154,22 @@ public class UpgradePortletPreferencesTest {
 	}
 
 	@Test
+	public void testUpgradeSubfolderSelectedMissingRepository()
+		throws Exception {
+
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		_testUpgrade(
+			HashMapBuilder.put(
+				"rootFolderExternalReferenceCode",
+				folder.getExternalReferenceCode()
+			).build(),
+			HashMapBuilder.put(
+				"rootFolderId", String.valueOf(folder.getFolderId())
+			).build());
+	}
+
+	@Test
 	public void testUpgradeWithoutSelectedFolder() throws Exception {
 		_testUpgrade(Collections.emptyMap(), Collections.emptyMap());
 	}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.portlet.PortletPreferences;
 
@@ -81,6 +82,12 @@ public class UpgradePortletPreferences
 
 				return _toXML(portletPreferences);
 			}
+		}
+
+		if (Validator.isNotNull(rootFolderExternalReferenceCode)) {
+			portletPreferences.setValue(
+				"rootFolderExternalReferenceCode",
+				rootFolderExternalReferenceCode);
 		}
 
 		long selectedRepositoryId = GetterUtil.getLong(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/UpgradePortletPreferences.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/UpgradePortletPreferences.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.portlet.PortletPreferences;
 
@@ -83,6 +84,12 @@ public class UpgradePortletPreferences
 
 				return _toXML(portletPreferences);
 			}
+		}
+
+		if (Validator.isNotNull(rootFolderExternalReferenceCode)) {
+			portletPreferences.setValue(
+				"rootFolderExternalReferenceCode",
+				rootFolderExternalReferenceCode);
 		}
 
 		long selectedRepositoryId = GetterUtil.getLong(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99547

## What Is Being Fixed

The Document and Media display widget's upgrade process (v1_1_0 and v1_2_0) resolved the Root Folder's external reference code but only wrote it back into the portlet preferences after going on to resolve `selectedRepositoryId`. When `selectedRepositoryId` was absent, the upgrade process returned early, discarding the resolved Root Folder value, so the widget lost its Root Folder configuration during upgrade.

## How It Is Being Fixed

Both `UpgradePortletPreferences` classes now write `rootFolderExternalReferenceCode` into the preferences immediately after resolving it, before the `selectedRepositoryId` check, so the Root Folder configuration is preserved regardless of whether a repository was selected. A test was added to each corresponding `UpgradePortletPreferencesTest` covering a subfolder selected as Root Folder with no `selectedRepositoryId` preference present.

## PR Check

**pr-check: PASS** — tested on `fec7d917ced04fa92d8f4df737b5ffb4a988bb77`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fec7d917ced04fa92d8f4df737b5ffb4a988bb77"} -->
