### PR TITLE
LPD-97900 Prevent editing another user's comment in a project

### DIFF
--- a/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBDiscussionPermissionImpl.java
+++ b/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBDiscussionPermissionImpl.java
@@ -130,6 +130,44 @@ public class MBDiscussionPermissionImpl extends BaseDiscussionPermission {
 			ActionKeys.VIEW);
 	}
 
+	private int _getDepotEntryType(MBMessage message) {
+		InfoItemObjectProvider<Object> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, message.getClassName());
+
+		if (infoItemObjectProvider == null) {
+			return DepotConstants.TYPE_ANY;
+		}
+
+		try {
+			Object infoItem = infoItemObjectProvider.getInfoItem(
+				new ClassPKInfoItemIdentifier(message.getClassPK()));
+
+			if (!(infoItem instanceof GroupedModel)) {
+				return DepotConstants.TYPE_ANY;
+			}
+
+			GroupedModel groupedModel = (GroupedModel)infoItem;
+
+			DepotEntry depotEntry =
+				_depotEntryLocalService.fetchGroupDepotEntry(
+					groupedModel.getGroupId());
+
+			if (depotEntry == null) {
+				return DepotConstants.TYPE_ANY;
+			}
+
+			return depotEntry.getType();
+		}
+		catch (NoSuchInfoItemException noSuchInfoItemException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchInfoItemException);
+			}
+
+			return DepotConstants.TYPE_ANY;
+		}
+	}
+
 	private boolean _hasPermission(
 			PermissionChecker permissionChecker, MBMessage message,
 			String actionId)
@@ -148,11 +186,20 @@ public class MBDiscussionPermissionImpl extends BaseDiscussionPermission {
 				CommentGroupServiceConfiguration.class, message.getCompanyId(),
 				message.getGroupId());
 
