### PR TITLE
LPD-100130 Guard the CMS Add to Launch action behind its feature flag

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -236,6 +237,24 @@ public class ViewContentsSectionDisplayContextTest
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"trash", "delete", "Delete", null, fdsActionDropdownItems.get(15));
+	}
+
+	@FeatureFlag("LPD-72278")
+	@Test
+	@TestInfo("LPD-100130")
+	public void testGetFDSActionDropdownItemsWithAddToLaunchEnabled()
+		throws Exception {
+
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			getFDSActionDropdownItems();
+
+		Assert.assertEquals(
+			fdsActionDropdownItems.toString(), 17,
+			fdsActionDropdownItems.size());
+
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"rocket", "addToLaunch", "Add to Launch", "get",
+			fdsActionDropdownItems.get(16));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewVersionHistoryDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewVersionHistoryDisplayContextTest.java
@@ -10,6 +10,7 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -22,6 +23,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -29,6 +31,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -37,7 +40,11 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -115,6 +122,49 @@ public class ViewVersionHistoryDisplayContextTest
 				_getViewVersionHistoryDisplayContext(
 					_getMockHttpServletRequest(_objectEntry)),
 				"getAPIURL", new Class<?>[0]));
+	}
+
+	@Test
+	@TestInfo("LPD-100130")
+	public void testGetFDSActionDropdownItems() throws Exception {
+		_assertFDSActionDropdownItemIds(
+			"download", "view-content", "view-file", "restore", "expire",
+			"copy", "delete");
+	}
+
+	@FeatureFlag("LPD-72278")
+	@Test
+	@TestInfo("LPD-100130")
+	public void testGetFDSActionDropdownItemsWithAddToLaunchEnabled()
+		throws Exception {
+
+		_assertFDSActionDropdownItemIds(
+			"download", "view-content", "view-file", "addToLaunch", "restore",
+			"expire", "copy", "delete");
+	}
+
+	private void _assertFDSActionDropdownItemIds(String... expectedIds)
+		throws Exception {
+
+		List<String> fdsActionDropdownItemIds = new ArrayList<>();
+
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			ReflectionTestUtil.invoke(
+				_getViewVersionHistoryDisplayContext(
+					_getMockHttpServletRequest(_objectEntry)),
+				"getFDSActionDropdownItems", new Class<?>[0]);
+
+		for (FDSActionDropdownItem fdsActionDropdownItem :
+				fdsActionDropdownItems) {
+
+			Map<String, String> data =
+				(Map<String, String>)fdsActionDropdownItem.get("data");
+
+			fdsActionDropdownItemIds.add(data.get("id"));
+		}
+
+		Assert.assertEquals(
+			Arrays.asList(expectedIds), fdsActionDropdownItemIds);
 	}
 
 	private MockHttpServletRequest _getMockHttpServletRequest(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -308,20 +308,7 @@ public class SectionDisplayContextUtil {
 		List<FDSActionDropdownItem> fdsActionDropdownItems =
 			getFDSActionDropdownItems(httpServletRequest);
 
-		fdsActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHref(
-				"{actions.addToLaunch.href}"
-			).setIcon(
-				"rocket"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "add-to-launch")
-			).setMethod(
-				"get"
-			).setPermissionKey(
-				"addToLaunch"
-			).build(
-				"addToLaunch"
-			));
+		_addAddToLaunchAction(fdsActionDropdownItems, httpServletRequest);
 
 		return fdsActionDropdownItems;
 	}
@@ -952,6 +939,36 @@ public class SectionDisplayContextUtil {
 				"update"
 			).build(
 				"add-assets-to-project"
+			));
+	}
+
+	private static void _addAddToLaunchAction(
+		List<FDSActionDropdownItem> fdsActionDropdownItems,
+		HttpServletRequest httpServletRequest) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				themeDisplay.getCompanyId(), "LPD-72278")) {
+
+			return;
+		}
+
+		fdsActionDropdownItems.add(
+			FDSActionDropdownItemBuilder.setHref(
+				"{actions.addToLaunch.href}"
+			).setIcon(
+				"rocket"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "add-to-launch")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"addToLaunch"
+			).build(
+				"addToLaunch"
 			));
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -7,6 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItemList;
 import com.liferay.frontend.data.set.model.FDSSortItem;
 import com.liferay.frontend.data.set.model.FDSSortItemBuilder;
 import com.liferay.frontend.data.set.model.FDSSortItemList;
