### PR TITLE
LPD-97900 Prevent editing another user's comment in a project

### DIFF
--- a/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBDiscussionPermissionImpl.java
+++ b/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBDiscussionPermissionImpl.java
@@ -130,6 +130,44 @@ public class MBDiscussionPermissionImpl extends BaseDiscussionPermission {
 			ActionKeys.VIEW);
 	}
 
+	private int _getDepotEntryType(MBMessage message) {
+		InfoItemObjectProvider<Object> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, message.getClassName());
+
+		if (infoItemObjectProvider == null) {
+			return DepotConstants.TYPE_ANY;
+		}
+
+		try {
+			Object infoItem = infoItemObjectProvider.getInfoItem(
+				new ClassPKInfoItemIdentifier(message.getClassPK()));
+
+			if (!(infoItem instanceof GroupedModel)) {
+				return DepotConstants.TYPE_ANY;
+			}
+
+			GroupedModel groupedModel = (GroupedModel)infoItem;
+
+			DepotEntry depotEntry =
+				_depotEntryLocalService.fetchGroupDepotEntry(
+					groupedModel.getGroupId());
+
+			if (depotEntry == null) {
+				return DepotConstants.TYPE_ANY;
+			}
+
+			return depotEntry.getType();
+		}
+		catch (NoSuchInfoItemException noSuchInfoItemException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchInfoItemException);
+			}
+
+			return DepotConstants.TYPE_ANY;
+		}
+	}
+
 	private boolean _hasPermission(
 			PermissionChecker permissionChecker, MBMessage message,
 			String actionId)
@@ -148,11 +186,20 @@ public class MBDiscussionPermissionImpl extends BaseDiscussionPermission {
 				CommentGroupServiceConfiguration.class, message.getCompanyId(),
 				message.getGroupId());
 
+		int depotEntryType = _getDepotEntryType(message);
+
 		if ((commentGroupServiceConfiguration.alwaysEditableByOwner() ||
-			 _isSpaceDepotEntry(message)) &&
+			 (depotEntryType == DepotConstants.TYPE_PROJECT) ||
+			 (depotEntryType == DepotConstants.TYPE_SPACE)) &&
 			(permissionChecker.getUserId() == message.getUserId())) {
 
 			return true;
+		}
+
+		if ((depotEntryType == DepotConstants.TYPE_PROJECT) &&
+			actionId.equals(ActionKeys.UPDATE_DISCUSSION)) {
+
+			return false;
 		}
 
 		if (message.isPending()) {
@@ -169,46 +216,6 @@ public class MBDiscussionPermissionImpl extends BaseDiscussionPermission {
 		return hasPermission(
 			permissionChecker, message.getCompanyId(), message.getGroupId(),
 			className, message.getClassPK(), actionId);
-	}
-
-	private boolean _isSpaceDepotEntry(MBMessage message) {
-		InfoItemObjectProvider<Object> infoItemObjectProvider =
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemObjectProvider.class, message.getClassName());
-
-		if (infoItemObjectProvider == null) {
-			return false;
-		}
-
-		try {
-			Object infoItem = infoItemObjectProvider.getInfoItem(
-				new ClassPKInfoItemIdentifier(message.getClassPK()));
-
-			if (!(infoItem instanceof GroupedModel)) {
-				return false;
-			}
-
-			GroupedModel groupedModel = (GroupedModel)infoItem;
-
-			DepotEntry depotEntry =
-				_depotEntryLocalService.fetchGroupDepotEntry(
-					groupedModel.getGroupId());
-
-			if ((depotEntry != null) &&
-				(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
-
-				return true;
-			}
-
-			return false;
-		}
-		catch (NoSuchInfoItemException noSuchInfoItemException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchInfoItemException);
-			}
-
-			return false;
-		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97900

## What Is Being Fixed

- `UPDATE_DISCUSSION` is granted on the parent Project or Task entry rather than on the comment itself, so any role holding it, such as the CMP Project Manager, could edit a comment written by someone else.
- The space depot rule in `MBDiscussionPermissionImpl` already let the author edit and delete their own comment, but nothing denied everyone else, so the check fell through to the entry permission.

## How It Is Being Fixed

- **Depot type lookup:** `_isSpaceDepotEntry` -> `_getDepotEntryType`, so the depot type is available to more than one branch of the check instead of just the space test.
- **Author grant:** extended to project depots, so the author can still edit and delete their own comment in both space and project depots.
- **Non-author deny:** `UPDATE_DISCUSSION` is denied outright when the comment lives in a project depot and the user is not the author. Company admins are not exempt, since editing another user's words is never right in a project.
- **`DELETE_DISCUSSION` untouched:** a moderator can still delete other people's comments.
- Space depots are deliberately left alone.

## Why Are There No Tests?

- This is the same change as https://github.com/liferay-content-management/liferay-portal/pull/8722, minus the test changes, which need revision.
- The fix itself was already approved, and since LPD-97900 is a release blocker, I split it out so the fix can be merged first.
- The tests are tracked separately in https://liferay.atlassian.net/browse/LPD-100331.

## PR Check

**pr-check: PASS** — tested on `bf10abc8eb96c0e6bb0db6db694bb8e9caac1744`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bf10abc8eb96c0e6bb0db6db694bb8e9caac1744"} -->