+		int depotEntryType = _getDepotEntryType(message);
+
 		if ((commentGroupServiceConfiguration.alwaysEditableByOwner() ||
-			 _isSpaceDepotEntry(message)) &&
+			 (depotEntryType == DepotConstants.TYPE_PROJECT) ||
+			 (depotEntryType == DepotConstants.TYPE_SPACE)) &&
 			(permissionChecker.getUserId() == message.getUserId())) {
 
 			return true;
+		}
+
+		if ((depotEntryType == DepotConstants.TYPE_PROJECT) &&
+			actionId.equals(ActionKeys.UPDATE_DISCUSSION)) {
+
+			return false;
 		}
 
 		if (message.isPending()) {
@@ -169,46 +216,6 @@ public class MBDiscussionPermissionImpl extends BaseDiscussionPermission {
 		return hasPermission(
 			permissionChecker, message.getCompanyId(), message.getGroupId(),
 			className, message.getClassPK(), actionId);
-	}
-
-	private boolean _isSpaceDepotEntry(MBMessage message) {
-		InfoItemObjectProvider<Object> infoItemObjectProvider =
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemObjectProvider.class, message.getClassName());
-
-		if (infoItemObjectProvider == null) {
-			return false;
-		}
-
-		try {
-			Object infoItem = infoItemObjectProvider.getInfoItem(
-				new ClassPKInfoItemIdentifier(message.getClassPK()));
-
-			if (!(infoItem instanceof GroupedModel)) {
-				return false;
-			}
-
-			GroupedModel groupedModel = (GroupedModel)infoItem;
-
-			DepotEntry depotEntry =
-				_depotEntryLocalService.fetchGroupDepotEntry(
-					groupedModel.getGroupId());
-
-			if ((depotEntry != null) &&
-				(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
-
-				return true;
-			}
-
-			return false;
-		}
-		catch (NoSuchInfoItemException noSuchInfoItemException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchInfoItemException);
-			}
-
-			return false;
-		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/comment/test/MBDiscussionPermissionImplTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/comment/test/MBDiscussionPermissionImplTest.java
@@ -24,6 +24,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.comment.DiscussionPermission;
 import com.liferay.portal.kernel.model.Group;
@@ -45,6 +46,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -192,75 +194,72 @@ public class MBDiscussionPermissionImplTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
+	@TestInfo("LPD-97900")
+	public void testUserCannotUpdateSomeoneElseCommentInProject()
+		throws Exception {
+
+		_withPermissionChecker(
+			() -> {
+				long commentId = _addDepotComment(
+					DepotConstants.TYPE_PROJECT, _siteUser1);
+
+				_grantDiscussionPermissions(
+					_commentManager.fetchComment(commentId), _siteUser2);
+
+				PermissionChecker permissionChecker =
+					PermissionCheckerFactoryUtil.create(_siteUser2);
+
+				Assert.assertFalse(
+					_discussionPermission.hasUpdatePermission(
+						permissionChecker, commentId));
+				Assert.assertTrue(
+					_discussionPermission.hasDeletePermission(
+						permissionChecker, commentId));
+			});
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-97900")
+	public void testUserCanUpdateAndDeleteHisCommentInProject()
+		throws Exception {
+
+		_withPermissionChecker(
+			() -> {
+				long commentId = _addDepotComment(
+					DepotConstants.TYPE_PROJECT, _siteUser1);
+
+				PermissionChecker permissionChecker =
+					PermissionCheckerFactoryUtil.create(_siteUser1);
+
+				Assert.assertTrue(
+					_discussionPermission.hasUpdatePermission(
+						permissionChecker, commentId));
+				Assert.assertTrue(
+					_discussionPermission.hasDeletePermission(
+						permissionChecker, commentId));
+			});
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
 	@TestInfo("LPD-93071")
 	public void testUserCanUpdateAndDeleteHisCommentInSpace() throws Exception {
-		PermissionChecker originalPermissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-		String originalName = PrincipalThreadLocal.getName();
+		_withPermissionChecker(
+			() -> {
+				long commentId = _addDepotComment(
+					DepotConstants.TYPE_SPACE, _siteUser1);
 
-		try {
-			PrincipalThreadLocal.setName(_user.getUserId());
-			PermissionThreadLocal.setPermissionChecker(
-				PermissionCheckerFactoryUtil.create(_user));
+				PermissionChecker permissionChecker =
+					PermissionCheckerFactoryUtil.create(_siteUser1);
 
-			Group cmsGroup = CMSTestUtil.getOrAddGroup(
-				MBDiscussionPermissionImplTest.class);
-
-			_depotEntry = _depotEntryLocalService.addDepotEntry(
-				HashMapBuilder.put(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()
-				).build(),
-				null, DepotConstants.TYPE_SPACE,
-				ServiceContextTestUtil.getServiceContext(
-					cmsGroup.getGroupId()));
-
-			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.
-					getObjectDefinitionByExternalReferenceCode(
-						"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
-
-			ObjectEntryFolder objectEntryFolder =
-				_objectEntryFolderLocalService.
-					getObjectEntryFolderByExternalReferenceCode(
-						"L_CONTENTS", _depotEntry.getGroupId(),
-						_depotEntry.getCompanyId());
-
-			ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
-				_depotEntry.getGroupId(), _user.getUserId(),
-				objectDefinition.getObjectDefinitionId(),
-				objectEntryFolder.getObjectEntryFolderId(), "en_US",
-				HashMapBuilder.<String, Serializable>put(
-					"title_i18n",
-					HashMapBuilder.put(
-						"en_US", RandomTestUtil.randomString()
-					).build()
-				).build(),
-				ServiceContextTestUtil.getServiceContext(
-					_depotEntry.getGroupId()));
-
-			long commentId = _commentManager.addComment(
-				_siteUser1.getUserId(), _depotEntry.getGroupId(),
-				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
-				StringUtil.randomString(),
-				new IdentityServiceContextFunction(
-					ServiceContextTestUtil.getServiceContext(
-						_depotEntry.getGroupId(), _siteUser1.getUserId())));
-
-			PermissionChecker permissionChecker =
-				PermissionCheckerFactoryUtil.create(_siteUser1);
-
-			Assert.assertTrue(
-				_discussionPermission.hasUpdatePermission(
-					permissionChecker, commentId));
-			Assert.assertTrue(
-				_discussionPermission.hasDeletePermission(
-					permissionChecker, commentId));
-		}
-		finally {
-			PermissionThreadLocal.setPermissionChecker(
-				originalPermissionChecker);
-			PrincipalThreadLocal.setName(originalName);
-		}
+				Assert.assertTrue(
+					_discussionPermission.hasUpdatePermission(
+						permissionChecker, commentId));
+				Assert.assertTrue(
+					_discussionPermission.hasDeletePermission(
+						permissionChecker, commentId));
+			});
 	}
 
 	@Test
@@ -290,6 +289,70 @@ public class MBDiscussionPermissionImplTest {
 			StringUtil.randomString(), serviceContextFunction);
 	}
 
+	private long _addDepotComment(int depotType, User user) throws Exception {
+		Group cmsGroup = CMSTestUtil.getOrAddGroup(
+			MBDiscussionPermissionImplTest.class);
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			null, depotType,
+			ServiceContextTestUtil.getServiceContext(cmsGroup.getGroupId()));
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", _depotEntry.getGroupId(),
+					_depotEntry.getCompanyId());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_depotEntry.getGroupId(), _user.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", RandomTestUtil.randomString()
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(_depotEntry.getGroupId()));
+
+		return _commentManager.addComment(
+			user.getUserId(), _depotEntry.getGroupId(),
+			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
+			StringUtil.randomString(),
+			new IdentityServiceContextFunction(
+				ServiceContextTestUtil.getServiceContext(
+					_depotEntry.getGroupId(), user.getUserId())));
+	}
+
+	private void _grantDiscussionPermissions(Comment comment, User user)
+		throws Exception {
+
+		String className = comment.getClassName();
+		String primKey = String.valueOf(comment.getClassPK());
+
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		RoleTestUtil.addResourcePermission(
+			_role, className, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+			ActionKeys.DELETE_DISCUSSION);
+		RoleTestUtil.addResourcePermission(
+			_role, className, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+			ActionKeys.UPDATE_DISCUSSION);
+		RoleTestUtil.addResourcePermission(
+			_role, className, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+			ActionKeys.VIEW);
+
+		RoleLocalServiceUtil.addUserRole(user.getUserId(), _role.getRoleId());
+	}
+
 	private void _withAlwaysEditableByOwnerEnabled(
 			UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
@@ -315,6 +378,28 @@ public class MBDiscussionPermissionImplTest {
 		finally {
 			ConfigurationTestUtil.saveConfiguration(
 				configuration, originalConfigurationProperties);
+		}
+	}
+
+	private void _withPermissionChecker(
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String originalName = PrincipalThreadLocal.getName();
+
+		try {
+			PrincipalThreadLocal.setName(_user.getUserId());
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(_user));
+
+			unsafeRunnable.run();
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+			PrincipalThreadLocal.setName(originalName);
 		}
 	}
 
