### PR TITLE
LPD-95544 Add automated coverage for CMS Internal Search & Filtering

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
@@ -96,25 +96,11 @@ test(
 				value: space1Name,
 			});
 
-			await page
-				.getByRole('button', {exact: true, name: 'Filter'})
-				.click();
-			await page.getByRole('button', {exact: true, name: 'Back'}).click();
-			await page
-				.getByRole('menuitem', {exact: true, name: 'Type'})
-				.click();
-			await page
-				.getByRole('checkbox', {
-					exact: true,
-					name: 'Basic Web Content',
-				})
-				.check();
-			await page
-				.getByRole('button', {exact: true, name: 'Add Filter'})
-				.click();
-			await expect(
-				page.getByRole('button', {name: 'Type: Basic Web Content'})
-			).toBeVisible();
+			await applyFDSSelectionFilter(page, {
+				chained: true,
+				filter: 'Type',
+				value: 'Basic Web Content',
+			});
 
 			const searchInput = page.getByRole('searchbox', {name: 'Search'});
 
@@ -123,9 +109,7 @@ test(
 		});
 
 		await test.step('Only the item matching all three criteria remains', async () => {
-			await expect(assetsPage.getItem(matchingTitle)).toBeVisible({
-				timeout: 15000,
-			});
+			await expect(assetsPage.getItem(matchingTitle)).toBeVisible();
 			await expect(assetsPage.getItem(wrongKeywordTitle)).toBeHidden();
 			await expect(
 				assetsPage.getItem(`${matchingTitle} File`)

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {applyFDSSelectionFilter} from '../../../../utils/applyFDSSelectionFilter';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Combining Space, content type, and keyword filters in the All section narrows to only matching items',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.e']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const keyword = getRandomString();
+		const matchingTitle = `${keyword} Match`;
+		const wrongKeywordTitle = getRandomString();
+
+		let space1Name: string;
+
+		await test.step('Create two Spaces with content covering each filter combination', async () => {
+			const space1 =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			const space2 =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			space1Name = space1.name;
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: matchingTitle,
+				},
+				applicationName,
+				space1.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: wrongKeywordTitle,
+				},
+				applicationName,
+				space1.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `${matchingTitle} File.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: `${matchingTitle} File`,
+				},
+				'cms/basic-documents',
+				space1.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: `${keyword} Other Space`,
+				},
+				applicationName,
+				space2.name
+			);
+		});
+
+		await test.step('Apply Space and Type filters, then search by keyword', async () => {
+			await assetsPage.gotoAll();
+
+			await applyFDSSelectionFilter(page, {
+				filter: 'Space',
+				value: space1Name,
+			});
+
+			await page
+				.getByRole('button', {exact: true, name: 'Filter'})
+				.click();
+			await page.getByRole('button', {exact: true, name: 'Back'}).click();
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Type'})
+				.click();
+			await page
+				.getByRole('checkbox', {
+					exact: true,
+					name: 'Basic Web Content',
+				})
+				.check();
+			await page
+				.getByRole('button', {exact: true, name: 'Add Filter'})
+				.click();
+			await expect(
+				page.getByRole('button', {name: 'Type: Basic Web Content'})
+			).toBeVisible();
+
+			const searchInput = page.getByRole('searchbox', {name: 'Search'});
+
+			await searchInput.fill(keyword);
+			await searchInput.press('Enter');
+		});
+
+		await test.step('Only the item matching all three criteria remains', async () => {
+			await expect(assetsPage.getItem(matchingTitle)).toBeVisible({
+				timeout: 15000,
+			});
+			await expect(assetsPage.getItem(wrongKeywordTitle)).toBeHidden();
+			await expect(
+				assetsPage.getItem(`${matchingTitle} File`)
+			).toBeHidden();
+			await expect(
+				assetsPage.getItem(`${keyword} Other Space`)
+			).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import {applyFDSSelectionFilter} from '../../../../utils/applyFDSSelectionFilter';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+async function createStructuredContentStructure(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string
+) {
+	const definition = await apiHelpers.objectAdmin.postRandomObjectDefinition({
+		objectDefinitionSettings: [
+			{
+				name: 'acceptedGroupExternalReferenceCodes',
+				value: spaceExternalReferenceCode as unknown as object,
+			},
+		],
+		objectFields: [
+			{
+				DBType: 'String',
+				businessType: 'Text',
+				externalReferenceCode: getRandomString(),
+				indexed: true,
+				indexedAsKeyword: false,
+				indexedLanguageId: 'en_US',
+				label: {en_US: 'Title'},
+				localized: true,
+				name: 'title',
+				required: true,
+			},
+		],
+		objectFolderExternalReferenceCode: 'L_CMS_CONTENT_STRUCTURES',
+		scope: 'depot',
+		status: {code: 0},
+		titleObjectFieldName: 'title',
+	});
+
+	apiHelpers.data.push({id: definition.id, type: 'objectDefinition'});
+
+	return {
+		applicationName: definition.restContextPath.replace(/^\/o\//, ''),
+	};
+}
+
+test(
+	'Filtering the All section by Basic Web Content excludes Structured Content and files',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.b']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const webContentTitle = getRandomString();
+		const structuredContentTitle = getRandomString();
+		const fileTitle = getRandomString();
+
+		await test.step('Create one Basic Web Content, one Structured Content, and one file', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			const {applicationName} = await createStructuredContentStructure(
+				apiHelpers,
+				space.externalReferenceCode
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: webContentTitle,
+				},
+				'cms/basic-web-contents',
+				space.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: structuredContentTitle,
+				},
+				applicationName,
+				space.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `${fileTitle}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: fileTitle,
+				},
+				'cms/basic-documents',
+				space.name
+			);
+		});
+
+		await test.step('All three entries are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(webContentTitle)).toBeVisible();
+			await expect(
+				assetsPage.getItem(structuredContentTitle)
+			).toBeVisible();
+			await expect(assetsPage.getItem(fileTitle)).toBeVisible();
+		});
+
+		await test.step('Filtering by Type Basic Web Content shows only the web content', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Type',
+				value: 'Basic Web Content',
+			});
+
+			await expect(assetsPage.getItem(webContentTitle)).toBeVisible({
+				timeout: 5000,
+			});
+			await expect(
+				assetsPage.getItem(structuredContentTitle)
+			).toBeHidden();
+			await expect(assetsPage.getItem(fileTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
@@ -128,9 +128,7 @@ test(
 				value: 'Basic Web Content',
 			});
 
-			await expect(assetsPage.getItem(webContentTitle)).toBeVisible({
-				timeout: 5000,
-			});
+			await expect(assetsPage.getItem(webContentTitle)).toBeVisible();
 			await expect(
 				assetsPage.getItem(structuredContentTitle)
 			).toBeHidden();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
@@ -29,7 +29,13 @@ test(
 		const imageTitle = `${getRandomString()}.png`;
 		const textTitle = `${getRandomString()}.txt`;
 
-		await test.step('Upload a PNG image and a plain text file', async () => {
+		await test.step('Upload a PNG image and a plain text file into a fresh Space', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
 			await apiHelpers.objectEntry.postObjectEntry(
 				{
 					file: {
@@ -40,7 +46,7 @@ test(
 					title: imageTitle,
 				},
 				applicationName,
-				'Default'
+				space.name
 			);
 
 			await apiHelpers.objectEntry.postObjectEntry(
@@ -56,7 +62,7 @@ test(
 					title: textTitle,
 				},
 				applicationName,
-				'Default'
+				space.name
 			);
 		});
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {applyFDSSelectionFilter} from '../../../../utils/applyFDSSelectionFilter';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Filtering the Files section by an image extension excludes non-image files',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.d']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-documents';
+		const imageTitle = `${getRandomString()}.png`;
+		const textTitle = `${getRandomString()}.txt`;
+
+		await test.step('Upload a PNG image and a plain text file', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: imageTitle,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: imageTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64:
+							Buffer.from('plain text content').toString(
+								'base64'
+							),
+						name: textTitle,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: textTitle,
+				},
+				applicationName,
+				'Default'
+			);
+		});
+
+		await test.step('Both files are visible before filtering', async () => {
+			await assetsPage.gotoFiles();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await expect(assetsPage.getItem(imageTitle)).toBeVisible();
+			await expect(assetsPage.getItem(textTitle)).toBeVisible();
+		});
+
+		await test.step('Filtering by Extension png shows only the image file', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Extension',
+				value: 'png',
+			});
+
+			await expect(assetsPage.getItem(imageTitle)).toBeVisible();
+			await expect(assetsPage.getItem(textTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/keywordSearch.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/keywordSearch.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Searching a keyword in the All section returns matching content and files from all Spaces',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.a']},
+	async ({apiHelpers, assetsPage}) => {
+		const keyword = getRandomString();
+		const matchingContentTitle = `${keyword} Content`;
+		const matchingFileTitle = `${keyword} File`;
+		const unrelatedTitle = getRandomString();
+
+		await test.step('Create a matching content and a matching file in different Spaces, and an unrelated content', async () => {
+			const space1 =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			const space2 =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: matchingContentTitle,
+				},
+				'cms/basic-web-contents',
+				space1.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `${matchingFileTitle}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: matchingFileTitle,
+				},
+				'cms/basic-documents',
+				space2.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: unrelatedTitle,
+				},
+				'cms/basic-web-contents',
+				space1.name
+			);
+		});
+
+		await test.step('All entries are visible before searching', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(
+				assetsPage.getItem(matchingContentTitle)
+			).toBeVisible();
+			await expect(assetsPage.getItem(matchingFileTitle)).toBeVisible();
+			await expect(assetsPage.getItem(unrelatedTitle)).toBeVisible();
+		});
+
+		await test.step('Searching the keyword returns only the matching content and file', async () => {
+			await assetsPage.dataSetFragmentPage.search(keyword);
+
+			await expect(
+				assetsPage.getItem(matchingContentTitle)
+			).toBeVisible();
+			await expect(assetsPage.getItem(matchingFileTitle)).toBeVisible();
+			await expect(assetsPage.getItem(unrelatedTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/metadataSearch.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/metadataSearch.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+async function createFileStructureWithDescription(
+	apiHelpers: DataApiHelpers,
+	spaceExternalReferenceCode: string
+) {
+	const definition = await apiHelpers.objectAdmin.postRandomObjectDefinition({
+		objectDefinitionSettings: [
+			{
+				name: 'acceptedGroupExternalReferenceCodes',
+				value: spaceExternalReferenceCode as unknown as object,
+			},
+		],
+		objectFields: [
+			{
+				DBType: 'String',
+				businessType: 'Text',
+				externalReferenceCode: getRandomString(),
+				indexed: true,
+				indexedAsKeyword: false,
+				indexedLanguageId: 'en_US',
+				label: {en_US: 'Title'},
+				localized: true,
+				name: 'title',
+				required: true,
+			},
+			{
+				DBType: 'Long',
+				businessType: 'Attachment',
+				externalReferenceCode: getRandomString(),
+				label: {en_US: 'File'},
+				name: 'file',
+				objectFieldSettings: [
+					{
+						name: 'acceptedFileExtensions',
+						value: '*' as unknown as object,
+					},
+					{name: 'maximumFileSize', value: 100 as unknown as object},
+					{
+						name: 'fileSource',
+						value: 'userComputerToCMSBasicDocument' as unknown as object,
+					},
+					{
+						name: 'showFilesInLibrary',
+						value: false as unknown as object,
+					},
+				],
+				required: true,
+			},
+			{
+				DBType: 'String',
+				businessType: 'Text',
+				externalReferenceCode: getRandomString(),
+				indexed: true,
+				indexedAsKeyword: false,
+				indexedLanguageId: 'en_US',
+				label: {en_US: 'Description'},
+				localized: true,
+				name: 'description',
+			},
+		],
+		objectFolderExternalReferenceCode: 'L_CMS_FILE_TYPES',
+		scope: 'depot',
+		status: {code: 0},
+		titleObjectFieldName: 'title',
+	});
+
+	apiHelpers.data.push({id: definition.id, type: 'objectDefinition'});
+
+	return {
+		applicationName: definition.restContextPath.replace(/^\/o\//, ''),
+	};
+}
+
+test(
+	'Searching a word from a file’s Description metadata field returns that file',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.f']},
+	async ({apiHelpers, assetsPage}) => {
+		const matchingTitle = getRandomString();
+		const otherTitle = getRandomString();
+		const descriptionKeyword = getRandomString();
+
+		await test.step('Create a File structure with a Description field and two files, one with a matching description', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			const {applicationName} = await createFileStructureWithDescription(
+				apiHelpers,
+				space.externalReferenceCode
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					description: `A file about ${descriptionKeyword} topics`,
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `${matchingTitle}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: matchingTitle,
+				},
+				applicationName,
+				space.name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					description: 'An unrelated description',
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `${otherTitle}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: otherTitle,
+				},
+				applicationName,
+				space.name
+			);
+		});
+
+		await test.step('Both files are visible before searching', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(matchingTitle)).toBeVisible();
+			await expect(assetsPage.getItem(otherTitle)).toBeVisible();
+		});
+
+		await test.step('Searching a word from the description returns only the matching file', async () => {
+			await assetsPage.dataSetFragmentPage.search(descriptionKeyword);
+
+			await expect(assetsPage.getItem(matchingTitle)).toBeVisible();
+			await expect(assetsPage.getItem(otherTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/searchScopeByRole.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/searchScopeByRole.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {addRoleMemberAndSwitch} from '../spaces/helpers/roleMembership';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+async function createTwoSpacesWithKeywordContent(apiHelpers: any) {
+	const keyword = getRandomString();
+	const ownSpaceTitle = `${keyword} Own Space`;
+	const otherSpaceTitle = `${keyword} Other Space`;
+
+	const ownSpace = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name: `Space ${getRandomString()}`,
+		type: 'Space',
+	});
+
+	const otherSpace = await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+		{name: `Space ${getRandomString()}`, type: 'Space'}
+	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{
+			objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			title: ownSpaceTitle,
+		},
+		APPLICATION_NAME,
+		ownSpace.name
+	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{
+			objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			title: otherSpaceTitle,
+		},
+		APPLICATION_NAME,
+		otherSpace.name
+	);
+
+	return {keyword, otherSpaceTitle, ownSpace, ownSpaceTitle};
+}
+
+test(
+	'A Space Administrator searching a keyword sees only content from their own Spaces',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.g']},
+	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
+		const {keyword, otherSpaceTitle, ownSpace, ownSpaceTitle} =
+			await createTwoSpacesWithKeywordContent(apiHelpers);
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: 'Space Administrator',
+			spaceName: ownSpace.name,
+			spaceSummaryPage,
+		});
+
+		await assetsPage.gotoAll();
+		await assetsPage.dataSetFragmentPage.search(keyword);
+
+		await expect(assetsPage.getItem(ownSpaceTitle)).toBeVisible();
+		await expect(assetsPage.getItem(otherSpaceTitle)).toBeHidden();
+	}
+);
+
+test(
+	'A Space Content Reviewer searching a keyword sees only content from their own Spaces',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.h']},
+	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
+		const {keyword, otherSpaceTitle, ownSpace, ownSpaceTitle} =
+			await createTwoSpacesWithKeywordContent(apiHelpers);
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: 'Space Content Reviewer',
+			spaceName: ownSpace.name,
+			spaceSummaryPage,
+		});
+
+		await assetsPage.gotoAll();
+		await assetsPage.dataSetFragmentPage.search(keyword);
+
+		await expect(assetsPage.getItem(ownSpaceTitle)).toBeVisible();
+		await expect(assetsPage.getItem(otherSpaceTitle)).toBeHidden();
+	}
+);
+
+test(
+	'A Space Member searching a keyword sees only content they have view access to in their own Spaces',
+	{tag: ['@LPD-95544', '@LPD-95544/TC-21.i']},
+	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
+		const {keyword, otherSpaceTitle, ownSpace, ownSpaceTitle} =
+			await createTwoSpacesWithKeywordContent(apiHelpers);
+
+		const restrictedTitle = `${keyword} Restricted`;
+
+		const restrictedEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: restrictedTitle,
+			},
+			APPLICATION_NAME,
+			ownSpace.name
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			restrictedEntry.id,
+			[
+				{actionIds: ['VIEW'], roleName: 'Asset Library Administrator'},
+				{
+					actionIds: ['VIEW'],
+					roleName: 'Asset Library Content Reviewer',
+				},
+			]
+		);
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: null,
+			spaceName: ownSpace.name,
+			spaceSummaryPage,
+		});
+
+		await assetsPage.gotoAll();
+		await assetsPage.dataSetFragmentPage.search(keyword);
+
+		await expect(assetsPage.getItem(ownSpaceTitle)).toBeVisible();
+		await expect(assetsPage.getItem(otherSpaceTitle)).toBeHidden();
+		await expect(assetsPage.getItem(restrictedTitle)).toBeHidden();
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/searchScopeByRole.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/searchScopeByRole.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 import {addRoleMemberAndSwitch} from '../spaces/helpers/roleMembership';
@@ -23,7 +24,7 @@ const test = mergeTests(
 
 const APPLICATION_NAME = 'cms/basic-web-contents';
 
-async function createTwoSpacesWithKeywordContent(apiHelpers: any) {
+async function createTwoSpacesWithKeywordContent(apiHelpers: DataApiHelpers) {
 	const keyword = getRandomString();
 	const ownSpaceTitle = `${keyword} Own Space`;
 	const otherSpaceTitle = `${keyword} Other Space`;

--- a/modules/test/playwright/utils/applyFDSSelectionFilter.ts
+++ b/modules/test/playwright/utils/applyFDSSelectionFilter.ts
@@ -5,15 +5,24 @@
 
 import {Page, expect} from '@playwright/test';
 
+// When a filter is already applied, reopening the Filter dropdown lands on the
+// previous filter's option list; `chained` clicks Back to reach the filter
+// menu before selecting the next one.
+
 export async function applyFDSSelectionFilter(
 	page: Page,
 	{
+		chained = false,
 		exclude = false,
 		filter,
 		value,
-	}: {exclude?: boolean; filter: string; value: string}
+	}: {chained?: boolean; exclude?: boolean; filter: string; value: string}
 ) {
 	await page.getByRole('button', {exact: true, name: 'Filter'}).click();
+
+	if (chained) {
+		await page.getByRole('button', {exact: true, name: 'Back'}).click();
+	}
 
 	await page.getByRole('menuitem', {exact: true, name: filter}).click();
 

--- a/modules/test/playwright/utils/expectToPass.ts
+++ b/modules/test/playwright/utils/expectToPass.ts
@@ -9,20 +9,5 @@ export async function expectToPass(
 	callback: () => Promise<void>,
 	{timeout}: {timeout: number}
 ) {
-	const deadline = Date.now() + timeout;
-
-	while (true) {
-		const remaining = deadline - Date.now();
-
-		try {
-			await expect(callback).toPass({timeout: Math.max(remaining, 0)});
-
-			return;
-		}
-		catch (error) {
-			if (Date.now() >= deadline) {
-				throw error;
-			}
-		}
-	}
+	await expect(callback).toPass({timeout});
 }

--- a/modules/test/playwright/utils/expectToPass.ts
+++ b/modules/test/playwright/utils/expectToPass.ts
@@ -9,14 +9,20 @@ export async function expectToPass(
 	callback: () => Promise<void>,
 	{timeout}: {timeout: number}
 ) {
+	const deadline = Date.now() + timeout;
+
 	while (true) {
+		const remaining = deadline - Date.now();
+
 		try {
-			await expect(callback).toPass({timeout});
+			await expect(callback).toPass({timeout: Math.max(remaining, 0)});
 
 			return;
 		}
-		catch {
-			continue;
+		catch (error) {
+			if (Date.now() >= deadline) {
+				throw error;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds Playwright specs covering TC-21.a, b, d, e, f, g, h, i from LPD-95544 (CMS Internal Search & Filtering). TC-21.c is intentionally not duplicated — already covered by an existing test (`all.spec.ts`, LPD-91933).
- `keywordSearch.spec.ts` — unscoped keyword search returning matching content and files across Spaces (a).
- `contentTypeFilter.spec.ts` — content-type filter excludes Structured Content and files (b).
- `fileTypeFilter.spec.ts` — Files section Extension filter for images excludes non-image files (d).
- `combinedFilters.spec.ts` — Space + Type + keyword filters combined narrow to only matching items (e).
- `metadataSearch.spec.ts` — searching a word from a file's custom Description metadata field returns that file (f).
- `searchScopeByRole.spec.ts` — keyword search scoped to a Space Administrator's, Space Content Reviewer's, and Space Member's own Spaces, including a Space Member being unable to see an item they lack view permission for (g, h, i).

Also fixes two shared test-framework bugs found while implementing this coverage:
- `utils/expectToPass.ts` retried a failing condition forever instead of giving up after its timeout, which could hang the whole test process indefinitely (root cause of repeated OOM crashes while wiring TC-21.e).
- `addRoleMemberAndSwitch` created a role-test user without agreeing to the Terms of Use first, landing the new session on that wall instead of the CMS.

## Test plan
- [x] All 8 implemented scenarios run green via `npx playwright test keywordSearch.spec.ts contentTypeFilter.spec.ts fileTypeFilter.spec.ts combinedFilters.spec.ts metadataSearch.spec.ts searchScopeByRole.spec.ts --project site-cms-site-initializer.main --reporter=list`
- [x] No product defects found

https://claude.ai/code/session_01VCFvcRWBmgU93R4QnKncBw