### PR TITLE
LPD-100192 Fix UpgradeAssetCategoryTest fixture group data

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_3_x/test/UpgradeAssetCategoryTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_3_x/test/UpgradeAssetCategoryTest.java
@@ -86,6 +86,8 @@ public class UpgradeAssetCategoryTest {
 		AssetCategory category = _assetCategoryLocalService.createAssetCategory(
 			_counterLocalService.increment());
 
+		category.setGroupId(_group.getGroupId());
+		category.setCompanyId(_group.getCompanyId());
 		category.setParentCategoryId(parentCategoryId);
 		category.setVocabularyId(_assetVocabulary.getVocabularyId());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100192
https://liferay.atlassian.net/browse/LPD-100144

## What Is Being Fixed

`UpgradeAssetCategoryTest#testUpgrade` fails on all eight database vendors in `[master] ci:test:upgrade` since build 340. Commit 1981c929c940d (LPD-97350) removed the LPD-70396 feature flag early return from `AssetCategoryFriendlyURLModelListener.onAfterCreate`, so the listener now always resolves the category's group to create a friendly URL entry. The test fixture persists categories with `groupId` and `companyId` left at 0, so `setUp` now throws `ModelListenerException: NoSuchGroupException: No Group exists with the primary key 0`. The fixture only ever worked because the removed flag check read that same `companyId` of 0 and returned early, making this a test defect rather than a product defect.

## How It Is Being Fixed

`_createCategory` now sets `groupId` and `companyId` from the `_group` that `setUp` already creates for the vocabulary, so the friendly URL listener resolves a real group. Every existing assertion stays intact. Verified locally against a bundle running the degated listener: without the fix the test reproduces the exact CI failure, and with it `testUpgrade` passes.

## PR Check

**pr-check: PASS** — tested on `cfeef860794a1f97588fbedec3b5dfc51be04630`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cfeef860794a1f97588fbedec3b5dfc51be04630"} -->
