### PR TITLE
LPD-100524 Clean up a space depot when its group is deleted first

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -112,6 +113,29 @@ public class DepotEntryLocalServiceTest {
 				depotEntry.getCompanyId(), depotEntry.getUserId(),
 				group.getExternalReferenceCode(),
 				depotEntry.getModelClassName(), _filterFactory));
+		Assert.assertEquals(
+			0,
+			_objectEntryFolderLocalService.getObjectEntryFoldersCount(
+				depotEntry.getGroupId(), depotEntry.getCompanyId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT));
+	}
+
+	@Test
+	@TestInfo("LPD-100521")
+	public void testDeleteDepotEntryWhenGroupIsDeleted() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_groupLocalService.deleteGroup(depotEntry.getGroupId());
+
+		Assert.assertNull(
+			_depotEntryLocalService.fetchGroupDepotEntry(
+				depotEntry.getGroupId()));
+		Assert.assertNull(
+			CMSDefaultPermissionUtil.fetchObjectEntryByDepotGroupId(
+				depotEntry.getCompanyId(), depotEntry.getUserId(),
+				depotEntry.getGroupId(), depotEntry.getModelClassName(),
+				_filterFactory));
 		Assert.assertEquals(
 			0,
 			_objectEntryFolderLocalService.getObjectEntryFoldersCount(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
@@ -97,7 +97,7 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
 			ObjectEntryFolderUtil.deleteObjectEntryFolders(depotEntry);
 
-			_deleteCMSDefaultPermissions(depotEntry.getGroup());
+			_deleteCMSDefaultPermissions(depotEntry);
 		}
 
 		return super.deleteDepotEntry(depotEntry);
@@ -112,7 +112,7 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
 			ObjectEntryFolderUtil.deleteObjectEntryFolders(depotEntry);
 
-			_deleteCMSDefaultPermissions(depotEntry.getGroup());
+			_deleteCMSDefaultPermissions(depotEntry);
 		}
 
 		return super.deleteDepotEntry(depotEntryId);
@@ -180,22 +180,23 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 			group.getGroupId(), StringPool.BLANK);
 	}
 
-	private void _deleteCMSDefaultPermissions(Group group)
+	private void _deleteCMSDefaultPermissions(DepotEntry depotEntry)
 		throws PortalException {
 
 		ObjectDefinition cmsDefaultPermissionObjectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION", group.getCompanyId());
+					"L_CMS_DEFAULT_PERMISSION", depotEntry.getCompanyId());
 
 		if (cmsDefaultPermissionObjectDefinition == null) {
 			return;
 		}
 
-		ObjectEntry objectEntry = CMSDefaultPermissionUtil.fetchObjectEntry(
-			group.getCompanyId(), group.getCreatorUserId(),
-			group.getExternalReferenceCode(), DepotEntry.class.getName(),
-			_filterFactory);
+		ObjectEntry objectEntry =
+			CMSDefaultPermissionUtil.fetchObjectEntryByDepotGroupId(
+				depotEntry.getCompanyId(), depotEntry.getUserId(),
+				depotEntry.getGroupId(), DepotEntry.class.getName(),
+				_filterFactory);
 
 		if (objectEntry == null) {
 			return;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100524

## What Is Being Fixed

Depot deletion is a two-way cycle between two model listeners. `DepotEntryModelListener.onAfterRemove` deletes the depot's group, and `GroupModelListener.onAfterRemove` registers a commit callback that deletes the depot entry if one still exists for that group. Each direction is guarded only by a row-existence check.

Entering from the depot side is fine, because the CMS wrapper runs while the group row is still present. Entering from the group side is not. `GroupLocalService.deleteGroup` commits the group removal first, and only then calls back into `deleteDepotEntry`, where the wrapper's next statement was `depotEntry.getGroup()` — a hard `findByPrimaryKey` against a row that no longer exists.

`TransactionCallbackUtil` catches and logs the resulting `NoSuchGroupException`, so nothing surfaced to the caller. Worse, the throw landed ahead of `super.deleteDepotEntry`, so the entire depot cleanup was abandoned rather than just the CMS default permission entry: the depot entry row survived, and with it its `DepotEntryGroupRel`s, its `DepotEntryPin`s and its resource row. The object entry folder deletion on the preceding line rolled back too, since the callback runs in its own new transaction.

The group-first path is reached in production when an instance is deleted, since `CompanyLocalServiceImpl` deletes each group directly, and from Site Admin through `GroupService.deleteGroup`. In the integration suite the damage stayed invisible because DataGuard's leftover sweep removed the orphans after each test, which is why the only symptom on CI was a log entry and the test that failed was `PortalLogAssertorTest`. Four of the eighteen errors in the 2026-08-03 CMS batch console log come from here: three from `ObjectEntryFolderModelListenerTest` and one from `ObjectDefinitionDeployerImplTest`.

## How It Is Being Fixed

`_deleteCMSDefaultPermissions` now takes the `DepotEntry` rather than a `Group`, and looks the permission entry up with `CMSDefaultPermissionUtil.fetchObjectEntryByDepotGroupId`. The depot entry already carries the company id, the user id and the group id, so no group is loaded at all and the ordering stops mattering.

That lookup is not new. It already exists in `site-cms-site-initializer-api` and is used the same way by this module's own `GroupModelListener` and by `CMSDefaultPermissionsUpgradeProcess`, and `depotGroupId` is written unconditionally by `addOrUpdateObjectEntry`, so every entry can be found through it. Keying on the depot group id also closes a second latent miss, because the old lookup keyed on the group's external reference code, which is mutable — the very reason `fetchObjectEntryByDepotGroupId` was added in the first place.

Guarding with a `fetchGroup(...) != null` check was rejected: it would turn a loud failure into a permanent silent leak of the permission entry.

## Test Execution

```bash
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests DepotEntryLocalServiceTest
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests ObjectEntryFolderModelListenerTest
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests ObjectDefinitionDeployerImplTest
```

`DepotEntryLocalServiceTest` gains `testDeleteDepotEntryWhenGroupIsDeleted`, a sibling of the existing `testDeleteDepotEntry` that covers the group-first direction. It deletes the group and then asserts all three cleanups happened: the depot entry is gone, the CMS default permission entry is gone, and no object entry folders remain. Against unmodified production code it fails on its first assertion, printing the surviving depot entry.

The other two classes are the regression cases from the CMS batch. Both already passed while logging errors, so they were verified by diffing the bundle log across the run rather than by the test result. After the fix the log delta for all three classes contains zero `ERROR` and zero `WARN` entries.

## PR Check

**pr-check: PASS** — tested on `1b30b3c36f69f5b62e585e653552d18578b5aaab`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1b30b3c36f69f5b62e585e653552d18578b5aaab"} -->
