### PR TITLE
LPD-88276 Cover External Video creation from the All section

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -20,6 +20,10 @@ import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
+const _EXTERNAL_VIDEO_ID = 'IqCSx3omX4o';
+
+const _EXTERNAL_VIDEO_URL = `https://www.youtube.com/watch?v=${_EXTERNAL_VIDEO_ID}`;
+
 const _PNG_BASE64 =
 	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgAAACAAEABToPCwAAAABJRU5ErkJggg==';
 
@@ -1575,5 +1579,73 @@ test(
 				card.getByText('Approved', {exact: true})
 			).toBeVisible();
 		});
+	}
+);
+
+test(
+	'External Video can be created from the All section',
+	{tag: ['@LPD-85552', '@LPD-88276']},
+	async ({apiHelpers, assetsPage, contentsPage}) => {
+		const applicationName = 'cms/external-videos';
+		const videoTitle = getRandomString();
+
+		try {
+			await test.step('Create an External Video from the All section', async () => {
+				await assetsPage.gotoAll();
+
+				await assetsPage.createContent('External Video');
+
+				await contentsPage.fillData([
+					{label: 'Title', value: videoTitle},
+					{label: 'Video URL', value: _EXTERNAL_VIDEO_URL},
+				]);
+
+				await contentsPage.saveContent();
+			});
+
+			await test.step('The External Video is listed in the All section', async () => {
+				const item = assetsPage.getItem(videoTitle);
+
+				await expect(item).toBeVisible();
+				await expect(
+					item.getByText('External Video', {exact: true})
+				).toBeVisible();
+				await expect(
+					item.getByText('Approved', {exact: true})
+				).toBeVisible();
+			});
+
+			await test.step('The Cards view shows the thumbnail of the video', async () => {
+				await assetsPage.changeVisualizationMode('Cards');
+
+				const card = assetsPage.getCardItem(videoTitle);
+
+				await expect(card).toBeVisible();
+
+				await expect(card.locator('img')).toHaveAttribute(
+					'src',
+					new RegExp(_EXTERNAL_VIDEO_ID)
+				);
+			});
+		}
+		finally {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					'Default',
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const objectEntry = response.items.find(
+				(item: {title: string}) => item.title === videoTitle
+			);
+
+			if (objectEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(objectEntry.id)
+				);
+			}
+		}
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88276

## What Is Being Fixed

The parent story LPD-85552 (Actions - Single Actions) asks for coverage of the single-item actions in the CMS Assets views: creating content from the OOTB structures, creating content from custom structures, editing an entry by clicking its title or through the row Edit action, and deleting an entry through the row Delete action.

An audit of the existing suite found all of those already covered, with one exception. Creating an External Video through the UI was not exercised anywhere. The only existing coverage asserts that External Video appears in the Space Summary creation dropdown and that an API-seeded entry renders a video preview, so no test had ever driven the creation form itself. Basic Document creation is covered end to end in the DXP folder-hierarchy suite, custom structure creation in the content editor suite, and both row actions in the content editor and All section suites.

## How It Is Being Fixed

Adds a single test to the All section suite that creates an External Video from the All section creation menu, fills the Title and Video URL fields, publishes, and then asserts the entry is listed with the External Video type and an Approved status.

Placing the test on the All section rather than on Files also closes a second gap, since no test previously drove an All section creation menu through to a saved entry. The creation menu there was only ever opened to assert that it offers no Folder option.

The final assertion checks that the submitted URL was parsed into the expected video, by switching to Cards view and matching the video id in the thumbnail src. It deliberately asserts the src attribute rather than the visibility of the thumbnail image, because asserting visibility would make the result depend on the remote image loading and would fail on a restricted network even when the product behaved correctly. The iframe preview used by the Files suite is not reachable here, since the All section offers only Cards and Table views while the iframe renders in the Files-only Gallery view.

Because the entry is created through the UI rather than through the API helpers, it is not covered by the automatic data cleanup, so the test deletes it explicitly in a finally block.

## Test Execution

```
cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/all.spec.ts --project site-cms-site-initializer.main -g "@LPD-88276" --reporter=list
```

Run six consecutive times, all green. The full all.spec.ts suite was also run, with all 28 tests passing.

## PR Check

**pr-check: PASS** — tested on `b72dc8b61c8e140cf1e1b11a0300e6d83e147496`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "b72dc8b61c8e140cf1e1b11a0300e6d83e147496"} -->
