### PR TITLE
LPD-100945 Provision the Design Library roles in the test fixture

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -69,6 +70,9 @@ public class DepotPermissionCheckerWrapperTest {
 
 	@Before
 	public void setUp() throws Exception {
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), true, "LPD-57283");
+
 		_group = GroupTestUtil.addGroup();
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100945

## What Is Being Fixed

Five tests in `DepotPermissionCheckerWrapperTest` fail with `NoSuchRoleException: No Role exists with the key {companyId=..., name=design library owner}`. They are exactly the five methods annotated `@FeatureFlag("LPD-57283")`, and they were reported failing in the U152 release build.

The four Design Library roles are provisioned in two places, both gated on the LPD-57283 feature flag: `DepotRolesPortalInstanceLifecycleListener` creates them at portal instance startup, and `DesignLibraryFeatureFlagListener.onValue` creates them when the flag is enabled at runtime. The `@FeatureFlag` test rule only sets the flag value, it never fires the listener, so on an instance that started with the flag disabled the roles never exist and the `RoleLocalServiceUtil.getRole` lookup in `DepotTestUtil.withDesignLibrary*` throws.

## How It Is Being Fixed

`setUp` now calls `FeatureFlagTestUtil.invokeFeatureFlagListeners` for LPD-57283, which fires `DesignLibraryFeatureFlagListener` and provisions the roles before each test runs. This mirrors the fix applied to `DepotEntryUserNotificationTest` in LPD-100486, which addressed the same failure mode in the CMS module.

## Test Execution

```
gradlew -p modules/apps/depot/depot-test testIntegration --tests DepotPermissionCheckerWrapperTest
```

Without this change the run is 39 passed and 5 failed, all five with `NoSuchRoleException`. With it, all 44 pass.

## PR Check

**pr-check: PASS** — tested on `579dbf2a721646d500bfc4208890c6f5c1072b29`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "579dbf2a721646d500bfc4208890c6f5c1072b29"} -->
