### PR TITLE
LPD-100099 Publish asset category property changes to live

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -1032,6 +1032,14 @@ public class TaxonomyCategoryResourceImpl
 
 		Map<String, String> map = new HashMap<>();
 
+		for (AssetCategoryProperty assetCategoryProperty :
+				assetCategoryProperties) {
+
+			map.put(
+				assetCategoryProperty.getKey(),
+				assetCategoryProperty.getValue());
+		}
+
 		if (taxonomyCategoryProperties != null) {
 			for (TaxonomyCategoryProperty taxonomyCategoryProperty :
 					taxonomyCategoryProperties) {
@@ -1040,14 +1048,6 @@ public class TaxonomyCategoryResourceImpl
 					taxonomyCategoryProperty.getKey(),
 					taxonomyCategoryProperty.getValue());
 			}
-		}
-
-		for (AssetCategoryProperty assetCategoryProperty :
-				assetCategoryProperties) {
-
-			map.put(
-				assetCategoryProperty.getKey(),
-				assetCategoryProperty.getValue());
 		}
 
 		String[] strings = new String[map.size()];

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -78,6 +78,7 @@ import com.liferay.portal.vulcan.scope.Scope;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -480,6 +481,7 @@ public class TaxonomyCategoryResourceTest
 		_testPatchTaxonomyCategoryFriendlyUrlPathWithPeriodsAndSlashes();
 		_testPatchTaxonomyCategorySystem();
 		_testPatchTaxonomyCategorySystemParent();
+		_testPatchTaxonomyCategoryUpdatesTaxonomyCategoryProperty();
 		_testPatchTaxonomyCategoryWithExistingParentTaxonomyCategory(
 			testPatchTaxonomyCategory_addTaxonomyCategory(),
 			_addAssetVocabulary());
@@ -587,6 +589,7 @@ public class TaxonomyCategoryResourceTest
 		super.testPutSiteTaxonomyCategoryByExternalReferenceCode();
 
 		_testPutSiteTaxonomyCategoryByExternalReferenceCodeUpdatesParentToDefault();
+		_testPutSiteTaxonomyCategoryByExternalReferenceCodeUpdatesTaxonomyCategoryProperty();
 		_testPutSiteTaxonomyCategoryByExternalReferenceCodeWithParentTaxonomyCategory();
 	}
 
@@ -1658,6 +1661,53 @@ public class TaxonomyCategoryResourceTest
 		}
 	}
 
+	private void _testPatchTaxonomyCategoryUpdatesTaxonomyCategoryProperty()
+		throws Exception {
+
+		TaxonomyCategory taxonomyCategory =
+			testPatchTaxonomyCategory_addTaxonomyCategory();
+
+		long categoryId = GetterUtil.getLong(taxonomyCategory.getId());
+
+		String key1 = RandomTestUtil.randomString();
+
+		_assetCategoryPropertyLocalService.addCategoryProperty(
+			TestPropsValues.getUserId(), categoryId, key1,
+			RandomTestUtil.randomString());
+
+		String key2 = RandomTestUtil.randomString();
+		String value2 = RandomTestUtil.randomString();
+
+		_assetCategoryPropertyLocalService.addCategoryProperty(
+			TestPropsValues.getUserId(), categoryId, key2, value2);
+
+		String value1 = RandomTestUtil.randomString();
+
+		TaxonomyCategory patchTaxonomyCategory =
+			taxonomyCategoryResource.patchTaxonomyCategory(
+				taxonomyCategory.getId(),
+				new TaxonomyCategory() {
+					{
+						taxonomyCategoryProperties =
+							new TaxonomyCategoryProperty[] {
+								new TaxonomyCategoryProperty() {
+									{
+										key = key1;
+										value = value1;
+									}
+								}
+							};
+					}
+				});
+
+		Map<String, String> map = _toMap(
+			patchTaxonomyCategory.getTaxonomyCategoryProperties());
+
+		Assert.assertEquals(map.toString(), 2, map.size());
+		Assert.assertEquals(value1, map.get(key1));
+		Assert.assertEquals(value2, map.get(key2));
+	}
+
 	private void _testPatchTaxonomyCategoryWithExistingParentTaxonomyCategory(
 			TaxonomyCategory taxonomyCategory, AssetVocabulary assetVocabulary)
 		throws Exception {
@@ -2200,6 +2250,45 @@ public class TaxonomyCategoryResourceTest
 		}
 	}
 
