### PR TITLE
LPD-98572 Preserve the configured vocabulary order across sites

### DIFF
--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -222,6 +222,25 @@ public class AssetCategoriesNavigationDisplayContext {
 		return _displayStyleGroupId;
 	}
 
+	private Long _getAssetVocabularyId(
+		String assetVocabularyExternalReferenceCode, long groupId) {
+
+		if (assetVocabularyExternalReferenceCode == null) {
+			return null;
+		}
+
+		AssetVocabulary assetVocabulary =
+			AssetVocabularyLocalServiceUtil.
+				fetchAssetVocabularyByExternalReferenceCode(
+					assetVocabularyExternalReferenceCode, groupId);
+
+		if (assetVocabulary == null) {
+			return null;
+		}
+
+		return assetVocabulary.getVocabularyId();
+	}
+
 	private String[] _getAssetVocabularyIds() {
 		List<Long> assetVocabularyIds = new ArrayList<>();
 
@@ -267,19 +286,10 @@ public class AssetCategoriesNavigationDisplayContext {
 			assetVocabularyIds.addAll(
 				(List<Long>)TransformUtil.transformToList(
 					assetVocabularyExternalReferenceCodes,
-					assetVocabularyExternalReferenceCode -> {
-						AssetVocabulary assetVocabulary =
-							AssetVocabularyLocalServiceUtil.
-								fetchAssetVocabularyByExternalReferenceCode(
-									assetVocabularyExternalReferenceCode,
-									group.getGroupId());
-
-						if (assetVocabulary == null) {
-							return null;
-						}
-
-						return assetVocabulary.getVocabularyId();
-					}));
+					assetVocabularyExternalReferenceCode ->
+						_getAssetVocabularyId(
+							assetVocabularyExternalReferenceCode,
+							group.getGroupId())));
 		}
 
 		return assetVocabularyIds;
