### PR TITLE
LPD-99996 Assert Versions option is absent, not the More dropdown

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/versions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/versions.spec.ts
@@ -481,7 +481,9 @@ test(
 			});
 
 			await test.step('Check versions tab is not visible', async () => {
-				await expect(infoPanelPage.selectTab('More')).not.toBeVisible();
+				await expect(
+					infoPanelPage.dropdownTab('Versions')
+				).not.toBeVisible();
 				await expect(
 					infoPanelPage.selectTab('Versions')
 				).not.toBeVisible();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99996

## What Is Being Fixed

The Playwright test `site-cms-site-initializer/main/info-panel/versions.spec.ts > Versions tab should not be visible for Space Member role` was failing. The requirement under test is that a user holding only the Space Member role cannot reach the Versions view of a content item, but the test verified this indirectly by asserting that the info panel's More overflow dropdown was not visible. The More dropdown is only the container that holds the overflow tabs, so its presence reflects how many tabs the panel renders rather than whether a Space Member is allowed to see Versions. Once the panel rendered that dropdown for a Space Member because other permitted entries landed in it, the assertion failed even though Versions itself was correctly hidden.

## How It Is Being Fixed

The assertion now targets the element the requirement is actually about: the Versions menu item inside the dropdown must not be visible. It goes through the existing `InfoPanelPage.dropdownTab` locator rather than an inline one, which keeps the locator definition in the page object and applies its `exact: true` match so the name cannot collide with another entry. This decouples the test from how the panel distributes tabs between the visible row and the overflow dropdown, so it fails only when a Space Member can genuinely reach Versions. The neighbouring assertions are untouched — Versions must still be absent as a top-level tab, and Comments must still be visible, which keeps the two negative assertions from passing vacuously against a panel that never rendered.

## PR Check

**pr-check: PASS** — tested on `15f4f26be2975109f086715965391267fc9f1cf4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Per-Module Compile and JavaScript Unit Tests matched the diff path but do not apply: `modules/test/playwright` builds no OSGi bundle and has no `deploy` task, and its `test` script runs Playwright, which is out of pr-check scope.

<!-- pr-check {"result": "success", "sha": "15f4f26be2975109f086715965391267fc9f1cf4"} -->
