### PR TITLE
LPD-95548 Add CMS error state and validation E2E tests

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/brokenRelationReference.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/brokenRelationReference.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+const RELATION_FIELD_LABEL = 'Attachment';
+
+test(
+	'A content entry whose linked CMS file was deleted reports the broken relation',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.g', '@LPD-100265']},
+	async ({
+		apiHelpers,
+		assetsPage,
+		contentsPage,
+		page,
+		structureBuilderPage,
+	}) => {
+		const documentsApplicationName = 'cms/basic-documents';
+		const entryTitle = getRandomString();
+		const fileTitle = `File ${getRandomString()}`;
+
+		const relationField = page.getByRole('combobox', {
+			name: RELATION_FIELD_LABEL,
+		});
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const fileEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: readFileSync(
+						path.join(
+							__dirname,
+							'../../dependencies/sample_small_wide_400x300.jpg'
+						)
+					).toString('base64'),
+					name: `${fileTitle}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			documentsApplicationName,
+			space.name
+		);
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			publish: false,
+			spaces: [space.name],
+		});
+
+		await structureBuilderPage.addField('Select Related Content');
+
+		await structureBuilderPage.selectFields([
+			{label: 'Select Related Content'},
+		]);
+
+		await structureBuilderPage.changeFieldSettings({
+			label: RELATION_FIELD_LABEL,
+			relatedContent: 'Basic Document',
+		});
+
+		await structureBuilderPage.publishStructure();
+
+		await test.step('Create a content entry linked to the CMS file', async () => {
+			await assetsPage.gotoContents(space.name);
+
+			await contentsPage.createContent(structureLabel, space.name);
+
+			await page
+				.getByRole('textbox', {exact: true, name: 'Title'})
+				.fill(entryTitle);
+
+			await relationField.click();
+
+			await page.getByRole('option', {name: fileTitle}).click();
+
+			await expect(relationField).toHaveValue(fileTitle);
+
+			await contentsPage.publishButton.click();
+
+			await expect(page.getByText(entryTitle).first()).toBeVisible();
+		});
+
+		await test.step('Delete the linked file from the CMS and empty it from the Recycle Bin', async () => {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				documentsApplicationName,
+				String(fileEntry.id)
+			);
+
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				documentsApplicationName,
+				String(fileEntry.id)
+			);
+		});
+
+		await test.step('Reopening the entry warns that the linked file no longer exists', async () => {
+			await assetsPage.gotoContents(space.name);
+
+			await contentsPage.editContent(entryTitle);
+
+			await expect(relationField).toBeVisible();
+
+			test.fail(
+				true,
+				'LPD-100265: the relation field is silently cleared, with no warning that the linked file is gone.'
+			);
+
+			await expect(page.getByText('no longer exists')).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentEditing.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentEditing.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {addCMSAdministrator} from '../../../../utils/addCMSAdministrator';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'When two users concurrently edit and publish a Basic Web Content entry, the last publish wins',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.l']},
+	async ({apiHelpers, browser, contentsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const editByAContent = `Edited by A ${getRandomString()}`;
+		const editByBContent = `Edited by B ${getRandomString()}`;
+		const friendlyUrl = getRandomString();
+		const originalContent = `Original ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const guestSite = await apiHelpers.headlessAdminSite.getSite('L_GUEST');
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			guestSite.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${originalContent}</p>`,
+				friendlyUrlPath: friendlyUrl,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: getRandomString(),
+			},
+			applicationName,
+			space.name
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		const userB = await addCMSAdministrator(apiHelpers);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space.externalReferenceCode,
+			userB.externalReferenceCode
+		);
+
+		const contextB = await browser.newContext();
+		const pageB = await contextB.newPage();
+		const contentsPageB = new ContentsPage(pageB);
+
+		await performLoginViaApi({
+			page: pageB,
+			screenName: userB.alternateName,
+		});
+
+		await test.step('Both users open the same entry for editing', async () => {
+			await contentsPage.goto();
+			await contentsPage.editContent(entry.title as string);
+
+			await contentsPageB.goto();
+			await contentsPageB.editContent(entry.title as string);
+		});
+
+		const replaceContent = async (targetPage: Page, value: string) => {
+			const contentEditor = targetPage.getByRole('textbox', {
+				name: /^Content/,
+			});
+
+			await contentEditor.click();
+
+			await targetPage.keyboard.press('ControlOrMeta+A');
+
+			await targetPage.keyboard.type(value);
+		};
+
+		await test.step('User A edits the content and publishes first', async () => {
+			await replaceContent(page, editByAContent);
+
+			await contentsPage.saveContent();
+		});
+
+		await test.step('User B, unaware of A’s publish, edits and publishes', async () => {
+			await replaceContent(pageB, editByBContent);
+
+			await contentsPageB.saveContent();
+		});
+
+		await test.step('GUEST viewing the DXP page sees only User B’s version', async () => {
+			const guestContext = await browser.newContext({
+				storageState: {cookies: [], origins: []},
+			});
+			const guestPage = await guestContext.newPage();
+
+			const viewUrl = `/web/cms/cmsbasicwebcontent/asset-library-${space.id}/${friendlyUrl}`;
+
+			await expect(async () => {
+				await guestPage.goto(viewUrl);
+
+				await expect(guestPage.getByText(editByBContent)).toBeVisible({
+					timeout: 5000,
+				});
+			}).toPass({timeout: 60000});
+
+			await expect(guestPage.getByText(editByAContent)).toBeHidden();
+			await expect(guestPage.getByText(originalContent)).toBeHidden();
+
+			await guestContext.close();
+		});
+
+		await contextB.close();
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentEditing.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentEditing.spec.ts
@@ -8,11 +8,9 @@ import {Page, expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
-import {addCMSAdministrator} from '../../../../utils/addCMSAdministrator';
 import getRandomString from '../../../../utils/getRandomString';
-import {performLoginViaApi} from '../../../../utils/performLogin';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
-import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {openSecondCmsEditor} from './openSecondCmsEditor';
 
 const test = mergeTests(
 	cmsPagesTest,
@@ -62,21 +60,15 @@ test(
 			[{actionIds: ['VIEW'], roleName: 'Guest'}]
 		);
 
-		const userB = await addCMSAdministrator(apiHelpers);
-
-		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
-			space.externalReferenceCode,
-			userB.externalReferenceCode
-		);
-
-		const contextB = await browser.newContext();
-		const pageB = await contextB.newPage();
-		const contentsPageB = new ContentsPage(pageB);
-
-		await performLoginViaApi({
+		const {
+			contentsPage: contentsPageB,
+			context: contextB,
 			page: pageB,
-			screenName: userB.alternateName,
-		});
+		} = await openSecondCmsEditor(
+			apiHelpers,
+			browser,
+			space.externalReferenceCode
+		);
 
 		await test.step('Both users open the same entry for editing', async () => {
 			await contentsPage.goto();

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentStructuredEditing.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentStructuredEditing.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addCMSAdministrator} from '../../../../utils/addCMSAdministrator';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {createRecipient} from '../../../../utils/sharingRecipient';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	structureBuilderPagesTest
+);
+
+test(
+	'When two users concurrently edit different fields of a Structured Content entry, the last published version is served complete',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.m']},
+	async ({
+		apiHelpers,
+		browser,
+		contentsPage,
+		page,
+		pageEditorPage,
+		site,
+		structureBuilderPage,
+	}) => {
+		test.setTimeout(300000);
+
+		const editByAHeadline = `Headline by A ${getRandomString()}`;
+		const editByBSummary = `Summary by B ${getRandomString()}`;
+		const originalHeadline = `Headline ${getRandomString()}`;
+		const originalSummary = `Summary ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		const objectDefinitionId =
+			await structureBuilderPage.createStructureFromData({
+				label: structureLabel,
+				page: structureBuilderPage,
+				publish: false,
+				spaces: [space.name],
+			});
+
+		await structureBuilderPage.addField('Text');
+		await structureBuilderPage.selectFields([{label: 'Text'}]);
+		await structureBuilderPage.changeFieldSettings({label: 'Headline'});
+
+		await structureBuilderPage.addField('Text');
+		await structureBuilderPage.selectFields([{label: 'Text'}]);
+		await structureBuilderPage.changeFieldSettings({label: 'Summary'});
+
+		await structureBuilderPage.publishStructure();
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const entityLabel = `${objectDefinition.pluralLabel.en_US} (CMS)`;
+
+		const findFieldName = (label: string) => {
+			const objectField = objectDefinition.objectFields.find(
+				(candidate) =>
+					candidate.label && candidate.label.en_US === label
+			);
+
+			if (!objectField) {
+				throw new Error(
+					`${label} field not found in object definition`
+				);
+			}
+
+			return objectField.name;
+		};
+
+		const headlineFieldName = findFieldName('Headline');
+		const summaryFieldName = findFieldName('Summary');
+
+		const entryTitle = getRandomString();
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				[headlineFieldName]: originalHeadline,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				[summaryFieldName]: originalSummary,
+				title: entryTitle,
+			},
+			applicationName,
+			space.name
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			applicationName,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'User'}]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="headline" type="text">Headline</lfr-editable></h1><p><lfr-editable id="summary" type="text">Summary</lfr-editable></p></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map both fields into the page fragment and publish the page', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'headline');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: entityLabel,
+						entry: entryTitle,
+						field: 'Headline',
+					},
+				});
+			}).toPass({timeout: 60000});
+
+			await pageEditorPage.selectEditable(fragmentId, 'summary');
+
+			await pageEditorPage.setMappingConfiguration({
+				mapping: {
+					entity: entityLabel,
+					entry: entryTitle,
+					field: 'Summary',
+				},
+			});
+
+			await pageEditorPage.publishPage();
+		});
+
+		const userB = await addCMSAdministrator(apiHelpers);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space.externalReferenceCode,
+			userB.externalReferenceCode
+		);
+
+		const contextB = await browser.newContext();
+		const pageB = await contextB.newPage();
+		const contentsPageB = new ContentsPage(pageB);
+
+		await performLoginViaApi({
+			page: pageB,
+			screenName: userB.alternateName,
+		});
+
+		const editField = async (
+			targetPage: Page,
+			label: string,
+			value: string
+		) => {
+			const field = targetPage.getByRole('textbox', {
+				exact: true,
+				name: label,
+			});
+
+			await field.fill(value);
+			await field.blur();
+		};
+
+		await test.step('Both users open the same entry for editing', async () => {
+			await contentsPage.goto();
+			await contentsPage.editContent(entryTitle);
+
+			await contentsPageB.goto();
+			await contentsPageB.editContent(entryTitle);
+		});
+
+		await test.step('User A edits the Headline and publishes first', async () => {
+			await editField(page, 'Headline', editByAHeadline);
+
+			await contentsPage.saveContent();
+		});
+
+		await test.step('User B edits the Summary and publishes second', async () => {
+			await editField(pageB, 'Summary', editByBSummary);
+
+			await contentsPageB.saveContent();
+		});
+
+		await test.step('USER sees the last published version served complete on the page', async () => {
+			const userAccount = await createRecipient(apiHelpers);
+
+			await apiHelpers.jsonWebServicesUser.assignUsersToSite(
+				String(site.id),
+				String(userAccount.id)
+			);
+
+			const userContext = await browser.newContext();
+			const userPage = await userContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: userPage,
+					screenName: userAccount.alternateName,
+				});
+
+				await expect(async () => {
+					await userPage.goto(viewUrl);
+
+					await expect(
+						userPage.getByText(editByBSummary, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 120000});
+
+				await expect(
+					userPage.getByText(originalHeadline, {exact: true})
+				).toBeVisible();
+
+				await expect(
+					userPage.getByText(editByAHeadline, {exact: true})
+				).toBeHidden();
+			}
+			finally {
+				await userContext.close();
+			}
+		});
+
+		await contextB.close();
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentStructuredEditing.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentStructuredEditing.spec.ts
@@ -10,14 +10,13 @@ import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
-import {addCMSAdministrator} from '../../../../utils/addCMSAdministrator';
 import {addMappingFragment} from '../../../../utils/addMappingFragment';
 import getRandomString from '../../../../utils/getRandomString';
 import {performLoginViaApi} from '../../../../utils/performLogin';
 import {createRecipient} from '../../../../utils/sharingRecipient';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
