### PR TITLE
LPD-100486 Provision the Design Library roles in the test fixture

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/DepotEntryUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/DepotEntryUserNotificationTest.java
@@ -323,6 +323,7 @@ public class DepotEntryUserNotificationTest {
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
 		themeDisplay.setPathFriendlyURLPublic("/path-friendly-url-public");
+		themeDisplay.setSiteGroupId(TestPropsValues.getGroupId());
 
 		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/DepotEntryUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/DepotEntryUserNotificationTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
@@ -73,6 +74,9 @@ public class DepotEntryUserNotificationTest {
 
 	@Before
 	public void setUp() throws Exception {
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), true, "LPD-57283");
+
 		_depotEntry1 = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100486

## What Is Being Fixed

All five tests in `DepotEntryUserNotificationTest` fail in the shared `@Before`, so none of them reaches its own assertions:

```
com.liferay.portal.kernel.exception.NoSuchRoleException: No Role exists with the key {companyId=..., name=design library owner}
	at com.liferay.portal.service.impl.RoleLocalServiceImpl.getRole(RoleLocalServiceImpl.java:994)
	at com.liferay.depot.service.impl.DepotEntryLocalServiceImpl.addDepotEntry(DepotEntryLocalServiceImpl.java:147)
	at ...DepotEntryUserNotificationTest.setUp(DepotEntryUserNotificationTest.java:85)
```

Line 85 is the fixture entry created with `DepotConstants.TYPE_DESIGN_LIBRARY`. Since LPD-98812, `addDepotEntry` resolves the owner role from the depot subtype, and LPD-99354 gated the Design Library variant behind the `LPD-57283` feature flag, which is `false` by portal default.

Only `DepotRolesPortalInstanceLifecycleListener` at portal instance registration and `DesignLibraryFeatureFlagListener` at runtime ever create those roles. The class-level `@FeatureFlag("LPD-57283")` already on the test triggers neither, because `FeatureFlagTestRule` only flips a `PropsUtil` value and installs a `MockFeatureFlagManager`, and the instance-registration hook already ran at boot with the flag off. So the flag reads as enabled inside the test while the roles genuinely do not exist.

The same missing role also explains five of the eighteen ERROR entries in the CMS batch console log. Committing the asset library fixture entry at line 76 triggers a search reindex, and `DepotEntrySearchPermissionRoleContributor.contribute` asks for `design library member` because the flag reads as enabled. Line 49 logs the resulting `NoSuchRoleException` instead of failing, so the log is polluted for `PortalLogAssertorTest` to find.

## How It Is Being Fixed

Two changes, both confined to the test fixture. There is no production change, because the production behaviour is correct and only the test environment was missing state.

The fixture invokes the feature flag listeners itself, as the first statement of `setUp`, before any `addDepotEntry` call. This is an established pattern rather than a new one: `FragmentSetResourceTest.setUp` does exactly this, and LPD-99530 applied the same three lines to `ChangeStyleBookEntryMVCActionCommandTest` and `MasterLayoutsImporterTest`. `DepotEntryUserNotificationTest` was missed in that sweep.

The fixture also gives its `ThemeDisplay` a site group. `PortalImpl` dereferences `themeDisplay.getSiteGroup()` when it resolves a layout friendly URL, and the fixture built a `ThemeDisplay` carrying only a company and a friendly URL path. `PortletURLImpl` logs and swallows the resulting `NullPointerException`, so the tests stay green while every run leaves three more errors in the log. Those were unreachable before the first change, because the tests died in `setUp` first, so fixing only the roles would have traded five log errors for three new ones and left `PortalLogAssertorTest` still failing on this class.

## Test Execution

```
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration \
	--tests DepotEntryUserNotificationTest
```

Reproduced on clean `master` first, 5 tests and 5 failures with the identical `NoSuchRoleException`. All 5 now pass, and a log diff across the run shows zero ERROR entries, verified by comparing the bundle log line count before and after. No deploy was needed, since the change lives in a `-test` module and `testIntegration` wires the test bundle into the running portal itself.

## PR Check

**pr-check: PASS** — tested on `e9bbfdef6dd538b55cbe0074b2c49106cb4669b7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e9bbfdef6dd538b55cbe0074b2c49106cb4669b7"} -->
