### PR TITLE
LPD-99924 Fix drag and drop reordering in the navigation menu

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
@@ -524,6 +524,15 @@ AUI.add(
 				_handleDrop(event) {
 					const instance = this;
 
+					const dataTransfer = event._event.dataTransfer;
+
+					const dragDropFiles =
+						dataTransfer && AArray(dataTransfer.files);
+
+					if (!dragDropFiles || !dragDropFiles.length) {
+						return;
+					}
+
 					event.halt();
 
 					const uploaderBoundingBox = instance._uploaderBoundingBox;
@@ -532,15 +541,9 @@ AUI.add(
 
 					const uploader = instance._uploader;
 
-					const dataTransfer = event._event.dataTransfer;
-
-					const dragDropFiles =
-						dataTransfer && AArray(dataTransfer.files);
-
 					if (
-						dragDropFiles &&
-						(target === uploaderBoundingBox ||
-							uploaderBoundingBox.contains(target))
+						target === uploaderBoundingBox ||
+						uploaderBoundingBox.contains(target)
 					) {
 						event.fileList = dragDropFiles.map((item) => {
 							return new A.FileHTML5(item);

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
@@ -18,7 +18,7 @@ import com.liferay.knowledge.base.service.KBArticleServiceUtil;
 import com.liferay.knowledge.base.service.KBFolderLocalServiceUtil;
 import com.liferay.knowledge.base.service.KBFolderServiceUtil;
 import com.liferay.knowledge.base.service.KBTemplateServiceUtil;
-import com.liferay.knowledge.base.util.comparator.KBArticleTitleComparator;
+import com.liferay.knowledge.base.util.comparator.KBArticlePriorityComparator;
 import com.liferay.knowledge.base.util.comparator.KBObjectsPriorityComparator;
 import com.liferay.knowledge.base.util.comparator.KBTemplateTitleComparator;
 import com.liferay.knowledge.base.web.internal.display.context.helper.KBArticleURLHelper;
@@ -290,7 +290,7 @@ public class KBAdminNavigationDisplayContext {
 		List<KBArticle> kbArticles = KBArticleServiceUtil.getKBArticles(
 			parentKBArticle.getGroupId(), parentKBArticle.getResourcePrimKey(),
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS, WorkflowConstants.STATUS_ANY,
-			KBArticleTitleComparator.getInstance(true));
+			KBArticlePriorityComparator.getInstance(true));
 
 		for (KBArticle kbArticle : kbArticles) {
 			if (moveKBObjectId == kbArticle.getResourcePrimKey()) {

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -224,6 +224,27 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
+	async postKnowledgeBaseArticleKnowledgeBaseArticle({
+		articleBody,
+		parentKnowledgeBaseArticleId,
+		title,
+	}: {
+		articleBody: string;
+		parentKnowledgeBaseArticleId: string;
+		title: string;
+	}): Promise<KnowledgeBaseArticle> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/knowledge-base-articles/${parentKnowledgeBaseArticleId}/knowledge-base-articles`,
+			{
+				data: {
+					articleBody,
+					title,
+				},
+				failOnStatusCode: true,
+			}
+		);
+	}
+
 	async postMessageBoardSectionMessageBoardThread({
 		articleBody,
 		headline,

--- a/modules/test/playwright/tests/knowledge-base-web/main/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/main/knowledge-base-web.spec.ts
@@ -356,3 +356,78 @@ test('Add an image to an article through the Upload Image tab', async ({
 
 	await expect(page.locator('img[src*="sample_image"]')).toBeVisible();
 });
+
+test(
+	'Child articles are ordered by priority in the navigation menu',
+	{tag: '@LPD-99924'},
+	async ({apiHelpers, knowledgeBasePage, page, site}) => {
+		const parentKnowledgeBaseArticle =
+			await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
+				articleBody: getRandomString(),
+				siteId: site.id,
+				title: 'Parent',
+			});
+
+		for (const title of ['Child C', 'Child B', 'Child A']) {
+			await apiHelpers.headlessDelivery.postKnowledgeBaseArticleKnowledgeBaseArticle(
+				{
+					articleBody: getRandomString(),
+					parentKnowledgeBaseArticleId: String(
+						parentKnowledgeBaseArticle.id
+					),
+					title,
+				}
+			);
+		}
+
+		await knowledgeBasePage.goto(site.friendlyUrlPath);
+
+		await page
+			.locator('.treeview-link', {hasText: 'Parent'})
+			.locator('.component-expander')
+			.click();
+
+		await expect(
+			page.locator('.treeview-link', {hasText: 'Child A'})
+		).toBeVisible();
+
+		const getChildOrder = async () =>
+			(await page.locator('.treeview-link').allInnerTexts())
+				.map((text) => text.trim())
+				.filter((text) => text.startsWith('Child'));
+
+		expect(await getChildOrder()).toEqual([
+			'Child C',
+			'Child B',
+			'Child A',
+		]);
+
+		await page
+			.locator('.treeview-link', {hasText: 'Child A'})
+			.getByRole('button', {name: 'Drag'})
+			.press('Enter');
+
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('Enter');
+
+		await waitForAlert(page);
+
+		await page.reload();
+
+		await page
+			.locator('.treeview-link', {hasText: 'Parent'})
+			.locator('.component-expander')
+			.click();
+
+		await expect(
+			page.locator('.treeview-link', {hasText: 'Child A'})
+		).toBeVisible();
+
+		expect(await getChildOrder()).toEqual([
+			'Child C',
+			'Child A',
+			'Child B',
+		]);
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99924

## What Is Being Fixed

Two defects made drag and drop reordering of child articles in the Knowledge Base navigation menu fail.

The drop never reached the tree. `Liferay.Upload._handleDrop` is bound on the document element and called `event.halt()`, which is `preventDefault()` plus `stopPropagation()`, on every drop before checking whether the drop carried any files. The drag and drop backend completes a drop from a listener on `window` in the bubble phase, so halting the event first meant the drop was discarded silently, with no request, no error and no feedback. The uploader binds that listener when an attachments uploader initializes, which happens on the article form, so reordering broke as soon as a user had visited the form and appeared to work again only after a full page reload. That is the hard refresh behavior described in the ticket.

Child articles were also displayed in title order while being stored and repositioned by priority, so a move that did reach the server did not survive a reload.

## How It Is Being Fixed

`_handleDrop` now returns early unless the drop actually carries files. File drops behave exactly as before, still halted so the browser cannot navigate to a dropped file, and every other drop propagates to the handlers that other drag and drop implementations depend on. The previous guard could not have prevented this, because `dataTransfer.files` is an empty `FileList` for a non-file drag and `A.Array([])` is truthy.

The navigation menu now sorts child articles with `KBArticlePriorityComparator` instead of `KBArticleTitleComparator`, so the order on screen matches the order that is stored and the index the client sends when repositioning an article.

## How To Test The Upload Changes

1. Open Knowledge Base admin and create a parent article with three child articles under it.

1. Without reloading, expand the parent in the navigation menu and drag one child between the other two. The article moves, a success message appears, and the new order survives a reload. Before this change the drop did nothing at all.

1. Open an article for editing, expand **Attachments**, and drag a file onto the drop zone. The file is still picked up, confirming file drops are unaffected.

1. Drag a file onto a part of the page outside the attachments drop zone. Nothing happens and the browser does not navigate to the file, confirming file drops are still halted.

## Why There Is No Test For `upload.js`

The file is an `AUI.add('liferay-upload', ...)` module that depends on the AlloyUI runtime and reads `document.currentScript.src` at load time, so it cannot be imported into Jest. `frontend-js-aui-web` declares no `test` script, and there is no precedent in the repository for unit testing the `liferay/*.js` AUI modules.

A functional test at the gesture level does not work either. Playwright's `dragTo` and manual mouse stepping both dispatch the native `dragstart` and `drop` events, but the drag and drop backend never accepts the drop, so such a test fails whether or not the fix is present and proves nothing.

The keyboard reordering path used by the Playwright test added here calls the drop handler directly and never dispatches a native `drop` event, so it cannot exercise this code path. That was confirmed by reverting `upload.js` and rerunning the test, which still passed.

The upload change was therefore verified manually with the steps above. The Playwright test added here covers the comparator change, and was confirmed to fail without it.

## PR Check

**pr-check: PASS** — tested on `b2f263e3aab683a0e8e7881b392a070d3dfe4843`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b2f263e3aab683a0e8e7881b392a070d3dfe4843"} -->