@@ -354,6 +439,9 @@ public class MBDiscussionPermissionImplTest {
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@DeleteAfterTestRun
+	private Role _role;
 
 	@DeleteAfterTestRun
 	private User _siteUser1;

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
@@ -92,11 +92,15 @@ const initialComments: Comment[] = [
 	},
 ];
 
-const renderComponent = (addCommentURL = 'addCommentURL', readOnly = false) => {
+const renderComponent = (
+	addCommentURL = 'addCommentURL',
+	readOnly = false,
+	comments = initialComments
+) => {
 	return render(
 		<CommentsPanel
 			addCommentURL={addCommentURL}
-			comments={initialComments}
+			comments={comments}
 			deleteCommentURL="deleteCommentURL"
 			editCommentURL="editCommentURL"
 			editorConfig={{}}
@@ -135,6 +139,17 @@ describe('CommentsPanel', () => {
 			screen.queryByTitle('rate-this-as-good')
 		).not.toBeInTheDocument();
 		expect(screen.queryByTitle('rate-this-as-bad')).not.toBeInTheDocument();
+	});
+
+	it('hides the edit action when the comment cannot be updated', async () => {
+		renderComponent('addCommentURL', false, [
+			{...initialComments[0], children: [], hasUpdatePermission: false},
+		]);
+
+		await userEvent.click(screen.getByTitle('actions'));
+
+		expect(screen.getByText('delete')).toBeInTheDocument();
+		expect(screen.queryByText('edit')).not.toBeInTheDocument();
 	});
 
 	it('deletes the child comment', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97900

## What Is Being Fixed

In CMP, a user holding the Project Manager role — a Space Role with the `project` subtype — could edit a comment written by someone else, on both Projects and Tasks. Only the author should be able to edit a comment; anyone holding delete permission may still delete one.

`UPDATE_DISCUSSION` is granted on the parent Project or Task entry rather than on the comment itself, and it was never checked against the comment's author. The CMP model listener grants the Project Manager role every action ID on each entry, so that role passed the edit check on anyone's comment. The same hole was open to the object REST `PUT .../comments/{externalReferenceCode}` endpoint, which resolves permission through the same call.

## How It Is Being Fixed

The fix lands in `MBDiscussionPermissionImpl`, where every caller resolves comment permission, so the UI, the CMS Struts action, and the REST endpoint are all closed by one change. A non-author is now denied `UPDATE_DISCUSSION` on a comment whose parent entry belongs to a CMP Project. A Project, and every Task inside it, is a depot entry of type `DepotConstants.TYPE_PROJECT`, which is what the check tests, so Projects and Tasks are both covered without a separate case. Editing another user's words is never right in a Project, so company admins are not exempt either. `DELETE_DISCUSSION` is untouched, which keeps a moderator able to delete other people's comments.

The existing early return that lets a comment's owner edit their own comment, added for Spaces by LPD-93071, now covers Projects too. It has to, because the new check does not look at who wrote the comment, so the author would be blocked too.

Spaces (`DepotConstants.TYPE_SPACE`) are deliberately left alone, so CMS comments behave exactly as before.

<img width="1407" height="980" alt="Screenshot 2026-07-30 at 4 29 43 PM" src="https://github.com/user-attachments/assets/181afad6-c24d-4df2-bdde-e77485745ef0" />

## PR Check

**pr-check: PASS** — tested on `c272b0a3c0401d2ddb7cfd99c8381b5e6ace3cc1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

Two validations were run with reduced scope, noted for transparency. Source Format was verified per module rather than through `ant format-source-current-branch`, which fails on a pre-existing violation in `workspaces/liferay-osbfaro-workspace/.../NaniteDemoCreatorService.java`, a file this branch does not touch. JavaScript Unit Tests used the documented oversized-suite fallback and ran only `CommentsPanel.test.tsx` (10 tests); the full `site-cms-site-initializer` suite takes over seven hours on this machine.

<!-- pr-check {"result": "success", "sha": "c272b0a3c0401d2ddb7cfd99c8381b5e6ace3cc1"} -->

cc @marcelabc