### PR TITLE
LPD-100516 Remove the LPD-99742 test reintroduced by a stale branch

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -140,43 +140,6 @@ public class UpdateStructureStrutsActionTest {
 	}
 
 	@Test
-	@TestInfo("LPD-99742")
-	public void testExecuteDoesNotDeleteEdgeObjectRelationships()
-		throws Exception {
-
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
-
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
-
-		Assert.assertTrue(objectRelationship.isEdge());
-
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		_updateStructureStrutsAction.execute(
-			_getMockHttpServletRequest(_objectDefinition2),
-			mockHttpServletResponse);
-
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			mockHttpServletResponse.getContentAsString());
-
-		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
-
-		Assert.assertNotNull(
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
-	}
-
-	@Test
 	@TestInfo("LPD-92696")
 	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100516

## What Is Being Fixed

`UpdateStructureStrutsActionTest.testExecuteDoesNotDeleteEdgeObjectRelationships` fails on master at its final `Assert.assertNotNull` (line 174), because the edge object relationship it expects to survive is deleted. The other two tests in the class pass.

The test asserts behaviour that master deliberately does not have:

- `6022f74e86a5c` (LPD-99742) changed `UpdateStructureStrutsAction._deleteRelationships` from `getObjectRelationshipsByObjectDefinitionId2` to `getObjectRelationships`, and added a test for it.
- On 2026-07-30 three reverts backed all of it out: `795eb371482b0` the production fix, `a556a2498a69b` the test, and `9f4e4f9ffaaf0` a rename. Master returned to `getObjectRelationshipsByObjectDefinitionId2` with no test asserting the reverted behaviour, a consistent state.
- On 2026-08-01 the commit `6a6a39ebaeb13`, "LPD-99210 Remove the LPD-17564 feature flag from the tests", authored 2026-07-23, landed and re-added `testExecuteDoesNotDeleteEdgeObjectRelationships` tagged `@TestInfo("LPD-99742")`. Its branch predated the reverts, so its diff on this file carried the pre-revert content and Git merged it without conflict.

LPD-99742 is still an open Bug in Selected for Development with no resolution, so the production fix is not returning imminently.

## How It Is Being Fixed

The resurrected test method is removed, restoring the intended post-revert state of the file. The production code is left untouched; reinstating the fix belongs to LPD-99742.

The removal was verified to be surgical. Diffing this branch's version of the file against the tree at `795eb371482b0`, the last of the three reverts, leaves exactly two differences, the `FeatureFlag` import and the `@FeatureFlag("LPD-17564")` annotation. Those are the legitimate part of the LPD-99210 commit, so nothing beyond the resurrection was undone.

Scope was also checked across every file that both the 2026-07-30 reverts and the LPD-99210 commits touched. This is the only genuine resurrection. `CMSFeatureFlagListener` was deleted outright by `dcaf0a2548a55`, and the failing `depotRoles.spec.ts` tests come from `ba9be246e3e3a` (LPD-97885, 2026-07-15), which predates the reverts.

## Test Execution

```
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration \
	--tests UpdateStructureStrutsActionTest
```

Reproduced on clean `master` first, 3 tests with 1 failure. After the removal the class passes in full with its remaining 2 tests.

## PR Check

**pr-check: PASS** — tested on `5289a9cb6de0ba5ae38d40f4ffa3d4a10119c85d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "5289a9cb6de0ba5ae38d40f4ffa3d4a10119c85d"} -->