@@ -295,19 +305,9 @@ public class AssetCategoriesNavigationDisplayContext {
 
 		return TransformUtil.transformToList(
 			assetVocabularyExternalReferenceCodes,
-			assetVocabularyExternalReferenceCode -> {
-				AssetVocabulary assetVocabulary =
-					AssetVocabularyLocalServiceUtil.
-						fetchAssetVocabularyByExternalReferenceCode(
-							assetVocabularyExternalReferenceCode,
-							_themeDisplay.getScopeGroupId());
-
-				if (assetVocabulary == null) {
-					return null;
-				}
-
-				return assetVocabulary.getVocabularyId();
-			});
+			assetVocabularyExternalReferenceCode -> _getAssetVocabularyId(
+				assetVocabularyExternalReferenceCode,
+				_themeDisplay.getScopeGroupId()));
 	}
 
 	private String _getTitle(AssetVocabulary assetVocabulary) {

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -301,21 +301,49 @@ public class AssetCategoriesNavigationDisplayContext {
 
 		groupIdsMap.put(StringPool.BLANK, _themeDisplay.getScopeGroupId());
 
-		for (Map.Entry<String, Queue<String>> entry :
-				assetVocabularyExternalReferenceCodesMap.entrySet()) {
+		if (_isOrdered(
+				assetVocabularyExternalReferenceCodesMap,
+				groupExternalReferenceCodes)) {
 
-			Long groupId = groupIdsMap.get(entry.getKey());
+			for (String groupExternalReferenceCode :
+					groupExternalReferenceCodes) {
 
-			if (groupId == null) {
-				continue;
+				Long groupId = groupIdsMap.get(groupExternalReferenceCode);
+
+				if (groupId == null) {
+					continue;
+				}
+
+				Queue<String> assetVocabularyExternalReferenceCodes =
+					assetVocabularyExternalReferenceCodesMap.get(
+						groupExternalReferenceCode);
+
+				Long assetVocabularyId = _getAssetVocabularyId(
+					assetVocabularyExternalReferenceCodes.poll(), groupId);
+
+				if (assetVocabularyId != null) {
+					assetVocabularyIds.add(assetVocabularyId);
+				}
 			}
+		}
+		else {
+			for (Map.Entry<String, Queue<String>> entry :
+					assetVocabularyExternalReferenceCodesMap.entrySet()) {
 
-			assetVocabularyIds.addAll(
-				TransformUtil.transform(
-					entry.getValue(),
-					assetVocabularyExternalReferenceCode ->
-						_getAssetVocabularyId(
-							assetVocabularyExternalReferenceCode, groupId)));
+				Long groupId = groupIdsMap.get(entry.getKey());
+
+				if (groupId == null) {
+					continue;
+				}
+
+				assetVocabularyIds.addAll(
+					TransformUtil.transform(
+						entry.getValue(),
+						assetVocabularyExternalReferenceCode ->
+							_getAssetVocabularyId(
+								assetVocabularyExternalReferenceCode,
+								groupId)));
+			}
 		}
 
 		return ArrayUtil.toStringArray(assetVocabularyIds);
@@ -335,6 +363,34 @@ public class AssetCategoriesNavigationDisplayContext {
 		}
 
 		return title;
+	}
+
+	private boolean _isOrdered(
+		Map<String, Queue<String>> assetVocabularyExternalReferenceCodesMap,
+		String[] groupExternalReferenceCodes) {
+
+		Map<String, Integer> countsMap = new HashMap<>();
+
+		for (String groupExternalReferenceCode : groupExternalReferenceCodes) {
+			countsMap.put(
+				groupExternalReferenceCode,
+				countsMap.getOrDefault(groupExternalReferenceCode, 0) + 1);
+		}
+
+		for (Map.Entry<String, Queue<String>> entry :
+				assetVocabularyExternalReferenceCodesMap.entrySet()) {
+
+			Queue<String> assetVocabularyExternalReferenceCodes =
+				entry.getValue();
+
+			if (assetVocabularyExternalReferenceCodes.size() !=
+					GetterUtil.getInteger(countsMap.get(entry.getKey()))) {
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private KeyValuePair _toKeyValuePair(AssetVocabulary assetVocabulary) {

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -12,6 +12,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -36,8 +37,14 @@ import jakarta.portlet.RenderRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * @author Eudaldo Alonso
@@ -222,6 +229,15 @@ public class AssetCategoriesNavigationDisplayContext {
 		return _displayStyleGroupId;
 	}
 
+	private Queue<String> _getAssetVocabularyExternalReferenceCodes(
+		String key, PortletPreferences portletPreferences) {
+
+		return new ArrayDeque<>(
+			Arrays.asList(
+				GetterUtil.getStringValues(
+					portletPreferences.getValues(key, null))));
+	}
+
 	private Long _getAssetVocabularyId(
 		String assetVocabularyExternalReferenceCode, long groupId) {
 
@@ -246,68 +262,63 @@ public class AssetCategoriesNavigationDisplayContext {
 
 		PortletPreferences portletPreferences = _renderRequest.getPreferences();
 
-		assetVocabularyIds.addAll(
-			_getExternalAssetVocabularyIds(portletPreferences));
-		assetVocabularyIds.addAll(
-			_getLocalAssetVocabularyIds(portletPreferences));
+		String[] groupExternalReferenceCodes = GetterUtil.getStringValues(
+			portletPreferences.getValues(
+				"assetVocabularyGroupExternalReferenceCodes", null));
 
-		return ArrayUtil.toStringArray(assetVocabularyIds);
-	}
+		Map<String, Queue<String>> assetVocabularyExternalReferenceCodesMap =
+			new LinkedHashMap<>();
+		Map<String, Long> groupIdsMap = new HashMap<>();
 
-	private List<Long> _getExternalAssetVocabularyIds(
-		PortletPreferences portletPreferences) {
+		for (String groupExternalReferenceCode : groupExternalReferenceCodes) {
+			if (Validator.isNull(groupExternalReferenceCode) ||
+				assetVocabularyExternalReferenceCodesMap.containsKey(
+					groupExternalReferenceCode)) {
 
-		List<Long> assetVocabularyIds = new ArrayList<>();
-
-		String[] assetVocabularyGroupExternalReferenceCodes =
-			GetterUtil.getStringValues(
-				portletPreferences.getValues(
-					"assetVocabularyGroupExternalReferenceCodes", null));
-
-		for (String assetVocabularyGroupExternalReferenceCode :
-				assetVocabularyGroupExternalReferenceCodes) {
-
-			Group group =
-				GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
-					assetVocabularyGroupExternalReferenceCode,
-					_themeDisplay.getCompanyId());
-
-			if (group == null) {
 				continue;
 			}
 
-			String[] assetVocabularyExternalReferenceCodes =
-				GetterUtil.getStringValues(
-					portletPreferences.getValues(
-						"assetVocabularyExternalReferenceCodes_" +
-							assetVocabularyGroupExternalReferenceCode,
-						null));
+			assetVocabularyExternalReferenceCodesMap.put(
+				groupExternalReferenceCode,
+				_getAssetVocabularyExternalReferenceCodes(
+					"assetVocabularyExternalReferenceCodes_" +
+						groupExternalReferenceCode,
+					portletPreferences));
 
-			assetVocabularyIds.addAll(
-				(List<Long>)TransformUtil.transformToList(
-					assetVocabularyExternalReferenceCodes,
-					assetVocabularyExternalReferenceCode ->
-						_getAssetVocabularyId(
-							assetVocabularyExternalReferenceCode,
-							group.getGroupId())));
+			Group group =
+				GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+					groupExternalReferenceCode, _themeDisplay.getCompanyId());
+
+			if (group != null) {
+				groupIdsMap.put(groupExternalReferenceCode, group.getGroupId());
+			}
 		}
 
-		return assetVocabularyIds;
-	}
+		assetVocabularyExternalReferenceCodesMap.put(
+			StringPool.BLANK,
+			_getAssetVocabularyExternalReferenceCodes(
+				"assetVocabularyExternalReferenceCodes", portletPreferences));
 
-	private List<Long> _getLocalAssetVocabularyIds(
-		PortletPreferences portletPreferences) {
+		groupIdsMap.put(StringPool.BLANK, _themeDisplay.getScopeGroupId());
 
-		String[] assetVocabularyExternalReferenceCodes =
-			GetterUtil.getStringValues(
-				portletPreferences.getValues(
-					"assetVocabularyExternalReferenceCodes", null));
+		for (Map.Entry<String, Queue<String>> entry :
+				assetVocabularyExternalReferenceCodesMap.entrySet()) {
 
-		return TransformUtil.transformToList(
-			assetVocabularyExternalReferenceCodes,
-			assetVocabularyExternalReferenceCode -> _getAssetVocabularyId(
-				assetVocabularyExternalReferenceCode,
-				_themeDisplay.getScopeGroupId()));
+			Long groupId = groupIdsMap.get(entry.getKey());
+
+			if (groupId == null) {
+				continue;
+			}
+
+			assetVocabularyIds.addAll(
+				TransformUtil.transform(
+					entry.getValue(),
+					assetVocabularyExternalReferenceCode ->
+						_getAssetVocabularyId(
+							assetVocabularyExternalReferenceCode, groupId)));
+		}
+
+		return ArrayUtil.toStringArray(assetVocabularyIds);
 	}
 
 	private String _getTitle(AssetVocabulary assetVocabulary) {

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/exportimport/portlet/preferences/processor/AssetCategoriesNavigationPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/exportimport/portlet/preferences/processor/AssetCategoriesNavigationPortletPreferencesProcessor.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -27,10 +28,11 @@ import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.portlet.PortletPreferences;
 
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -231,36 +233,76 @@ public class AssetCategoriesNavigationPortletPreferencesProcessor
 			return;
 		}
 
-		for (int i = 0; i < assetVocabularyGroupExternalReferenceCodes.length;
-			 i++) {
+		Map<String, String[]> assetVocabularyExternalReferenceCodesMap =
+			new HashMap<>();
 
-			String assetVocabularyGroupExternalReferenceCode =
-				assetVocabularyGroupExternalReferenceCodes[i];
-			String newAssetVocabularyGroupExternalReferenceCode =
-				newAssetVocabularyGroupExternalReferenceCodes[i];
+		for (String assetVocabularyGroupExternalReferenceCode :
+				assetVocabularyGroupExternalReferenceCodes) {
 
-			if (Objects.equals(
-					assetVocabularyGroupExternalReferenceCode,
-					newAssetVocabularyGroupExternalReferenceCode)) {
+			if (Validator.isNull(assetVocabularyGroupExternalReferenceCode) ||
+				assetVocabularyExternalReferenceCodesMap.containsKey(
+					assetVocabularyGroupExternalReferenceCode)) {
 
 				continue;
 			}
 
-			String[] assetVocabularyExternalReferenceCodesValues =
+			String[] assetVocabularyExternalReferenceCodes =
 				portletPreferences.getValues(
 					"assetVocabularyExternalReferenceCodes_" +
 						assetVocabularyGroupExternalReferenceCode,
 					null);
 
-			portletPreferences.setValues(
-				"assetVocabularyExternalReferenceCodes_" +
-					newAssetVocabularyGroupExternalReferenceCode,
-				assetVocabularyExternalReferenceCodesValues);
+			if (assetVocabularyExternalReferenceCodes == null) {
+				continue;
+			}
+
+			assetVocabularyExternalReferenceCodesMap.put(
+				assetVocabularyGroupExternalReferenceCode,
+				assetVocabularyExternalReferenceCodes);
 
 			portletPreferences.reset(
 				"assetVocabularyExternalReferenceCodes_" +
 					assetVocabularyGroupExternalReferenceCode);
 		}
+
+		List<String> groupExternalReferenceCodes = new ArrayList<>();
+
+		for (int i = 0; i < assetVocabularyGroupExternalReferenceCodes.length;
+			 i++) {
+
+			String assetVocabularyGroupExternalReferenceCode =
+				assetVocabularyGroupExternalReferenceCodes[i];
+
+			if (Validator.isNull(assetVocabularyGroupExternalReferenceCode)) {
+				groupExternalReferenceCodes.add(
+					assetVocabularyGroupExternalReferenceCode);
+
+				continue;
+			}
+
+			String[] assetVocabularyExternalReferenceCodes =
+				assetVocabularyExternalReferenceCodesMap.get(
+					assetVocabularyGroupExternalReferenceCode);
+
+			if (assetVocabularyExternalReferenceCodes == null) {
+				continue;
+			}
+
+			String newAssetVocabularyGroupExternalReferenceCode =
+				newAssetVocabularyGroupExternalReferenceCodes[i];
+
+			groupExternalReferenceCodes.add(
+				newAssetVocabularyGroupExternalReferenceCode);
+
+			portletPreferences.setValues(
+				"assetVocabularyExternalReferenceCodes_" +
+					newAssetVocabularyGroupExternalReferenceCode,
+				assetVocabularyExternalReferenceCodes);
+		}
+
+		portletPreferences.setValues(
+			"assetVocabularyGroupExternalReferenceCodes",
+			ArrayUtil.toStringArray(groupExternalReferenceCodes));
 	}
 
 	@Reference

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationAction.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationAction.java
@@ -8,6 +8,7 @@ package com.liferay.asset.categories.navigation.web.internal.portlet.action;
 import com.liferay.asset.categories.navigation.constants.AssetCategoriesNavigationPortletKeys;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
@@ -28,7 +29,7 @@ import jakarta.portlet.ReadOnlyException;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,15 +76,11 @@ public class AssetCategoriesNavigationConfigurationAction
 		long[] assetVocabularyIds = GetterUtil.getLongValues(
 			StringUtil.split(assetVocabularyIdsString, ','));
 
-		Map<Long, List<String>> groupAssetVocabularyIdsMap =
-			_getGroupAssetVocabularyExternalReferenceCodesMap(
-				assetVocabularyIds);
-
 		try {
 			_resetPortletPreferences(portletPreferences);
 
 			_setPortletPreferences(
-				portletPreferences, portletRequest, groupAssetVocabularyIdsMap);
+				assetVocabularyIds, portletPreferences, portletRequest);
 
 			portletPreferences.reset("assetVocabularyIds");
 			portletPreferences.reset("displayStyleGroupId");
@@ -91,33 +88,6 @@ public class AssetCategoriesNavigationConfigurationAction
 		catch (ReadOnlyException readOnlyException) {
 			throw new SystemException(readOnlyException);
 		}
-	}
-
-	private Map<Long, List<String>>
-			_getGroupAssetVocabularyExternalReferenceCodesMap(
-				long[] assetVocabularyIds)
-		throws PortalException {
-
-		Map<Long, List<String>> groupAssetVocabularyExternalReferenceCodesMap =
-			new HashMap<>();
-
-		for (long assetVocabularyId : assetVocabularyIds) {
-			AssetVocabulary assetVocabulary =
-				_assetVocabularyService.fetchVocabulary(assetVocabularyId);
-
-			if (assetVocabulary == null) {
-				continue;
-			}
-
-			List<String> groupAssetVocabularyExternalReferenceCodes =
-				groupAssetVocabularyExternalReferenceCodesMap.computeIfAbsent(
-					assetVocabulary.getGroupId(), key -> new ArrayList<>());
-
-			groupAssetVocabularyExternalReferenceCodes.add(
-				assetVocabulary.getExternalReferenceCode());
-		}
-
-		return groupAssetVocabularyExternalReferenceCodesMap;
 	}
 
 	private void _resetPortletPreferences(PortletPreferences portletPreferences)
@@ -138,35 +108,55 @@ public class AssetCategoriesNavigationConfigurationAction
 	}
 
 	private void _setPortletPreferences(
-			PortletPreferences portletPreferences,
-			PortletRequest portletRequest,
-			Map<Long, List<String>> groupAssetVocabularyIdsMap)
+			long[] assetVocabularyIds, PortletPreferences portletPreferences,
+			PortletRequest portletRequest)
 		throws PortalException, ReadOnlyException {
 
+		Map<String, List<String>> assetVocabularyExternalReferenceCodesMap =
+			new LinkedHashMap<>();
 		List<String> groupExternalReferenceCodes = new ArrayList<>();
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		for (Map.Entry<Long, List<String>> entries :
-				groupAssetVocabularyIdsMap.entrySet()) {
+		for (long assetVocabularyId : assetVocabularyIds) {
+			AssetVocabulary assetVocabulary =
+				_assetVocabularyService.fetchVocabulary(assetVocabularyId);
 
-			Group group = _groupLocalService.getGroup(entries.getKey());
-
-			if (group.getGroupId() == themeDisplay.getScopeGroupId()) {
-				portletPreferences.setValues(
-					"assetVocabularyExternalReferenceCodes",
-					ArrayUtil.toStringArray(entries.getValue()));
+			if (assetVocabulary == null) {
+				continue;
 			}
-			else {
-				groupExternalReferenceCodes.add(
-					group.getExternalReferenceCode());
 
-				portletPreferences.setValues(
-					"assetVocabularyExternalReferenceCodes_" +
-						group.getExternalReferenceCode(),
-					ArrayUtil.toStringArray(entries.getValue()));
+			Group group = _groupLocalService.getGroup(
+				assetVocabulary.getGroupId());
+
+			String groupExternalReferenceCode = StringPool.BLANK;
+
+			if (group.getGroupId() != themeDisplay.getScopeGroupId()) {
+				groupExternalReferenceCode = group.getExternalReferenceCode();
 			}
+
+			groupExternalReferenceCodes.add(groupExternalReferenceCode);
+
+			String key = "assetVocabularyExternalReferenceCodes";
+
+			if (Validator.isNotNull(groupExternalReferenceCode)) {
+				key += "_" + groupExternalReferenceCode;
+			}
+
+			List<String> assetVocabularyExternalReferenceCodes =
+				assetVocabularyExternalReferenceCodesMap.computeIfAbsent(
+					key, curKey -> new ArrayList<>());
+
+			assetVocabularyExternalReferenceCodes.add(
+				assetVocabulary.getExternalReferenceCode());
+		}
+
+		for (Map.Entry<String, List<String>> entry :
+				assetVocabularyExternalReferenceCodesMap.entrySet()) {
+
+			portletPreferences.setValues(
+				entry.getKey(), ArrayUtil.toStringArray(entry.getValue()));
 		}
 
 		portletPreferences.setValues(

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationAction.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/AssetCategoriesNavigationConfigurationAction.java
@@ -68,7 +68,7 @@ public class AssetCategoriesNavigationConfigurationAction
 		String assetVocabularyIdsString = portletPreferences.getValue(
 			"assetVocabularyIds", null);
 
-		if (Validator.isNull(assetVocabularyIdsString)) {
+		if (assetVocabularyIdsString == null) {
 			return;
 		}
 
@@ -131,7 +131,7 @@ public class AssetCategoriesNavigationConfigurationAction
 
 			String key = entry.getKey();
 
-			if (key.startsWith("assetVocabularyExternalReferenceCodes_")) {
+			if (key.startsWith("assetVocabularyExternalReferenceCodes")) {
 				portletPreferences.reset(key);
 			}
 		}

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/upgrade/v1_0_2/UpgradePortletPreferences.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/upgrade/v1_0_2/UpgradePortletPreferences.java
@@ -17,7 +17,7 @@ import com.liferay.portlet.display.template.upgrade.BaseUpgradePortletPreference
 import jakarta.portlet.PortletPreferences;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,50 +75,9 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 			return;
 		}
 
-		Map<Long, List<String>> groupAssetVocabularyExternalReferenceCodesMap =
-			_getGroupAssetVocabularyExternalReferenceCodesMap(
-				assetVocabularyIds);
-
-		if (groupAssetVocabularyExternalReferenceCodesMap.isEmpty()) {
-			return;
-		}
-
-		portletPreferences.reset("assetVocabularyIds");
-
+		Map<String, List<String>> assetVocabularyExternalReferenceCodesMap =
+			new LinkedHashMap<>();
 		List<String> groupExternalReferenceCodes = new ArrayList<>();
-
-		for (Map.Entry<Long, List<String>> entries :
-				groupAssetVocabularyExternalReferenceCodesMap.entrySet()) {
-
-			String scopeExternalReferenceCode = getScopeExternalReferenceCode(
-				companyId, ownerId, ownerType, plid, entries.getKey());
-
-			if (Validator.isNull(scopeExternalReferenceCode)) {
-				portletPreferences.setValues(
-					"assetVocabularyExternalReferenceCodes",
-					ArrayUtil.toStringArray(entries.getValue()));
-			}
-			else {
-				groupExternalReferenceCodes.add(scopeExternalReferenceCode);
-
-				portletPreferences.setValues(
-					"assetVocabularyExternalReferenceCodes_" +
-						scopeExternalReferenceCode,
-					ArrayUtil.toStringArray(entries.getValue()));
-			}
-		}
-
-		portletPreferences.setValues(
-			"assetVocabularyGroupExternalReferenceCodes",
-			ArrayUtil.toStringArray(groupExternalReferenceCodes));
-	}
-
-	private Map<Long, List<String>>
-		_getGroupAssetVocabularyExternalReferenceCodesMap(
-			long[] assetVocabularyIds) {
-
-		Map<Long, List<String>> groupAssetVocabularyExternalReferenceCodesMap =
-			new HashMap<>();
 
 		for (long assetVocabularyId : assetVocabularyIds) {
 			AssetVocabulary assetVocabulary =
@@ -129,15 +88,43 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 				continue;
 			}
 
-			List<String> groupAssetVocabularyExternalReferenceCodes =
-				groupAssetVocabularyExternalReferenceCodesMap.computeIfAbsent(
-					assetVocabulary.getGroupId(), key -> new ArrayList<>());
+			String scopeExternalReferenceCode = GetterUtil.getString(
+				getScopeExternalReferenceCode(
+					companyId, ownerId, ownerType, plid,
+					assetVocabulary.getGroupId()));
 
-			groupAssetVocabularyExternalReferenceCodes.add(
+			groupExternalReferenceCodes.add(scopeExternalReferenceCode);
+
+			String key = "assetVocabularyExternalReferenceCodes";
+
+			if (Validator.isNotNull(scopeExternalReferenceCode)) {
+				key += "_" + scopeExternalReferenceCode;
+			}
+
+			List<String> assetVocabularyExternalReferenceCodes =
+				assetVocabularyExternalReferenceCodesMap.computeIfAbsent(
+					key, curKey -> new ArrayList<>());
+
+			assetVocabularyExternalReferenceCodes.add(
 				assetVocabulary.getExternalReferenceCode());
 		}
 
-		return groupAssetVocabularyExternalReferenceCodesMap;
+		if (groupExternalReferenceCodes.isEmpty()) {
+			return;
+		}
+
+		portletPreferences.reset("assetVocabularyIds");
+
+		for (Map.Entry<String, List<String>> entry :
+				assetVocabularyExternalReferenceCodesMap.entrySet()) {
+
+			portletPreferences.setValues(
+				entry.getKey(), ArrayUtil.toStringArray(entry.getValue()));
+		}
+
+		portletPreferences.setValues(
+			"assetVocabularyGroupExternalReferenceCodes",
+			ArrayUtil.toStringArray(groupExternalReferenceCodes));
 	}
 
 	private final AssetVocabularyLocalService _assetVocabularyLocalService;

--- a/modules/apps/asset/asset-categories-navigation-web/src/test/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContextTest.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/test/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContextTest.java
@@ -1,0 +1,378 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.navigation.web.internal.display.context;
+
+import com.liferay.asset.categories.navigation.web.internal.configuration.AssetCategoriesNavigationPortletInstanceConfiguration;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.upgrade.MockPortletPreferences;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+import jakarta.portlet.RenderRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Akhash Ramprakash
+ */
+public class AssetCategoriesNavigationDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_assetVocabularyLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			AssetVocabularyLocalServiceUtil.class);
+		_assetVocabularyServiceUtilMockedStatic = Mockito.mockStatic(
+			AssetVocabularyServiceUtil.class);
+		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
+			ConfigurationProviderUtil.class);
+		_groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			GroupLocalServiceUtil.class);
+
+		_companyId = RandomTestUtil.randomLong();
+
+		_setUpConfigurationProviderUtil();
+		_setUpThemeDisplay();
+
+		_companyGroup = _mockGroup();
+		_parentGroup = _mockGroup();
+	}
+
+	@After
+	public void tearDown() {
+		_assetVocabularyLocalServiceUtilMockedStatic.close();
+		_assetVocabularyServiceUtilMockedStatic.close();
+		_configurationProviderUtilMockedStatic.close();
+		_groupLocalServiceUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testGetAssetVocabularyIds() throws Exception {
+		_testGetAssetVocabularyIdsWithLegacyPortletPreferences();
+		_testGetAssetVocabularyIdsWithMisalignedPortletPreferences();
+		_testGetAssetVocabularyIdsWithOrderedPortletPreferences();
+		_testGetAssetVocabularyIdsWithUnresolvableAssetVocabulary();
+	}
+
+	private AssetCategoriesNavigationDisplayContext _createDisplayContext(
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+
+		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
+
+		Mockito.when(
+			renderRequest.getPreferences()
+		).thenReturn(
+			portletPreferences
+		);
+
+		return new AssetCategoriesNavigationDisplayContext(
+			mockHttpServletRequest, renderRequest);
+	}
+
+	private AssetVocabulary _mockAssetVocabulary(long groupId) {
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		long vocabularyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			assetVocabulary.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		Mockito.when(
+			assetVocabulary.getVocabularyId()
+		).thenReturn(
+			vocabularyId
+		);
+
+		_assetVocabularyLocalServiceUtilMockedStatic.when(
+			() ->
+				AssetVocabularyLocalServiceUtil.
+					fetchAssetVocabularyByExternalReferenceCode(
+						externalReferenceCode, groupId)
+		).thenReturn(
+			assetVocabulary
+		);
+
+		_assetVocabularyServiceUtilMockedStatic.when(
+			() -> AssetVocabularyServiceUtil.fetchVocabulary(vocabularyId)
+		).thenReturn(
+			assetVocabulary
+		);
+
+		return assetVocabulary;
+	}
+
+	private Group _mockGroup() {
+		Group group = Mockito.mock(Group.class);
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		long groupId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			group.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		Mockito.when(
+			group.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		_groupLocalServiceUtilMockedStatic.when(
+			() -> GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+				externalReferenceCode, _companyId)
+		).thenReturn(
+			group
+		);
+
+		return group;
+	}
+
+	private void _setUpConfigurationProviderUtil() {
+		AssetCategoriesNavigationPortletInstanceConfiguration
+			assetCategoriesNavigationPortletInstanceConfiguration =
+				Mockito.mock(
+					AssetCategoriesNavigationPortletInstanceConfiguration.
+						class);
+
+		Mockito.when(
+			assetCategoriesNavigationPortletInstanceConfiguration.
+				allAssetVocabularies()
+		).thenReturn(
+			false
+		);
+
+		_configurationProviderUtilMockedStatic.when(
+			() -> ConfigurationProviderUtil.getPortletInstanceConfiguration(
+				Mockito.eq(
+					AssetCategoriesNavigationPortletInstanceConfiguration.
+						class),
+				Mockito.any(ThemeDisplay.class))
+		).thenReturn(
+			assetCategoriesNavigationPortletInstanceConfiguration
+		);
+	}
+
+	private void _setUpThemeDisplay() {
+		_scopeGroupId = RandomTestUtil.randomLong();
+
+		_themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			_themeDisplay.getCompanyId()
+		).thenReturn(
+			_companyId
+		);
+
+		Mockito.when(
+			_themeDisplay.getScopeGroupId()
+		).thenReturn(
+			_scopeGroupId
+		);
+	}
+
+	private void _testGetAssetVocabularyIdsWithLegacyPortletPreferences()
+		throws Exception {
+
+		AssetVocabulary companyAssetVocabulary1 = _mockAssetVocabulary(
+			_companyGroup.getGroupId());
+		AssetVocabulary companyAssetVocabulary2 = _mockAssetVocabulary(
+			_companyGroup.getGroupId());
+		AssetVocabulary scopeAssetVocabulary = _mockAssetVocabulary(
+			_scopeGroupId);
+
+		PortletPreferences portletPreferences = new MockPortletPreferences();
+
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes",
+			scopeAssetVocabulary.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes_" +
+				_companyGroup.getExternalReferenceCode(),
+			companyAssetVocabulary1.getExternalReferenceCode(),
+			companyAssetVocabulary2.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyGroupExternalReferenceCodes",
+			_companyGroup.getExternalReferenceCode());
+
+		AssetCategoriesNavigationDisplayContext
+			assetCategoriesNavigationDisplayContext = _createDisplayContext(
+				portletPreferences);
+
+		Assert.assertArrayEquals(
+			new long[] {
+				companyAssetVocabulary1.getVocabularyId(),
+				companyAssetVocabulary2.getVocabularyId(),
+				scopeAssetVocabulary.getVocabularyId()
+			},
+			assetCategoriesNavigationDisplayContext.getAssetVocabularyIds());
+	}
+
+	private void _testGetAssetVocabularyIdsWithMisalignedPortletPreferences()
+		throws Exception {
+
+		AssetVocabulary companyAssetVocabulary = _mockAssetVocabulary(
+			_companyGroup.getGroupId());
+		AssetVocabulary scopeAssetVocabulary = _mockAssetVocabulary(
+			_scopeGroupId);
+
+		PortletPreferences portletPreferences = new MockPortletPreferences();
+
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes",
+			scopeAssetVocabulary.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes_" +
+				_companyGroup.getExternalReferenceCode(),
+			companyAssetVocabulary.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyGroupExternalReferenceCodes",
+			_companyGroup.getExternalReferenceCode(),
+			_companyGroup.getExternalReferenceCode(), StringPool.BLANK);
+
+		AssetCategoriesNavigationDisplayContext
+			assetCategoriesNavigationDisplayContext = _createDisplayContext(
+				portletPreferences);
+
+		Assert.assertArrayEquals(
+			new long[] {
+				companyAssetVocabulary.getVocabularyId(),
+				scopeAssetVocabulary.getVocabularyId()
+			},
+			assetCategoriesNavigationDisplayContext.getAssetVocabularyIds());
+	}
+
+	private void _testGetAssetVocabularyIdsWithOrderedPortletPreferences()
+		throws Exception {
+
+		AssetVocabulary companyAssetVocabulary1 = _mockAssetVocabulary(
+			_companyGroup.getGroupId());
+		AssetVocabulary companyAssetVocabulary2 = _mockAssetVocabulary(
+			_companyGroup.getGroupId());
+		AssetVocabulary parentAssetVocabulary = _mockAssetVocabulary(
+			_parentGroup.getGroupId());
+		AssetVocabulary scopeAssetVocabulary = _mockAssetVocabulary(
+			_scopeGroupId);
+
+		PortletPreferences portletPreferences = new MockPortletPreferences();
+
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes",
+			scopeAssetVocabulary.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes_" +
+				_companyGroup.getExternalReferenceCode(),
+			companyAssetVocabulary1.getExternalReferenceCode(),
+			companyAssetVocabulary2.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes_" +
+				_parentGroup.getExternalReferenceCode(),
+			parentAssetVocabulary.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyGroupExternalReferenceCodes",
+			_companyGroup.getExternalReferenceCode(), StringPool.BLANK,
+			_parentGroup.getExternalReferenceCode(),
+			_companyGroup.getExternalReferenceCode());
+
+		AssetCategoriesNavigationDisplayContext
+			assetCategoriesNavigationDisplayContext = _createDisplayContext(
+				portletPreferences);
+
+		Assert.assertArrayEquals(
+			new long[] {
+				companyAssetVocabulary1.getVocabularyId(),
+				scopeAssetVocabulary.getVocabularyId(),
+				parentAssetVocabulary.getVocabularyId(),
+				companyAssetVocabulary2.getVocabularyId()
+			},
+			assetCategoriesNavigationDisplayContext.getAssetVocabularyIds());
+	}
+
+	private void _testGetAssetVocabularyIdsWithUnresolvableAssetVocabulary()
+		throws Exception {
+
+		AssetVocabulary companyAssetVocabulary = _mockAssetVocabulary(
+			_companyGroup.getGroupId());
+		AssetVocabulary scopeAssetVocabulary = _mockAssetVocabulary(
+			_scopeGroupId);
+
+		PortletPreferences portletPreferences = new MockPortletPreferences();
+
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes",
+			scopeAssetVocabulary.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes_" +
+				_companyGroup.getExternalReferenceCode(),
+			RandomTestUtil.randomString(),
+			companyAssetVocabulary.getExternalReferenceCode());
+		portletPreferences.setValues(
+			"assetVocabularyGroupExternalReferenceCodes",
+			_companyGroup.getExternalReferenceCode(), StringPool.BLANK,
+			_companyGroup.getExternalReferenceCode());
+
+		AssetCategoriesNavigationDisplayContext
+			assetCategoriesNavigationDisplayContext = _createDisplayContext(
+				portletPreferences);
+
+		Assert.assertArrayEquals(
+			new long[] {
+				scopeAssetVocabulary.getVocabularyId(),
+				companyAssetVocabulary.getVocabularyId()
+			},
+			assetCategoriesNavigationDisplayContext.getAssetVocabularyIds());
+	}
+
+	private MockedStatic<AssetVocabularyLocalServiceUtil>
+		_assetVocabularyLocalServiceUtilMockedStatic;
+	private MockedStatic<AssetVocabularyServiceUtil>
+		_assetVocabularyServiceUtilMockedStatic;
+	private Group _companyGroup;
+	private long _companyId;
+	private MockedStatic<ConfigurationProviderUtil>
+		_configurationProviderUtilMockedStatic;
+	private MockedStatic<GroupLocalServiceUtil>
+		_groupLocalServiceUtilMockedStatic;
+	private Group _parentGroup;
+	private long _scopeGroupId;
+	private ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/portlet/preferences/processor/test/AssetCategoriesNavigationPortletPreferencesProcessorTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/portlet/preferences/processor/test/AssetCategoriesNavigationPortletPreferencesProcessorTest.java
@@ -13,12 +13,15 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -86,6 +89,14 @@ public class AssetCategoriesNavigationPortletPreferencesProcessorTest {
 	public void testProcessAssetVocabularyExternalReferenceCode()
 		throws Exception {
 
+		Group companyGroup = _groupLocalService.getCompanyGroup(
+			_group.getCompanyId());
+
+		AssetVocabulary companyAssetVocabulary1 = AssetTestUtil.addVocabulary(
+			companyGroup.getGroupId());
+		AssetVocabulary companyAssetVocabulary2 = AssetTestUtil.addVocabulary(
+			companyGroup.getGroupId());
+
 		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
 			_group.getGroupId());
 
@@ -94,6 +105,16 @@ public class AssetCategoriesNavigationPortletPreferencesProcessorTest {
 		_portletPreferences.setValues(
 			"assetVocabularyExternalReferenceCodes",
 			assetVocabulary.getExternalReferenceCode());
+		_portletPreferences.setValues(
+			"assetVocabularyExternalReferenceCodes_" +
+				companyGroup.getExternalReferenceCode(),
+			companyAssetVocabulary1.getExternalReferenceCode(),
+			companyAssetVocabulary2.getExternalReferenceCode());
+		_portletPreferences.setValues(
+			"assetVocabularyGroupExternalReferenceCodes",
+			companyGroup.getExternalReferenceCode(), StringPool.BLANK,
+			companyGroup.getExternalReferenceCode(),
+			RandomTestUtil.randomString());
 
 		_portletPreferences.store();
 
@@ -102,28 +123,52 @@ public class AssetCategoriesNavigationPortletPreferencesProcessorTest {
 				processExportPortletPreferences(
 					_portletDataContextExport, _portletPreferences);
 
-		String[] exportedAssetVocabularyExternalReferenceCodes =
+		Assert.assertArrayEquals(
+			new String[] {
+				companyGroup.getExternalReferenceCode(), StringPool.BLANK,
+				companyGroup.getExternalReferenceCode()
+			},
 			exportedPortletPreferences.getValues(
-				"assetVocabularyExternalReferenceCodes", null);
-
-		Assert.assertNotNull(exportedAssetVocabularyExternalReferenceCodes);
-
-		Assert.assertEquals(
-			assetVocabulary.getExternalReferenceCode(),
-			exportedAssetVocabularyExternalReferenceCodes[0]);
+				"assetVocabularyGroupExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {assetVocabulary.getExternalReferenceCode()},
+			exportedPortletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {
+				companyAssetVocabulary1.getExternalReferenceCode(),
+				companyAssetVocabulary2.getExternalReferenceCode()
+			},
+			exportedPortletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes_" +
+					companyGroup.getExternalReferenceCode(),
+				null));
 
 		PortletPreferences importedPortletPreferences =
 			_exportImportPortletPreferencesProcessor.
 				processImportPortletPreferences(
 					_portletDataContextImport, exportedPortletPreferences);
 
-		String[] importedAssetVocabularyExternalReferenceCodes =
+		Assert.assertArrayEquals(
+			new String[] {
+				companyGroup.getExternalReferenceCode(), StringPool.BLANK,
+				companyGroup.getExternalReferenceCode()
+			},
 			importedPortletPreferences.getValues(
-				"assetVocabularyExternalReferenceCodes", null);
-
-		Assert.assertEquals(
-			assetVocabulary.getExternalReferenceCode(),
-			importedAssetVocabularyExternalReferenceCodes[0]);
+				"assetVocabularyGroupExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {assetVocabulary.getExternalReferenceCode()},
+			importedPortletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {
+				companyAssetVocabulary1.getExternalReferenceCode(),
+				companyAssetVocabulary2.getExternalReferenceCode()
+			},
+			importedPortletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes_" +
+					companyGroup.getExternalReferenceCode(),
+				null));
 	}
 
 	@Inject(
@@ -134,6 +179,9 @@ public class AssetCategoriesNavigationPortletPreferencesProcessorTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	private Layout _layout;
 	private PortletDataContext _portletDataContextExport;

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/test/AssetCategoriesNavigationConfigurationActionTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/navigation/web/internal/portlet/action/test/AssetCategoriesNavigationConfigurationActionTest.java
@@ -1,0 +1,203 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.navigation.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.categories.navigation.constants.AssetCategoriesNavigationPortletKeys;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.ConfigurationAction;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockPortletRequest;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portlet.PortletPreferencesImpl;
+
+import jakarta.portlet.PortletPreferences;
+import jakarta.portlet.PortletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Akhash Ramprakash
+ */
+@RunWith(Arquillian.class)
+public class AssetCategoriesNavigationConfigurationActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_parentGroup = GroupTestUtil.addGroup();
+
+		_group = GroupTestUtil.addGroup(_parentGroup.getGroupId());
+	}
+
+	@Test
+	public void testPostProcess() throws Exception {
+		Group companyGroup = _groupLocalService.getCompanyGroup(
+			_group.getCompanyId());
+
+		AssetVocabulary companyAssetVocabulary1 = AssetTestUtil.addVocabulary(
+			companyGroup.getGroupId());
+		AssetVocabulary companyAssetVocabulary2 = AssetTestUtil.addVocabulary(
+			companyGroup.getGroupId());
+
+		AssetVocabulary parentAssetVocabulary = AssetTestUtil.addVocabulary(
+			_parentGroup.getGroupId());
+		AssetVocabulary scopeAssetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		PortletPreferences portletPreferences = new PortletPreferencesImpl();
+
+		portletPreferences.setValue(
+			"allAssetVocabularies", Boolean.FALSE.toString());
+		portletPreferences.setValue(
+			"assetVocabularyIds",
+			StringUtil.merge(
+				new Long[] {
+					companyAssetVocabulary1.getVocabularyId(),
+					scopeAssetVocabulary.getVocabularyId(),
+					parentAssetVocabulary.getVocabularyId(),
+					companyAssetVocabulary2.getVocabularyId()
+				}));
+
+		_postProcess(portletPreferences);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				companyGroup.getExternalReferenceCode(), StringPool.BLANK,
+				_parentGroup.getExternalReferenceCode(),
+				companyGroup.getExternalReferenceCode()
+			},
+			portletPreferences.getValues(
+				"assetVocabularyGroupExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {scopeAssetVocabulary.getExternalReferenceCode()},
+			portletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {
+				companyAssetVocabulary1.getExternalReferenceCode(),
+				companyAssetVocabulary2.getExternalReferenceCode()
+			},
+			portletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes_" +
+					companyGroup.getExternalReferenceCode(),
+				null));
+		Assert.assertArrayEquals(
+			new String[] {parentAssetVocabulary.getExternalReferenceCode()},
+			portletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes_" +
+					_parentGroup.getExternalReferenceCode(),
+				null));
+		Assert.assertNull(
+			portletPreferences.getValue("assetVocabularyIds", null));
+	}
+
+	@Test
+	public void testPostProcessWithoutAssetVocabularies() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		PortletPreferences portletPreferences = new PortletPreferencesImpl();
+
+		portletPreferences.setValue(
+			"allAssetVocabularies", Boolean.FALSE.toString());
+		portletPreferences.setValue(
+			"assetVocabularyIds",
+			String.valueOf(assetVocabulary.getVocabularyId()));
+
+		_postProcess(portletPreferences);
+
+		Assert.assertArrayEquals(
+			new String[] {assetVocabulary.getExternalReferenceCode()},
+			portletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes", null));
+
+		portletPreferences.setValue("assetVocabularyIds", StringPool.BLANK);
+
+		_postProcess(portletPreferences);
+
+		Assert.assertNull(
+			portletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes", null));
+		Assert.assertNull(
+			portletPreferences.getValues(
+				"assetVocabularyGroupExternalReferenceCodes", null));
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
+	private void _postProcess(PortletPreferences portletPreferences)
+		throws Exception {
+
+		MockPortletRequest mockPortletRequest = new MockPortletRequest();
+
+		mockPortletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		ReflectionTestUtil.invoke(
+			_configurationAction, "postProcess",
+			new Class<?>[] {
+				long.class, PortletRequest.class, PortletPreferences.class
+			},
+			TestPropsValues.getCompanyId(), mockPortletRequest,
+			portletPreferences);
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "jakarta.portlet.name=" + AssetCategoriesNavigationPortletKeys.ASSET_CATEGORIES_NAVIGATION
+	)
+	private ConfigurationAction _configurationAction;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@DeleteAfterTestRun
+	private Group _parentGroup;
+
+}

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/navigation/web/internal/upgrade/v1_0_2/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/navigation/web/internal/upgrade/v1_0_2/test/UpgradePortletPreferencesTest.java
@@ -14,6 +14,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.model.Group;
@@ -85,6 +86,62 @@ public class UpgradePortletPreferencesTest {
 				"displayStyleGroupExternalReferenceCode",
 				_group.getExternalReferenceCode()
 			).build());