+	private void _testPutSiteTaxonomyCategoryByExternalReferenceCodeUpdatesTaxonomyCategoryProperty()
+		throws Exception {
+
+		TaxonomyCategory taxonomyCategory =
+			testPutSiteTaxonomyCategoryByExternalReferenceCode_addTaxonomyCategory();
+
+		String propertyKey = RandomTestUtil.randomString();
+
+		_assetCategoryPropertyLocalService.addCategoryProperty(
+			TestPropsValues.getUserId(),
+			GetterUtil.getLong(taxonomyCategory.getId()), propertyKey,
+			RandomTestUtil.randomString());
+
+		String propertyValue = RandomTestUtil.randomString();
+
+		taxonomyCategory.setTaxonomyCategoryProperties(
+			new TaxonomyCategoryProperty[] {
+				new TaxonomyCategoryProperty() {
+					{
+						key = propertyKey;
+						value = propertyValue;
+					}
+				}
+			});
+
+		TaxonomyCategory putTaxonomyCategory =
+			taxonomyCategoryResource.
+				putSiteTaxonomyCategoryByExternalReferenceCode(
+					taxonomyCategory.getSiteId(),
+					taxonomyCategory.getExternalReferenceCode(),
+					taxonomyCategory);
+
+		Map<String, String> map = _toMap(
+			putTaxonomyCategory.getTaxonomyCategoryProperties());
+
+		Assert.assertEquals(map.toString(), 1, map.size());
+		Assert.assertEquals(propertyValue, map.get(propertyKey));
+	}
+
 	private void _testPutSiteTaxonomyCategoryByExternalReferenceCodeWithParentTaxonomyCategory()
 		throws Exception {
 
@@ -2259,6 +2348,22 @@ public class TaxonomyCategoryResourceTest
 				putParentTaxonomyCategory.getId(),
 				Long.valueOf(assetCategory.getParentCategoryId()));
 		}
+	}
+
+	private Map<String, String> _toMap(
+		TaxonomyCategoryProperty[] taxonomyCategoryProperties) {
+
+		Map<String, String> map = new HashMap<>();
+
+		for (TaxonomyCategoryProperty taxonomyCategoryProperty :
+				taxonomyCategoryProperties) {
+
+			map.put(
+				taxonomyCategoryProperty.getKey(),
+				taxonomyCategoryProperty.getValue());
+		}
+
+		return map;
 	}
 
 	private void _waitForFinish(JSONObject jsonObject) throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100099

## What Is Being Fixed

Changes to asset category properties (the key/value pairs on a category's Properties tab) are silently dropped when updating a category. A value change made through `PATCH /v1.0/taxonomy-categories/{id}` or `PUT /v1.0/sites/{siteId}/taxonomy-categories/by-external-reference-code/{erc}` has no effect, and since staging publication upserts categories through the headless taxonomy resource via the batch engine, property changes made on a staging site never reach live even though the publication reports success. Reported by a customer on 2026.Q1 (LPP-64988); this worked on 2024.Q1, which still published categories through the old LAR portlet data handler (removed by LPD-80479).

## How It Is Being Fixed

LPS-138566 merged the incoming taxonomy category properties with the persisted ones using `map.putIfAbsent` for the persisted values, so the request always won for an existing key. The Stream removal refactor in LPS-178727 rewrote the method with a plain `map.put` that runs after the incoming properties are collected, silently flipping the precedence so the persisted value always won instead. This change restores the original precedence in `TaxonomyCategoryResourceImpl#_merge` by collecting the persisted properties first and letting the incoming request properties override them. Properties the request does not name remain preserved, so PATCH semantics are unchanged.

## How Can You Verify That It Works

The new integration test scenarios in `TaxonomyCategoryResourceTest` cover updating an existing property value through PUT by external reference code (the publication path) and through PATCH (which must also preserve unnamed properties). Verified end-to-end on a local bundle: with local staging enabled, changing a category property value in staging and publishing to live (Categories selected) now updates the live category's property, where before it silently kept the old value.

## PR Check

**pr-check: PASS** — tested on `008085483bb8065882f8ea7a752fb243c95524f9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "008085483bb8065882f8ea7a752fb243c95524f9"} -->