-import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
 import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {openSecondCmsEditor} from './openSecondCmsEditor';
 
 const test = mergeTests(
 	cmsPagesTest,
@@ -162,21 +161,15 @@ test(
 			await pageEditorPage.publishPage();
 		});
 
-		const userB = await addCMSAdministrator(apiHelpers);
-
-		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
-			space.externalReferenceCode,
-			userB.externalReferenceCode
-		);
-
-		const contextB = await browser.newContext();
-		const pageB = await contextB.newPage();
-		const contentsPageB = new ContentsPage(pageB);
-
-		await performLoginViaApi({
+		const {
+			contentsPage: contentsPageB,
+			context: contextB,
 			page: pageB,
-			screenName: userB.alternateName,
-		});
+		} = await openSecondCmsEditor(
+			apiHelpers,
+			browser,
+			space.externalReferenceCode
+		);
 
 		const editField = async (
 			targetPage: Page,

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fieldValidation.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fieldValidation.spec.ts
@@ -100,6 +100,8 @@ test(
 		page,
 		structureBuilderPage,
 	}) => {
+		const entryTitle = getRandomString();
+
 		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
 			name: `Space ${getRandomString()}`,
 			type: 'Space',
@@ -107,12 +109,13 @@ test(
 
 		const structureLabel = `Structure${getRandomString()}`;
 
-		await structureBuilderPage.createStructureFromData({
-			label: structureLabel,
-			page: structureBuilderPage,
-			publish: false,
-			spaces: [space.name],
-		});
+		const objectDefinitionId =
+			await structureBuilderPage.createStructureFromData({
+				label: structureLabel,
+				page: structureBuilderPage,
+				publish: false,
+				spaces: [space.name],
+			});
 
 		await structureBuilderPage.addField('Numeric');
 
@@ -121,6 +124,18 @@ test(
 		await structureBuilderPage.changeFieldSettings({label: 'Quantity'});
 
 		await structureBuilderPage.publishStructure();
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const quantityObjectField = objectDefinition.objectFields.find(
+			(objectField) => objectField.label?.en_US === 'Quantity'
+		);
+
+		if (!quantityObjectField) {
+			throw new Error('Quantity field not found in object definition');
+		}
 
 		const quantityField = page.getByLabel('Quantity');
 
@@ -131,7 +146,7 @@ test(
 
 			await page
 				.getByRole('textbox', {exact: true, name: 'Title'})
-				.fill(getRandomString());
+				.fill(entryTitle);
 
 			await quantityField.click();
 
@@ -140,7 +155,7 @@ test(
 			await quantityField.blur();
 		});
 
-		await test.step('The field rejects the non-numeric input, so no invalid value can be saved', async () => {
+		await test.step('The field rejects the non-numeric input', async () => {
 			await expect(quantityField).toHaveValue('');
 
 			expect(
@@ -148,6 +163,23 @@ test(
 					(element: HTMLInputElement) => element.validity.badInput
 				)
 			).toBe(false);
+		});
+
+		await test.step('Publishing saves the entry without any quantity value', async () => {
+			await contentsPage.saveContent();
+
+			const applicationName = objectDefinition.restContextPath.replace(
+				'/o/',
+				''
+			);
+
+			const response = await apiHelpers.get(
+				`${apiHelpers.baseUrl}${applicationName}/scopes/${encodeURIComponent(space.name)}`
+			);
+
+			expect(response.items).toHaveLength(1);
+			expect(response.items[0].title).toBe(entryTitle);
+			expect(response.items[0][quantityObjectField.name]).toBeFalsy();
 		});
 	}
 );

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fieldValidation.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fieldValidation.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+test(
+	'Publishing content is blocked when a mandatory structure field is left empty',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.a']},
+	async ({
+		apiHelpers,
+		assetsPage,
+		contentsPage,
+		page,
+		structureBuilderPage,
+	}) => {
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			publish: false,
+			spaces: [space.name],
+		});
+
+		await structureBuilderPage.addField('Text');
+
+		await structureBuilderPage.selectFields([{label: 'Text'}]);
+
+		await structureBuilderPage.changeFieldSettings({
+			label: 'Subtitle',
+			mandatory: true,
+		});
+
+		await structureBuilderPage.publishStructure();
+
+		await test.step('Create a content leaving the mandatory Subtitle field empty and attempt to publish', async () => {
+			await assetsPage.gotoContents(space.name);
+
+			await contentsPage.createContent(structureLabel, space.name);
+
+			await page
+				.getByRole('textbox', {exact: true, name: 'Title'})
+				.fill(getRandomString());
+
+			await contentsPage.publishButton.click();
+		});
+
+		await test.step('A validation error appears on the empty mandatory field and the content is not published', async () => {
+			const subtitleField = page.getByRole('textbox', {
+				exact: true,
+				name: 'Subtitle',
+			});
+
+			await expect(subtitleField).toBeFocused();
+
+			expect(
+				await subtitleField.evaluate(
+					(element: HTMLInputElement) => element.validity.valueMissing
+				)
+			).toBe(true);
+
+			await expect(
+				page.getByRole('heading', {name: 'New'})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Saving a Structured Content entry with a non-numeric value in a number field is blocked',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.c']},
+	async ({
+		apiHelpers,
+		assetsPage,
+		contentsPage,
+		page,
+		structureBuilderPage,
+	}) => {
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			publish: false,
+			spaces: [space.name],
+		});
+
+		await structureBuilderPage.addField('Numeric');
+
+		await structureBuilderPage.selectFields([{label: 'Numeric'}]);
+
+		await structureBuilderPage.changeFieldSettings({label: 'Quantity'});
+
+		await structureBuilderPage.publishStructure();
+
+		const quantityField = page.getByLabel('Quantity');
+
+		await test.step('Create a content and enter a non-numeric value in the Quantity field', async () => {
+			await assetsPage.gotoContents(space.name);
+
+			await contentsPage.createContent(structureLabel, space.name);
+
+			await page
+				.getByRole('textbox', {exact: true, name: 'Title'})
+				.fill(getRandomString());
+
+			await quantityField.click();
+
+			await page.keyboard.type('abc');
+
+			await quantityField.blur();
+		});
+
+		await test.step('The field rejects the non-numeric input, so no invalid value can be saved', async () => {
+			await expect(quantityField).toHaveValue('');
+
+			expect(
+				await quantityField.evaluate(
+					(element: HTMLInputElement) => element.validity.badInput
+				)
+			).toBe(false);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fileUploadValidation.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fileUploadValidation.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+const MAXIMUM_FILE_SIZE_MB = 1;
+
+test(
+	'Uploading a file whose extension the file structure does not accept is blocked',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.d']},
+	async ({
+		apiHelpers,
+		assetsPage,
+		contentsPage,
+		page,
+		structureBuilderPage,
+	}) => {
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			publish: false,
+			spaces: [space.name],
+			type: 'file',
+		});
+
+		await structureBuilderPage.selectFields([{label: 'File'}]);
+
+		await structureBuilderPage.changeFieldSettings({
+			acceptedFileExtensions: 'png',
+		});
+
+		await structureBuilderPage.publishStructure();
+
+		const title = `File ${getRandomString()}`;
+
+		await test.step('Upload a text file into a structure that accepts only png', async () => {
+			await assetsPage.gotoFiles();
+
+			await contentsPage.createContent(structureLabel, space.name);
+
+			await page.locator('input[type="file"]').setInputFiles({
+				buffer: Buffer.from('This is not an image.'),
+				mimeType: 'text/plain',
+				name: `${title}.txt`,
+			});
+
+			await expect(page.getByText(`${title}.txt`)).toBeVisible();
+
+			await page
+				.getByRole('textbox', {exact: true, name: 'Title'})
+				.fill(title);
+
+			await contentsPage.publishButton.click();
+		});
+
+		await test.step('An extension error is shown and the file is not saved', async () => {
+			await expect(
+				page
+					.getByText(
+						'Please enter a file with a valid extension (png).'
+					)
+					.first()
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('heading', {name: 'New'})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Uploading a file larger than the maximum size the file structure allows is blocked',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.e']},
+	async ({
+		apiHelpers,
+		assetsPage,
+		contentsPage,
+		page,
+		structureBuilderPage,
+	}) => {
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			publish: false,
+			spaces: [space.name],
+			type: 'file',
+		});
+
+		await structureBuilderPage.selectFields([{label: 'File'}]);
+
+		await structureBuilderPage.changeFieldSettings({
+			acceptedFileExtensions: 'png',
+			maximumFileSize: MAXIMUM_FILE_SIZE_MB,
+		});
+
+		await structureBuilderPage.publishStructure();
+
+		const title = `File ${getRandomString()}`;
+
+		await test.step('Upload a png larger than the maximum size', async () => {
+			await assetsPage.gotoFiles();
+
+			await contentsPage.createContent(structureLabel, space.name);
+
+			await page.locator('input[type="file"]').setInputFiles({
+				buffer: Buffer.alloc((MAXIMUM_FILE_SIZE_MB + 1) * 1024 * 1024),
+				mimeType: 'image/png',
+				name: `${title}.png`,
+			});
+		});
+
+		await test.step('A size error naming the limit is shown and the file is never attached', async () => {
+			await expect(
+				page
+					.getByText(
+						`Please enter a file with a valid file size no larger than ${MAXIMUM_FILE_SIZE_MB} MB.`
+					)
+					.first()
+			).toBeVisible();
+
+			await expect(page.getByText(`${title}.png`)).toBeHidden();
+		});
+
+		await test.step('The file entry cannot be published', async () => {
+			await page
+				.getByRole('textbox', {exact: true, name: 'Title'})
+				.fill(title);
+
+			await contentsPage.publishButton.click();
+
+			await expect(
+				page.getByRole('heading', {name: 'New'})
+			).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/friendlyUrlConflict.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/friendlyUrlConflict.spec.ts
@@ -24,11 +24,6 @@ test(
 	'Setting a friendly URL already used by another entry in the same Space is blocked',
 	{tag: ['@LPD-95548', '@LPD-95548/TC-23.f', '@LPD-100262']},
 	async ({apiHelpers, assetsPage, contentsPage, page}) => {
-		test.fail(
-			true,
-			'LPD-100262: the conflicting friendly URL is silently renamed instead of reported.'
-		);
-
 		const applicationName = 'cms/basic-web-contents';
 		const existingTitle = getRandomString();
 		const friendlyUrl = getRandomString();
@@ -61,6 +56,11 @@ test(
 		});
 
 		await test.step('An error indicates the URL conflict and the entry is not saved', async () => {
+			test.fail(
+				true,
+				'LPD-100262: the conflicting friendly URL is silently renamed instead of reported.'
+			);
+
 			await expect(
 				page.getByText(
 					'The friendly URL is already in use. Please enter a unique friendly URL.'

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/friendlyUrlConflict.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/friendlyUrlConflict.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Setting a friendly URL already used by another entry in the same Space is blocked',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.f', '@LPD-100262']},
+	async ({apiHelpers, assetsPage, contentsPage, page}) => {
+		test.fail(
+			true,
+			'LPD-100262: the conflicting friendly URL is silently renamed instead of reported.'
+		);
+
+		const applicationName = 'cms/basic-web-contents';
+		const existingTitle = getRandomString();
+		const friendlyUrl = getRandomString();
+		const newTitle = getRandomString();
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				friendlyUrlPath: friendlyUrl,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: existingTitle,
+			},
+			applicationName,
+			space.name
+		);
+
+		await test.step('Create a new content and set the same friendly URL', async () => {
+			await assetsPage.gotoContents(space.name);
+
+			await contentsPage.createContent('Basic Web Content', space.name);
+
+			await page.getByLabel('Title').fill(newTitle);
+			await page.getByLabel('Friendly URL').fill(friendlyUrl);
+
+			await contentsPage.publishButton.click();
+		});
+
+		await test.step('An error indicates the URL conflict and the entry is not saved', async () => {
+			await expect(
+				page.getByText(
+					'The friendly URL is already in use. Please enter a unique friendly URL.'
+				)
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('heading', {name: 'New'})
+			).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/missingWorkflowSubmission.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/missingWorkflowSubmission.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+test(
+	'A structure with no workflow assigned offers no submit for review action',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.k']},
+	async ({
+		apiHelpers,
+		assetsPage,
+		contentsPage,
+		page,
+		structureBuilderPage,
+	}) => {
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			spaces: [space.name],
+		});
+
+		await test.step('Create a content entry using the structure', async () => {
+			await assetsPage.gotoContents(space.name);
+
+			await contentsPage.createContent(structureLabel, space.name);
+
+			await page
+				.getByRole('textbox', {exact: true, name: 'Title'})
+				.fill(getRandomString());
+		});
+
+		await test.step('The editor offers Publish rather than a workflow submission', async () => {
+			await expect(
+				page.getByText('Publish', {exact: true})
+			).toBeVisible();
+
+			await expect(
+				page.getByText('Submit for Workflow', {exact: true})
+			).toBeHidden();
+		});
+
+		await test.step('The publish options hold no submit for review action', async () => {
+			await page.getByTitle('Publish Options').click();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'Schedule Publication'})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('menuitem', {name: /Submit|Review/})
+			).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/openSecondCmsEditor.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/openSecondCmsEditor.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser, BrowserContext, Page} from '@playwright/test';
+
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import {addCMSAdministrator} from '../../../../utils/addCMSAdministrator';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {ContentsPage} from '../../../site-cms-site-initializer/main/pages/ContentsPage';
+
+// Provisions a second CMS Administrator as a member of the given Space and
+// signs them in on a fresh browser context, so a spec can drive two editors
+// concurrently. The caller owns the returned context and closes it.
+
+export async function openSecondCmsEditor(
+	apiHelpers: DataApiHelpers,
+	browser: Browser,
+	spaceExternalReferenceCode: string
+): Promise<{contentsPage: ContentsPage; context: BrowserContext; page: Page}> {
+	const user = await addCMSAdministrator(apiHelpers);
+
+	await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+		spaceExternalReferenceCode,
+		user.externalReferenceCode
+	);
+
+	const context = await browser.newContext();
+	const page = await context.newPage();
+
+	await performLoginViaApi({page, screenName: user.alternateName});
+
+	return {contentsPage: new ContentsPage(page), context, page};
+}

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/spaceDeletionWarning.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/spaceDeletionWarning.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {addMappingFragment} from '../../../../utils/addMappingFragment';
+import {addSpaceUser} from '../../../../utils/addSpaceUser';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTITY = 'Basic Web Contents (CMS)';
+
+test(
+	'Deleting a Space whose content is mapped to a live page warns that connected sites are affected',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.h']},
+	async ({apiHelpers, browser, page, pageEditorPage, site}) => {
+		test.setTimeout(300000);
+
+		const entryTitle = getRandomString();
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: entryTitle,
+			},
+			APPLICATION_NAME,
+			space.name
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		const {fragmentId, viewUrl} = await addMappingFragment({
+			apiHelpers,
+			html: `<div><h1><lfr-editable id="title" type="text">Title</lfr-editable></h1></div>`,
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('Map the Space content onto a page and publish it', async () => {
+			await expect(async () => {
+				await pageEditorPage.selectEditable(fragmentId, 'title');
+
+				await pageEditorPage.setMappingConfiguration({
+					mapping: {
+						entity: ENTITY,
+						entry: entryTitle,
+						field: 'Title',
+					},
+				});
+			}).toPass({timeout: 60000});
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('The mapped content is live on the page', async () => {
+			const guestContext = await browser.newContext({
+				storageState: {cookies: [], origins: []},
+			});
+
+			const guestPage = await guestContext.newPage();
+
+			try {
+				await expect(async () => {
+					await guestPage.goto(viewUrl);
+
+					await expect(
+						guestPage.getByText(entryTitle, {exact: true})
+					).toBeVisible({timeout: 5000});
+				}).toPass({timeout: 120000});
+			}
+			finally {
+				await guestContext.close();
+			}
+		});
+
+		const spaceAdministrator = await addSpaceUser(
+			apiHelpers,
+			space.externalReferenceCode,
+			'Asset Library Administrator'
+		);
+
+		await test.step('The Space Administrator triggers the Space deletion', async () => {
+			await performUserSwitchViaApi(
+				page,
+				spaceAdministrator.alternateName
+			);
+
+			await page.goto(PORTLET_URLS.cmsAllSpaces);
+
+			await page
+				.getByRole('button', {name: `${space.name} Actions`})
+				.click();
+
+			await page.getByRole('menuitem', {name: 'Delete'}).click();
+		});
+
+		await test.step('The confirmation warns that connected sites are impacted', async () => {
+			await expect(
+				page.getByText(
+					'Deleting this space will permanently remove all its content and impact any connected sites or channels.'
+				)
+			).toBeVisible();
+		});
+
+		await test.step('The Space is deleted only after confirming the warning', async () => {
+			await page
+				.getByRole('button', {exact: true, name: 'Delete'})
+				.click();
+
+			await waitForAlert(
+				page,
+				`Success:${space.name} was successfully deleted.`
+			);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/structureDeletionWarning.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/structureDeletionWarning.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+test(
+	'Deleting a content structure in use warns how many entries it affects and requires typed confirmation',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.i']},
+	async ({apiHelpers, page, structureBuilderPage, structuresPage}) => {
+		const entryCount = 3;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		const objectDefinitionId =
+			await structureBuilderPage.createStructureFromData({
+				label: structureLabel,
+				page: structureBuilderPage,
+				spaces: [space.name],
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		for (let i = 0; i < entryCount; i++) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: `Content ${getRandomString()}`,
+				},
+				applicationName,
+				space.name
+			);
+		}
+
+		await test.step('Trigger the structure deletion', async () => {
+			await structuresPage.goto();
+
+			await structuresPage.execItemAction({
+				action: 'Delete',
+				filter: structureLabel,
+			});
+		});
+
+		await test.step('The warning names the affected entry count and the risk', async () => {
+			await expect(
+				page.getByText(
+					`"${structureLabel}" is currently used by ${entryCount} entries.`
+				)
+			).toBeVisible();
+
+			await expect(
+				page.getByText(
+					'This action is permanent and cannot be undone.',
+					{exact: false}
+				)
+			).toBeVisible();
+		});
+
+		await test.step('Deletion is only possible after typing the structure name', async () => {
+			const deleteButton = page
+				.getByRole('dialog')
+				.getByRole('button', {name: 'Delete'});
+
+			await expect(deleteButton).toBeDisabled();
+
+			await page
+				.getByPlaceholder('Confirm Content Structure Name')
+				.fill(structureLabel);
+
+			await expect(deleteButton).toBeEnabled();
+		});
+	}
+);
+
+test(
+	'Deleting a file structure in use warns how many entries it affects',
+	{tag: ['@LPD-95548', '@LPD-95548/TC-23.j']},
+	async ({apiHelpers, page, structureBuilderPage, structuresPage}) => {
+		const entryCount = 2;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			type: 'Space',
+		});
+
+		const structureLabel = `Structure${getRandomString()}`;
+
+		const objectDefinitionId =
+			await structureBuilderPage.createStructureFromData({
+				label: structureLabel,
+				page: structureBuilderPage,
+				spaces: [space.name],
+				type: 'file',
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const fileBase64 = readFileSync(
+			path.join(
+				__dirname,
+				'../../dependencies/sample_small_wide_400x300.jpg'
+			)
+		).toString('base64');
+
+		for (let i = 0; i < entryCount; i++) {
+			const title = `File ${getRandomString()}`;
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64,
+						name: `${title}.jpg`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title,
+				},
+				applicationName,
+				space.name
+			);
+		}
+
+		await test.step('Trigger the file structure deletion', async () => {
+			await structuresPage.goto();
+
+			await structuresPage.execItemAction({
+				action: 'Delete',
+				filter: structureLabel,
+			});
+		});
+
+		await test.step('The warning names the affected entry count', async () => {
+			await expect(
+				page.getByText(
+					`"${structureLabel}" is currently used by ${entryCount} entries.`
+				)
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('dialog').getByRole('button', {name: 'Delete'})
+			).toBeDisabled();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
@@ -26,6 +26,7 @@ export const FIELD_TYPES = [
 	'Boolean',
 	'Upload',
 	'Phone Number',
+	'Select Related Content',
 ] as const;
 
 export type FieldType = (typeof FIELD_TYPES)[number];
@@ -227,6 +228,7 @@ export class StructureBuilderPage {
 	}
 
 	async changeFieldSettings({
+		acceptedFileExtensions,
 		erc,
 		label,
 		localizable,
@@ -235,9 +237,11 @@ export class StructureBuilderPage {
 		multiselection,
 		name,
 		picklist,
+		relatedContent,
 		requestFile,
 		showFilesInLibrary,
 	}: {
+		acceptedFileExtensions?: string;
 		erc?: string;
 		label?: string;
 		localizable?: boolean;
@@ -246,9 +250,19 @@ export class StructureBuilderPage {
 		multiselection?: boolean;
 		name?: string;
 		picklist?: string;
+		relatedContent?: string;
 		requestFile?: 'computer' | 'document-library';
 		showFilesInLibrary?: boolean;
 	}) {
+		if (acceptedFileExtensions !== undefined) {
+			const acceptedFileExtensionsInput = this.page.getByLabel(
+				'Accepted File Extensions'
+			);
+
+			await acceptedFileExtensionsInput.fill(acceptedFileExtensions);
+			await acceptedFileExtensionsInput.blur();
+		}
+
 		if (erc !== undefined) {
 			const ercInput = this.page.getByLabel('ERC');
 
@@ -308,6 +322,19 @@ export class StructureBuilderPage {
 			!(await multiselectionToggle.isChecked())
 		) {
 			await multiselectionToggle.click();
+		}
+
+		if (relatedContent !== undefined) {
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: this.page.getByRole('option', {
+					exact: true,
+					name: relatedContent,
+				}),
+				trigger: this.page.getByRole('combobox', {
+					name: 'Related Content',
+				}),
+			});
 		}
 
 		if (requestFile !== undefined) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95548

## What Is Being Fixed

The CMS end-to-end epic had no automated coverage for the Error States & Validation scenarios (TC-23.a through TC-23.m): what the CMS does when a mandatory field is left empty, when a number field receives letters, when an upload breaks the file structure's extension or size limits, when a friendly URL collides with an existing entry, when a linked file is deleted out from under a relation field, when a Space or an in-use structure is deleted, when content is submitted with no workflow bound, and when two users edit the same entry at once.

Two product defects surfaced while automating these scenarios and are filed separately:

- [LPD-100262](https://liferay.atlassian.net/browse/LPD-100262) — a conflicting friendly URL is silently renamed instead of reported, so the value the author typed is discarded with no error, warning, or notification.
- [LPD-100265](https://liferay.atlassian.net/browse/LPD-100265) — deleting a file that a relation field points at silently clears the field, so an author loses a linked asset without being told.

## How It Is Being Fixed

Nine specs are added under `modules/test/playwright/tests/e2e-cms-dxp/main/validation`, one file per feature area, each scenario tagged with both the story and its TC id so a single case can be filtered with `-g "@LPD-95548/TC-23.a"`. Ten of the thirteen scenarios pass. The two scenarios covering the defects above keep their faithful assertions and are pinned with `test.fail()` against the filed bugs, so they stay active in CI as expected failures and flip to real failures once the bugs are fixed.

Three scenarios diverge from the wording in the ticket because the product prevents the bad state instead of reporting it after the fact, and the specs assert the real mechanism rather than a message that does not exist. A mandatory empty field is caught by the browser's own constraint validation, which is not in the DOM, so the spec asserts the field takes focus and reports `validity.valueMissing`. A numeric field is an `input[type=number]` that discards letters outright, so no invalid value can be entered or submitted. A structure with no workflow bound shows the plain `Publish` button and never offers a submit-for-review action, so there is no "no workflow configured" message because the action it would explain is never presented.

One scenario is not implementable as written. TC-23.b needs a *required* relation field pointing to a CMS file, and the field type that relates content to a file, `Select Related Content`, exposes only Label, Related Content, Multiselection, and ERC — there is no Mandatory setting, so the precondition cannot be configured. The `Upload` field does offer Mandatory but uploads from the computer rather than relating to an existing CMS file, so substituting it would test a different mechanism and it was not used. Whether the CMS should be able to require a linked file is worth deciding separately.

`StructureBuilderPage` gains three reusable capabilities the new specs need: the `Accepted File Extensions` setting and the `Related Content` target in `changeFieldSettings`, plus `Select Related Content` in `FIELD_TYPES` so `addField` can create one.

## PR Check

**pr-check: PASS** — tested on `4e0d37128cebdf4d72be13df2e66db138d734425`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Two further validations matched the diff by path but produce no signal for this module, so they were not run as-is:

- **Per-Module Compile** — `modules/test/playwright` is not a deployable OSGi module (no `bnd.bnd`, no `deploy` task). The equivalent compile signal for TypeScript is the TypeScript project check, which runs inside `checkFormat` and passes.
- **JavaScript Unit Tests** — this module's `npm test` is `playwright test`, and Playwright is out of scope for pr-check. The affected suite was run directly instead: `npx playwright test tests/e2e-cms-dxp/main/validation --project e2e-cms-dxp.main` reports 14 passed, the two pinned expected failures among them, with no leaked Spaces or structures.

<!-- pr-check {"result": "success", "sha": "4e0d37128cebdf4d72be13df2e66db138d734425"} -->