+	}
+
+	@Test
+	public void testUpgradePortletPreferencesKeepsAssetVocabulariesOrder()
+		throws Exception {
+
+		Group companyGroup = _groupLocalService.getCompanyGroup(
+			_group.getCompanyId());
+
+		AssetVocabulary companyAssetVocabulary1 = AssetTestUtil.addVocabulary(
+			companyGroup.getGroupId());
+		AssetVocabulary companyAssetVocabulary2 = AssetTestUtil.addVocabulary(
+			companyGroup.getGroupId());
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		String portletId = LayoutTestUtil.addPortletToLayout(
+			_layout,
+			AssetCategoriesNavigationPortletKeys.ASSET_CATEGORIES_NAVIGATION,
+			_getPreferenceMap(
+				HashMapBuilder.put(
+					"assetVocabularyIds",
+					StringUtil.merge(
+						new Long[] {
+							companyAssetVocabulary1.getVocabularyId(),
+							assetVocabulary.getVocabularyId(),
+							companyAssetVocabulary2.getVocabularyId()
+						})
+				).build()));
+
+		_runUpgrade();
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, portletId);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				companyGroup.getExternalReferenceCode(), StringPool.BLANK,
+				companyGroup.getExternalReferenceCode()
+			},
+			portletPreferences.getValues(
+				"assetVocabularyGroupExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {assetVocabulary.getExternalReferenceCode()},
+			portletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes", null));
+		Assert.assertArrayEquals(
+			new String[] {
+				companyAssetVocabulary1.getExternalReferenceCode(),
+				companyAssetVocabulary2.getExternalReferenceCode()
+			},
+			portletPreferences.getValues(
+				"assetVocabularyExternalReferenceCodes_" +
+					companyGroup.getExternalReferenceCode(),
+				null));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98572

## What Is Being Fixed

When the Categories Navigation widget is configured on a child site with vocabularies from more than one site, the order arranged in the configuration panel is not the order the widget renders: parent and global site vocabularies always come out before the current site's, and any interleaving between sites is lost. The order survives neither a save nor the preference upgrade, because the preferences record the selection per site and never record the order across sites. Two adjacent defects in the same flow are fixed along the way: deselecting vocabularies could leave the removed ones rendering (the current site's list and a fully cleared selection were never reset), and the export processor could clear a site's vocabulary list while renaming the per-site keys.

## How It Is Being Fixed

The selection is stored in the existing keys, but assetVocabularyGroupExternalReferenceCodes now records one entry per selected vocabulary, in the configured order, instead of one entry per distinct site. A blank entry stands for the current site, so the preferences stay meaningful when they reach another site through export, staging, or site templates — exactly like the unsuffixed vocabulary list always has — and no new preference keys are introduced. The display context detects the ordered format by checking that every site's occurrences in the sequence match its stored list, rebuilds the configured order by consuming each site's list one vocabulary per entry, and falls back to the previous external-then-local rendering for preferences written before this change, so existing data renders exactly as before. The preference upgrade emits the same ordered format, deriving each entry and its key suffix from one helper so they cannot disagree, and the export processor renames the per-site lists in two phases so repeated entries, the blank current-site entries, and renames that collide with a later site's key can no longer clear a list. The save path, the read path, the upgrade, and the export round trip are each covered by tests, including the LAR export and import of the ordered format.

## PR Check

**pr-check: PASS** — tested on `e6361f8b9b86e25352cc7202595eb5663b279791`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e6361f8b9b86e25352cc7202595eb5663b279791"} -->
