### PR TITLE
LPD-95549 Add authenticated headless API access tests

### DIFF
--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/authenticatedAccess.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/authenticatedAccess.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../../utils/performLogin';
+import {createRecipient} from '../../../../utils/sharingRecipient';
+import {getAsGuest} from './getAsGuest';
+import {getWithBasicAuth} from './getWithBasicAuth';
+
+const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
+
+const CONTENTS_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const DOCUMENTS_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'An authenticated client can read a restricted Basic Web Content that an anonymous client cannot',
+	{
+		tag: ['@LPD-95549', '@LPD-95549/TC-24.a', '@LPD-95549/TC-24.b'],
+	},
+	async ({apiHelpers, browser, site}) => {
+		const bodyValue = `Body ${getRandomString()}`;
+		const contentTitle = `Title ${getRandomString()}`;
+		const friendlyUrlPath = `slug-${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${bodyValue}</p>`,
+				friendlyUrlPath,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			CONTENTS_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			CONTENTS_APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['VIEW'], roleName: 'User'}]
+		);
+
+		const user = await createRecipient(apiHelpers);
+
+		await test.step('An authenticated request returns 200 with all expected field values', async () => {
+			const {body, status} = await getWithBasicAuth(
+				browser,
+				`/o/${CONTENTS_APPLICATION_NAME}/${entry.id}`,
+				user.emailAddress
+			);
+
+			expect(status).toBe(200);
+			expect(body?.title).toBe(contentTitle);
+			expect(String(body?.content)).toContain(bodyValue);
+			expect(body?.friendlyUrlPath).toBe(friendlyUrlPath);
+		});
+
+		await test.step('An anonymous request for the same entry is denied and leaks no data', async () => {
+			const {body, status} = await getAsGuest(
+				browser,
+				`/o/${CONTENTS_APPLICATION_NAME}/${entry.id}`
+			);
+
+			expect([401, 403, 404]).toContain(status);
+			expect(body?.title).not.toBe(contentTitle);
+		});
+	}
+);
+
+test(
+	'An authenticated client can read a restricted file with its metadata and download it',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.c']},
+	async ({apiHelpers, browser, site}) => {
+		const fileName = `restricted_${getRandomString()}.jpg`;
+		const fileTitle = `File ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {fileBase64: imageBase64, name: fileName},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			DOCUMENTS_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			DOCUMENTS_APPLICATION_NAME,
+			entry.id,
+			[{actionIds: ['DOWNLOAD_FILE', 'VIEW'], roleName: 'User'}]
+		);
+
+		const user = await createRecipient(apiHelpers);
+
+		const downloadHref =
+			await test.step('An authenticated request returns the file metadata and a download URL', async () => {
+				const {body, status} = await getWithBasicAuth(
+					browser,
+					`/o/${DOCUMENTS_APPLICATION_NAME}/${entry.id}`,
+					user.emailAddress
+				);
+
+				expect(status).toBe(200);
+				expect(body?.title).toBe(fileTitle);
+
+				const file = body?.file as {
+					extension?: string;
+					link?: {href?: string};
+					mimeType?: string;
+					name?: string;
+				};
+
+				expect(file?.name).toBe(fileName);
+				expect(file?.extension).toBe('jpg');
+				expect(file?.mimeType).toBe('image/jpeg');
+				expect(file?.link?.href).toBeTruthy();
+
+				return String(file?.link?.href);
+			});
+
+		await test.step('The download URL serves the file to the authenticated user', async () => {
+			const userContext = await browser.newContext();
+			const userPage = await userContext.newPage();
+
+			try {
+				await performLoginViaApi({
+					page: userPage,
+					screenName: user.alternateName,
+				});
+
+				const status = await userPage.evaluate(async (href) => {
+					const response = await fetch(href, {redirect: 'manual'});
+
+					return response.status;
+				}, downloadHref);
+
+				expect(status).toBe(200);
+			}
+			finally {
+				await userContext.close();
+			}
+		});
+
+		await test.step('An anonymous request for the same file is denied', async () => {
+			const {status} = await getAsGuest(
+				browser,
+				`/o/${DOCUMENTS_APPLICATION_NAME}/${entry.id}`
+			);
+
+			expect([401, 403, 404]).toContain(status);
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/contentFiltering.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/contentFiltering.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
+import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
+import {getWithBasicAuth} from './getWithBasicAuth';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	isolatedSiteTest,
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+const CONTENTS_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const DOCUMENTS_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A category filter returns only the entries tagged with that category',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.d']},
+	async ({apiHelpers, browser, site}) => {
+		const categorizedTitle = `Categorized ${getRandomString()}`;
+		const otherCategorizedTitle = `Other Categorized ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const uncategorizedTitle = `Uncategorized ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const cmsSite =
+			await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath('cms');
+
+		const vocabulary =
+			await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
+				assetLibraries: [{id: -1}],
+				assetTypes: [
+					{
+						required: false,
+						subtype: 'AllAssetSubtypes',
+						type: 'AllAssetTypes',
+					},
+				],
+				name: `Vocabulary ${getRandomString()}`,
+				siteId: cmsSite.id,
+				visibilityType: 'PUBLIC',
+			});
+
+		const category =
+			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+				{
+					name: `Category ${getRandomString()}`,
+					vocabularyId: vocabulary.id,
+				}
+			);
+
+		const otherCategory =
+			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+				{
+					name: `Other Category ${getRandomString()}`,
+					vocabularyId: vocabulary.id,
+				}
+			);
+
+		for (const [title, taxonomyCategoryIds] of [
+			[categorizedTitle, [category.id]],
+			[otherCategorizedTitle, [otherCategory.id]],
+			[uncategorizedTitle, undefined],
+		] as [string, number[] | undefined][]) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					taxonomyCategoryIds,
+					title,
+				},
+				CONTENTS_APPLICATION_NAME,
+				spaceName
+			);
+		}
+
+		const {body, status} = await getWithBasicAuth(
+			browser,
+			`/o/${CONTENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${encodeURIComponent(`taxonomyCategoryIds/any(t:t eq ${category.id})`)}`,
+			'test@liferay.com'
+		);
+
+		expect(status).toBe(200);
+
+		const titles = ((body?.items as {title: string}[]) || []).map(
+			(item) => item.title
+		);
+
+		expect(titles).toEqual([categorizedTitle]);
+	}
+);
+
+test(
+	'A tag filter returns only the content entries and files carrying that tag',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.e']},
+	async ({apiHelpers, browser, site}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const tag = `tag${getRandomString()}`;
+		const taggedFileTitle = `Tagged File ${getRandomString()}`;
+		const taggedTitle = `Tagged ${getRandomString()}`;
+		const untaggedFileTitle = `Untagged File ${getRandomString()}`;
+		const untaggedTitle = `Untagged ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		for (const [title, keywords] of [
+			[taggedTitle, [tag]],
+			[untaggedTitle, [`other${getRandomString()}`]],
+		] as [string, string[]][]) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					keywords,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title,
+				},
+				CONTENTS_APPLICATION_NAME,
+				spaceName
+			);
+		}
+
+		for (const [title, keywords] of [
+			[taggedFileTitle, [tag]],
+			[untaggedFileTitle, undefined],
+		] as [string, string[] | undefined][]) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: imageBase64,
+						name: `${getRandomString()}.jpg`,
+					},
+					keywords,
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title,
+				},
+				DOCUMENTS_APPLICATION_NAME,
+				spaceName
+			);
+		}
+
+		const filter = encodeURIComponent(`keywords/any(k:k eq '${tag}')`);
+
+		const contents = await getWithBasicAuth(
+			browser,
+			`/o/${CONTENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${filter}`,
+			'test@liferay.com'
+		);
+
+		expect(contents.status).toBe(200);
+		expect(
+			((contents.body?.items as {title: string}[]) || []).map(
+				(item) => item.title
+			)
+		).toEqual([taggedTitle]);
+
+		const files = await getWithBasicAuth(
+			browser,
+			`/o/${DOCUMENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${filter}`,
+			'test@liferay.com'
+		);
+
+		expect(files.status).toBe(200);
+		expect(
+			((files.body?.items as {title: string}[]) || []).map(
+				(item) => item.title
+			)
+		).toEqual([taggedFileTitle]);
+	}
+);
+
+test(
+	'A field filter on a Structured Content type returns only the entries whose field matches',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.f']},
+	async ({apiHelpers, browser, site, structureBuilderPage}) => {
+		test.setTimeout(240000);
+
+		const matchingTitle = `Matching ${getRandomString()}`;
+		const nonMatchingTitle = `Non Matching ${getRandomString()}`;
+		const regionValue = `Region ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const structureLabel = `Article ${getRandomString()}`;
+		const structureName = `Article${getRandomInt()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const objectDefinitionId =
+			await test.step('Build a custom structure with a Region text field', async () => {
+				const id = await structureBuilderPage.createStructureFromData({
+					label: structureLabel,
+					name: structureName,
+					page: structureBuilderPage,
+					publish: false,
+					spaces: [spaceName],
+				});
+
+				await structureBuilderPage.addField('Text');
+				await structureBuilderPage.selectFields([{label: 'Text'}]);
+				await structureBuilderPage.changeFieldSettings({
+					label: 'Region',
+				});
+
+				await structureBuilderPage.publishStructure();
+
+				return id;
+			});
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/${objectDefinitionId}`
+		);
+
+		const applicationName = objectDefinition.restContextPath.replace(
+			'/o/',
+			''
+		);
+
+		const regionField = objectDefinition.objectFields.find(
+			(objectField) => objectField.label?.en_US === 'Region'
+		);
+
+		if (!regionField) {
+			throw new Error('Region field not found in object definition');
+		}
+
+		for (const [title, value] of [
+			[matchingTitle, regionValue],
+			[nonMatchingTitle, `Other ${getRandomString()}`],
+		]) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					[regionField.name]: value,
+					[objectDefinition.titleObjectFieldName]: title,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				},
+				applicationName,
+				spaceName
+			);
+		}
+
+		const {body, status} = await getWithBasicAuth(
+			browser,
+			`/o/${applicationName}/scopes/${encodeURIComponent(spaceName)}?filter=${encodeURIComponent(`${regionField.name} eq '${regionValue}'`)}`,
+			'test@liferay.com'
+		);
+
+		expect(status).toBe(200);
+		expect(
+			((body?.items as {title: string}[]) || []).map((item) => item.title)
+		).toEqual([matchingTitle]);
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/contentFiltering.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/contentFiltering.spec.ts
@@ -13,7 +13,7 @@ import {loginTest} from '../../../../fixtures/loginTest';
 import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
 import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/structure-builder/fixtures/structureBuilderPagesTest';
-import {getWithBasicAuth} from './getWithBasicAuth';
+import {ADMIN_EMAIL_ADDRESS, getWithBasicAuth} from './getWithBasicAuth';
 
 const test = mergeTests(
 	dataApiHelpersTest,
@@ -100,19 +100,21 @@ test(
 			);
 		}
 
-		const {body, status} = await getWithBasicAuth(
-			browser,
-			`/o/${CONTENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${encodeURIComponent(`taxonomyCategoryIds/any(t:t eq ${category.id})`)}`,
-			'test@liferay.com'
-		);
+		await expect(async () => {
+			const {body, status} = await getWithBasicAuth(
+				browser,
+				`/o/${CONTENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${encodeURIComponent(`taxonomyCategoryIds/any(t:t eq ${category.id})`)}`,
+				ADMIN_EMAIL_ADDRESS
+			);
 
-		expect(status).toBe(200);
+			expect(status).toBe(200);
 
-		const titles = ((body?.items as {title: string}[]) || []).map(
-			(item) => item.title
-		);
+			const titles = ((body?.items as {title: string}[]) || []).map(
+				(item) => item.title
+			);
 
-		expect(titles).toEqual([categorizedTitle]);
+			expect(titles).toEqual([categorizedTitle]);
+		}).toPass({timeout: 30000});
 	}
 );
 
@@ -174,31 +176,35 @@ test(
 
 		const filter = encodeURIComponent(`keywords/any(k:k eq '${tag}')`);
 
-		const contents = await getWithBasicAuth(
-			browser,
-			`/o/${CONTENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${filter}`,
-			'test@liferay.com'
-		);
+		await expect(async () => {
+			const contents = await getWithBasicAuth(
+				browser,
+				`/o/${CONTENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${filter}`,
+				ADMIN_EMAIL_ADDRESS
+			);
 
-		expect(contents.status).toBe(200);
-		expect(
-			((contents.body?.items as {title: string}[]) || []).map(
-				(item) => item.title
-			)
-		).toEqual([taggedTitle]);
+			expect(contents.status).toBe(200);
+			expect(
+				((contents.body?.items as {title: string}[]) || []).map(
+					(item) => item.title
+				)
+			).toEqual([taggedTitle]);
+		}).toPass({timeout: 30000});
 
-		const files = await getWithBasicAuth(
-			browser,
-			`/o/${DOCUMENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${filter}`,
-			'test@liferay.com'
-		);
+		await expect(async () => {
+			const files = await getWithBasicAuth(
+				browser,
+				`/o/${DOCUMENTS_APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?filter=${filter}`,
+				ADMIN_EMAIL_ADDRESS
+			);
 
-		expect(files.status).toBe(200);
-		expect(
-			((files.body?.items as {title: string}[]) || []).map(
-				(item) => item.title
-			)
-		).toEqual([taggedFileTitle]);
+			expect(files.status).toBe(200);
+			expect(
+				((files.body?.items as {title: string}[]) || []).map(
+					(item) => item.title
+				)
+			).toEqual([taggedFileTitle]);
+		}).toPass({timeout: 30000});
 	}
 );
 
@@ -279,15 +285,19 @@ test(
 			);
 		}
 
-		const {body, status} = await getWithBasicAuth(
-			browser,
-			`/o/${applicationName}/scopes/${encodeURIComponent(spaceName)}?filter=${encodeURIComponent(`${regionField.name} eq '${regionValue}'`)}`,
-			'test@liferay.com'
-		);
+		await expect(async () => {
+			const {body, status} = await getWithBasicAuth(
+				browser,
+				`/o/${applicationName}/scopes/${encodeURIComponent(spaceName)}?filter=${encodeURIComponent(`${regionField.name} eq '${regionValue}'`)}`,
+				ADMIN_EMAIL_ADDRESS
+			);
 
-		expect(status).toBe(200);
-		expect(
-			((body?.items as {title: string}[]) || []).map((item) => item.title)
-		).toEqual([matchingTitle]);
+			expect(status).toBe(200);
+			expect(
+				((body?.items as {title: string}[]) || []).map(
+					(item) => item.title
+				)
+			).toEqual([matchingTitle]);
+		}).toPass({timeout: 30000});
 	}
 );

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/deletedContentAccess.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/deletedContentAccess.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {getAsGuest} from './getAsGuest';
+import {getWithBasicAuth} from './getWithBasicAuth';
+
+const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
+
+const CONTENTS_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const DOCUMENTS_APPLICATION_NAME = 'cms/basic-documents';
+
+const imageBase64 = readFileSync(
+	path.join(__dirname, '../../dependencies/sample_small_wide_400x300.jpg')
+).toString('base64');
+
+test(
+	'A deleted content entry and file return 404 to anonymous and authenticated clients alike',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.j']},
+	async ({apiHelpers, browser, site}) => {
+		const contentTitle = `Title ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>Body ${getRandomString()}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			CONTENTS_APPLICATION_NAME,
+			spaceName
+		);
+
+		const fileEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: imageBase64,
+					name: `${getRandomString()}.jpg`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			DOCUMENTS_APPLICATION_NAME,
+			spaceName
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			CONTENTS_APPLICATION_NAME,
+			contentEntry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			DOCUMENTS_APPLICATION_NAME,
+			fileEntry.id,
+			[{actionIds: ['DOWNLOAD_FILE', 'VIEW'], roleName: 'Guest'}]
+		);
+
+		await test.step('Delete both entries and empty them from the Recycle Bin', async () => {
+			for (const [applicationName, id] of [
+				[CONTENTS_APPLICATION_NAME, contentEntry.id],
+				[DOCUMENTS_APPLICATION_NAME, fileEntry.id],
+			] as [string, number][]) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(id)
+				);
+
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(id)
+				);
+			}
+		});
+
+		await test.step('Anonymous requests return 404 with no data', async () => {
+			for (const [applicationName, id, title] of [
+				[CONTENTS_APPLICATION_NAME, contentEntry.id, contentTitle],
+				[DOCUMENTS_APPLICATION_NAME, fileEntry.id, fileTitle],
+			] as [string, number, string][]) {
+				const {body, status} = await getAsGuest(
+					browser,
+					`/o/${applicationName}/${id}`
+				);
+
+				expect(status).toBe(404);
+				expect(body?.title).not.toBe(title);
+			}
+		});
+
+		await test.step('Authenticated requests return 404 with no data', async () => {
+			for (const [applicationName, id, title] of [
+				[CONTENTS_APPLICATION_NAME, contentEntry.id, contentTitle],
+				[DOCUMENTS_APPLICATION_NAME, fileEntry.id, fileTitle],
+			] as [string, number, string][]) {
+				const {body, status} = await getWithBasicAuth(
+					browser,
+					`/o/${applicationName}/${id}`,
+					'test@liferay.com'
+				);
+
+				expect(status).toBe(404);
+				expect(body?.title).not.toBe(title);
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/deletedContentAccess.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/deletedContentAccess.spec.ts
@@ -12,7 +12,7 @@ import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {getAsGuest} from './getAsGuest';
-import {getWithBasicAuth} from './getWithBasicAuth';
+import {ADMIN_EMAIL_ADDRESS, getWithBasicAuth} from './getWithBasicAuth';
 
 const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
 
@@ -118,7 +118,7 @@ test(
 				const {body, status} = await getWithBasicAuth(
 					browser,
 					`/o/${applicationName}/${id}`,
-					'test@liferay.com'
+					ADMIN_EMAIL_ADDRESS
 				);
 
 				expect(status).toBe(404);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/getWithBasicAuth.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/getWithBasicAuth.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser} from '@playwright/test';
+
+// Sends a GET request authenticated with a Basic Authorization header, from a
+// fresh browser context with an empty storage state, so the credentials are
+// the only authentication in play (no portal session cookie). An absolute URL
+// is reduced to its path to keep the request same-origin, and
+// redirect: 'manual' keeps an authentication redirect from being followed
+// into a 200.
+
+export async function getWithBasicAuth(
+	browser: Browser,
+	url: string,
+	emailAddress: string,
+	password: string = 'test'
+): Promise<{body: Record<string, unknown> | null; status: number}> {
+	const context = await browser.newContext({
+		storageState: {cookies: [], origins: []},
+	});
+
+	try {
+		const page = await context.newPage();
+
+		await page.goto('/');
+
+		const {pathname, search} = new URL(url, page.url());
+
+		return await page.evaluate(
+			async ({credentials, path}) => {
+				const response = await fetch(path, {
+					headers: {
+						Authorization: `Basic ${btoa(credentials)}`,
+					},
+					redirect: 'manual',
+				});
+
+				const contentType = response.headers.get('content-type') || '';
+
+				const body = contentType.includes('application/json')
+					? await response.json()
+					: null;
+
+				return {body, status: response.status};
+			},
+			{
+				credentials: `${emailAddress}:${password}`,
+				path: pathname + search,
+			}
+		);
+	}
+	finally {
+		await context.close();
+	}
+}

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/getWithBasicAuth.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/getWithBasicAuth.ts
@@ -5,18 +5,20 @@
 
 import {Browser} from '@playwright/test';
 
+export const ADMIN_EMAIL_ADDRESS = 'test@liferay.com';
+
 // Sends a GET request authenticated with a Basic Authorization header, from a
 // fresh browser context with an empty storage state, so the credentials are
-// the only authentication in play (no portal session cookie). An absolute URL
-// is reduced to its path to keep the request same-origin, and
-// redirect: 'manual' keeps an authentication redirect from being followed
-// into a 200.
+// the only authentication in play (no portal session cookie). An optional
+// language becomes the Accept-Language header. An absolute URL is reduced to
+// its path to keep the request same-origin, and redirect: 'manual' keeps an
+// authentication redirect from being followed into a 200.
 
 export async function getWithBasicAuth(
 	browser: Browser,
 	url: string,
 	emailAddress: string,
-	password: string = 'test'
+	{language, password = 'test'}: {language?: string; password?: string} = {}
 ): Promise<{body: Record<string, unknown> | null; status: number}> {
 	const context = await browser.newContext({
 		storageState: {cookies: [], origins: []},
@@ -30,11 +32,17 @@ export async function getWithBasicAuth(
 		const {pathname, search} = new URL(url, page.url());
 
 		return await page.evaluate(
-			async ({credentials, path}) => {
+			async ({credentials, language, path}) => {
+				const headers: Record<string, string> = {
+					Authorization: `Basic ${btoa(credentials)}`,
+				};
+
+				if (language) {
+					headers['Accept-Language'] = language;
+				}
+
 				const response = await fetch(path, {
-					headers: {
-						Authorization: `Basic ${btoa(credentials)}`,
-					},
+					headers,
 					redirect: 'manual',
 				});
 
@@ -48,6 +56,7 @@ export async function getWithBasicAuth(
 			},
 			{
 				credentials: `${emailAddress}:${password}`,
+				language,
 				path: pathname + search,
 			}
 		);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/localization.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/localization.spec.ts
@@ -3,62 +3,17 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Browser, expect, mergeTests} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
+import {ADMIN_EMAIL_ADDRESS, getWithBasicAuth} from './getWithBasicAuth';
 
 const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
 
 const APPLICATION_NAME = 'cms/basic-web-contents';
-
-async function getWithLanguage(
-	browser: Browser,
-	url: string,
-	language: string
-): Promise<{body: Record<string, unknown> | null; status: number}> {
-	const context = await browser.newContext({
-		storageState: {cookies: [], origins: []},
-	});
-
-	try {
-		const page = await context.newPage();
-
-		await page.goto('/');
-
-		const {pathname, search} = new URL(url, page.url());
-
-		return await page.evaluate(
-			async ({credentials, language, path}) => {
-				const response = await fetch(path, {
-					headers: {
-						'Accept-Language': language,
-						'Authorization': `Basic ${btoa(credentials)}`,
-					},
-					redirect: 'manual',
-				});
-
-				const contentType = response.headers.get('content-type') || '';
-
-				const body = contentType.includes('application/json')
-					? await response.json()
-					: null;
-
-				return {body, status: response.status};
-			},
-			{
-				credentials: 'test@liferay.com:test',
-				language,
-				path: pathname + search,
-			}
-		);
-	}
-	finally {
-		await context.close();
-	}
-}
 
 test(
 	'Requesting a translated language returns the translated values for all localizable fields',
@@ -97,10 +52,11 @@ test(
 			spaceName
 		);
 
-		const {body, status} = await getWithLanguage(
+		const {body, status} = await getWithBasicAuth(
 			browser,
 			`/o/${APPLICATION_NAME}/${entry.id}`,
-			'es-ES'
+			ADMIN_EMAIL_ADDRESS,
+			{language: 'es-ES'}
 		);
 
 		expect(status).toBe(200);
@@ -138,10 +94,11 @@ test(
 			spaceName
 		);
 
-		const {body, status} = await getWithLanguage(
+		const {body, status} = await getWithBasicAuth(
 			browser,
 			`/o/${APPLICATION_NAME}/${entry.id}`,
-			'fr-FR'
+			ADMIN_EMAIL_ADDRESS,
+			{language: 'fr-FR'}
 		);
 
 		expect(status).toBe(200);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/localization.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/localization.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+
+const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+async function getWithLanguage(
+	browser: Browser,
+	url: string,
+	language: string
+): Promise<{body: Record<string, unknown> | null; status: number}> {
+	const context = await browser.newContext({
+		storageState: {cookies: [], origins: []},
+	});
+
+	try {
+		const page = await context.newPage();
+
+		await page.goto('/');
+
+		const {pathname, search} = new URL(url, page.url());
+
+		return await page.evaluate(
+			async ({credentials, language, path}) => {
+				const response = await fetch(path, {
+					headers: {
+						'Accept-Language': language,
+						'Authorization': `Basic ${btoa(credentials)}`,
+					},
+					redirect: 'manual',
+				});
+
+				const contentType = response.headers.get('content-type') || '';
+
+				const body = contentType.includes('application/json')
+					? await response.json()
+					: null;
+
+				return {body, status: response.status};
+			},
+			{
+				credentials: 'test@liferay.com:test',
+				language,
+				path: pathname + search,
+			}
+		);
+	}
+	finally {
+		await context.close();
+	}
+}
+
+test(
+	'Requesting a translated language returns the translated values for all localizable fields',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.h']},
+	async ({apiHelpers, browser, site}) => {
+		const englishBody = `English body ${getRandomString()}`;
+		const englishTitle = `English title ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const spanishBody = `Cuerpo español ${getRandomString()}`;
+		const spanishTitle = `Título español ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content_i18n: {
+					en_US: `<p>${englishBody}</p>`,
+					es_ES: `<p>${spanishBody}</p>`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title_i18n: {
+					en_US: englishTitle,
+					es_ES: spanishTitle,
+				},
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const {body, status} = await getWithLanguage(
+			browser,
+			`/o/${APPLICATION_NAME}/${entry.id}`,
+			'es-ES'
+		);
+
+		expect(status).toBe(200);
+		expect(body?.title).toBe(spanishTitle);
+		expect(String(body?.content)).toContain(spanishBody);
+	}
+);
+
+test(
+	'Requesting a language with no translation falls back to the default language and shows which locales exist',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.i']},
+	async ({apiHelpers, browser, site}) => {
+		const englishBody = `English body ${getRandomString()}`;
+		const englishTitle = `English title ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				content: `<p>${englishBody}</p>`,
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: englishTitle,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const {body, status} = await getWithLanguage(
+			browser,
+			`/o/${APPLICATION_NAME}/${entry.id}`,
+			'fr-FR'
+		);
+
+		expect(status).toBe(200);
+
+		expect(body?.title).toBe(englishTitle);
+		expect(String(body?.content)).toContain(englishBody);
+
+		const titleTranslations = body?.title_i18n as Record<string, string>;
+
+		expect(Object.keys(titleTranslations)).toEqual(['en_US']);
+	}
+);

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/pagination.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/pagination.spec.ts
@@ -9,7 +9,7 @@ import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
-import {getWithBasicAuth} from './getWithBasicAuth';
+import {ADMIN_EMAIL_ADDRESS, getWithBasicAuth} from './getWithBasicAuth';
 
 const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
 
@@ -54,21 +54,25 @@ test(
 			);
 		}
 
-		const {body, status} = await getWithBasicAuth(
-			browser,
-			`/o/${APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?page=2&pageSize=${PAGE_SIZE}&sort=id:asc`,
-			'test@liferay.com'
-		);
+		await expect(async () => {
+			const {body, status} = await getWithBasicAuth(
+				browser,
+				`/o/${APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?page=2&pageSize=${PAGE_SIZE}&sort=id:asc`,
+				ADMIN_EMAIL_ADDRESS
+			);
 
-		expect(status).toBe(200);
+			expect(status).toBe(200);
 
-		expect(body?.page).toBe(2);
-		expect(body?.pageSize).toBe(PAGE_SIZE);
-		expect(body?.totalCount).toBe(ENTRY_COUNT);
-		expect(body?.lastPage).toBe(Math.ceil(ENTRY_COUNT / PAGE_SIZE));
+			expect(body?.page).toBe(2);
+			expect(body?.pageSize).toBe(PAGE_SIZE);
+			expect(body?.totalCount).toBe(ENTRY_COUNT);
+			expect(body?.lastPage).toBe(Math.ceil(ENTRY_COUNT / PAGE_SIZE));
 
-		expect(
-			((body?.items as {title: string}[]) || []).map((item) => item.title)
-		).toEqual(titles.slice(PAGE_SIZE));
+			expect(
+				((body?.items as {title: string}[]) || []).map(
+					(item) => item.title
+				)
+			).toEqual(titles.slice(PAGE_SIZE));
+		}).toPass({timeout: 30000});
 	}
 );

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/pagination.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/headless-api/pagination.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {getWithBasicAuth} from './getWithBasicAuth';
+
+const test = mergeTests(dataApiHelpersTest, isolatedSiteTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const ENTRY_COUNT = 12;
+
+const PAGE_SIZE = 10;
+
+test(
+	'A paginated request returns the second page with accurate pagination metadata',
+	{tag: ['@LPD-95549', '@LPD-95549/TC-24.g']},
+	async ({apiHelpers, browser, site}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const titlePrefix = `Page Entry ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode,
+			{searchable: true}
+		);
+
+		const titles: string[] = [];
+
+		for (let i = 1; i <= ENTRY_COUNT; i++) {
+			const title = `${titlePrefix} ${String(i).padStart(2, '0')}`;
+
+			titles.push(title);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title,
+				},
+				APPLICATION_NAME,
+				spaceName
+			);
+		}
+
+		const {body, status} = await getWithBasicAuth(
+			browser,
+			`/o/${APPLICATION_NAME}/scopes/${encodeURIComponent(spaceName)}?page=2&pageSize=${PAGE_SIZE}&sort=id:asc`,
+			'test@liferay.com'
+		);
+
+		expect(status).toBe(200);
+
+		expect(body?.page).toBe(2);
+		expect(body?.pageSize).toBe(PAGE_SIZE);
+		expect(body?.totalCount).toBe(ENTRY_COUNT);
+		expect(body?.lastPage).toBe(Math.ceil(ENTRY_COUNT / PAGE_SIZE));
+
+		expect(
+			((body?.items as {title: string}[]) || []).map((item) => item.title)
+		).toEqual(titles.slice(PAGE_SIZE));
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95549

## What Is Being Fixed

The CMS end-to-end epic covered anonymous headless access to published content (LPD-95541), but had no automated coverage for the authenticated side: reading restricted content and files with API credentials, filtering by category, tag, and structured field value, pagination metadata, localized responses, and what a deleted entry answers.

## How It Is Being Fixed

Five specs join the existing `headless-api` component under `modules/test/playwright/tests/e2e-cms-dxp/main/headless-api`, so the anonymous and authenticated scenarios live in one suite. A new `getWithBasicAuth` helper mirrors the existing `getAsGuest`: it sends the request with a Basic Authorization header from a session-free browser context, so the specs exercise real token-style authentication rather than a signed-in cookie. All ten scenarios pass.

Restricted entries are granted VIEW to the User role only; a fresh regular user reads them with credentials and is denied without. Filters use the object API's OData grammar — `taxonomyCategoryIds/any(t:t eq <id>)`, `keywords/any(k:k eq '<tag>')` asserted on both the contents and documents endpoints, and `<fieldName> eq '<value>'` on a custom structure's text field. Pagination asserts `page`, `pageSize`, `totalCount`, and `lastPage` plus the exact items on page 2. Localization asserts translated values under `Accept-Language: es-ES` and, for a locale with no translation, the default-language fallback with the `_i18n` map showing which locales exist.

Three product behaviors diverge from the ticket's literal wording and the specs assert the real mechanism: an anonymous request to a restricted entry answers 404 rather than 401/403 (the entry's existence is masked, matching the TC-18 precedent of treating 401/403/404 as the denial set), the response language is selected by the `Accept-Language` header rather than a `?language=` query parameter (which this API ignores), and the `/documents` download URL does not consume Basic credentials, so the download check runs in a signed-in session of the same user.

## PR Check

**pr-check: PASS** — tested on `b36312009e8ddf35f84cfc087cecf87a4e872a07`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Two further validations matched the diff by path but produce no signal for this module, so they were not run as-is:

- **Per-Module Compile** — `modules/test/playwright` is not a deployable OSGi module (no `bnd.bnd`, no `deploy` task). The equivalent compile signal for TypeScript is the TypeScript project check, which runs inside `checkFormat` and passes.
- **JavaScript Unit Tests** — this module's `npm test` is `playwright test`, and Playwright is out of scope for pr-check. The affected suite was run directly instead: `npx playwright test tests/e2e-cms-dxp/main/headless-api --project e2e-cms-dxp.main` reports 16 passed (the ten new scenarios plus the existing anonymous ones), with no leaked Spaces, structures, vocabularies, or users.

<!-- pr-check {"result": "success", "sha": "b36312009e8ddf35f84cfc087cecf87a4e872a07"} -->