@@ -18,6 +19,7 @@ import com.liferay.object.service.ObjectEntryVersionLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -88,7 +90,7 @@ public class ViewVersionHistoryDisplayContext {
 	}
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		return ListUtil.fromArray(
+		return FDSActionDropdownItemList.of(
 			new FDSActionDropdownItem(
 				"{file.link.href}", "download", "download",
 				_language.get(_httpServletRequest, "download"), "get", null,
@@ -107,10 +109,7 @@ public class ViewVersionHistoryDisplayContext {
 			new FDSActionDropdownItem(
 				StringPool.BLANK, "view", "view-file",
 				_language.get(_httpServletRequest, "view"), null, null, null),
-			new FDSActionDropdownItem(
-				"{actions.addToLaunch.href}", "rocket", "addToLaunch",
-				_language.get(_httpServletRequest, "add-to-launch"), "get",
-				"addToLaunch", null),
+			_getAddToLaunchFDSActionDropdownItem(),
 			new FDSActionDropdownItem(
 				"{actions.restore.href}", "restore", "restore",
 				_language.get(_httpServletRequest, "restore-version"), "put",
@@ -165,6 +164,19 @@ public class ViewVersionHistoryDisplayContext {
 				_objectEntry.getTitleValue(_themeDisplay.getLanguageId(), true),
 				"\" ", _language.get(_themeDisplay.getLocale(), "history"))
 		).build();
+	}
+
+	private FDSActionDropdownItem _getAddToLaunchFDSActionDropdownItem() {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-72278")) {
+
+			return null;
+		}
+
+		return new FDSActionDropdownItem(
+			"{actions.addToLaunch.href}", "rocket", "addToLaunch",
+			_language.get(_httpServletRequest, "add-to-launch"), "get",
+			"addToLaunch", null);
 	}
 
 	private FDSSortItem _getFDSSortItem(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100130

## What Is Being Fixed

`SectionDisplayContextUtil.getContentsFDSActionDropdownItems` appended the `addToLaunch` FDS action dropdown item unconditionally, and `ViewVersionHistoryDisplayContext.getFDSActionDropdownItems` did the same. The `AddToLaunchModal` component both actions drive is rendered in `view_contents.jsp` and `view_version_history.jsp` only when the `LPD-72278` feature flag is enabled.

Because `feature.flag.LPD-72278=false` is the portal default, the CMS contents list and the version history list offered an "Add to Launch" action to every user while its href stayed the unresolved literal `{actions.addToLaunch.href}` and the modal it opens was never rendered. Journal already guards the equivalent action on the same flag in `JournalArticleActionDropdownItemsProvider`, and the sibling method `_addAddAssetsToProjectBulkAction` in `SectionDisplayContextUtil` itself guards on `LPD-58677`. Only these two call sites skipped the guard.

As a side effect `ViewContentsSectionDisplayContextTest.testGetFDSActionDropdownItems` has failed since the change reached master, with `expected:<16> but was:<17>`. `ViewVersionHistoryDisplayContext` had no dropdown coverage at all, so its instance of the same defect failed silently.

## How It Is Being Fixed

In `SectionDisplayContextUtil` the item moves into a private `_addAddToLaunchAction` helper that reads `ThemeDisplay` off the request and returns early unless `LPD-72278` is enabled, matching the shape of `_addAddAssetsToProjectBulkAction` in the same class.

In `ViewVersionHistoryDisplayContext` the list construction switches from `ListUtil.fromArray` to `FDSActionDropdownItemList.of`, which skips null elements, and the item moves into a private `_getAddToLaunchFDSActionDropdownItem` that returns null when the flag is off. This keeps the item in its original position after `view-file` without introducing a magic index.

With the flag off both methods now return exactly what they returned before the regression, so no pre-existing caller can depend on the longer shape.

## Test Execution

```
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration \
	--tests ViewContentsSectionDisplayContextTest \
	--tests ViewVersionHistoryDisplayContextTest
```

`ViewContentsSectionDisplayContextTest` keeps the existing `testGetFDSActionDropdownItems` as the flag-off case and adds `testGetFDSActionDropdownItemsWithAddToLaunchEnabled`. `ViewVersionHistoryDisplayContextTest` adds both flag states, each dispatching to a private `_assertFDSActionDropdownItemIds` helper that compares the ordered action ids.

## PR Check

**pr-check: PASS** — tested on `caafaa44628d4a0baec058c750018eb3ac8974c3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "caafaa44628d4a0baec058c750018eb3ac8974c3"} -->
