### PR TITLE
LPD-100993 Resolve category display page URLs with special characters

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageObjectProvider.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -117,7 +118,7 @@ public class AssetCategoryLayoutDisplayPageObjectProvider
 			_assetVocabularyLocalService.fetchAssetVocabulary(
 				_assetCategory.getVocabularyId());
 
-		sb.append(assetVocabulary.getName());
+		sb.append(HttpComponentsUtil.encodePath(assetVocabulary.getName()));
 
 		Collections.reverse(ancestorAssetCategories);
 

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -175,9 +176,8 @@ public class AssetCategoryLayoutDisplayPageProvider
 			return null;
 		}
 
-		AssetVocabulary assetVocabulary =
-			_assetVocabularyLocalService.fetchGroupVocabulary(
-				groupId, parts[0]);
+		AssetVocabulary assetVocabulary = _fetchAssetVocabulary(
+			groupId, parts[0]);
 
 		if (assetVocabulary == null) {
 			return null;
@@ -188,10 +188,8 @@ public class AssetCategoryLayoutDisplayPageProvider
 		long parentClassPK = assetVocabulary.getVocabularyId();
 
 		for (int i = 1; i < parts.length; i++) {
-			friendlyURLEntryLocalization =
-				_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
-					groupId, _portal.getClassNameId(AssetCategory.class),
-					parentClassPK, _language.getLanguageId(locale), parts[i]);
+			friendlyURLEntryLocalization = _fetchFriendlyURLEntryLocalization(
+				groupId, parentClassPK, locale, parts[i]);
 
 			if (friendlyURLEntryLocalization == null) {
 				break;
@@ -235,6 +233,47 @@ public class AssetCategoryLayoutDisplayPageProvider
 		}
 
 		return assetCategory;
+	}
+
+	private AssetVocabulary _fetchAssetVocabulary(long groupId, String name) {
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.fetchGroupVocabulary(groupId, name);
+
+		if (assetVocabulary != null) {
+			return assetVocabulary;
+		}
+
+		String decodedName = HttpComponentsUtil.decodePath(name);
+
+		if (name.equals(decodedName)) {
+			return null;
+		}
+
+		return _assetVocabularyLocalService.fetchGroupVocabulary(
+			groupId, decodedName);
+	}
+
+	private FriendlyURLEntryLocalization _fetchFriendlyURLEntryLocalization(
+		long groupId, long parentClassPK, Locale locale, String urlTitle) {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
+				groupId, _portal.getClassNameId(AssetCategory.class),
+				parentClassPK, _language.getLanguageId(locale), urlTitle);
+
+		if (friendlyURLEntryLocalization != null) {
+			return friendlyURLEntryLocalization;
+		}
+
+		String decodedURLTitle = HttpComponentsUtil.decodePath(urlTitle);
+
+		if (urlTitle.equals(decodedURLTitle)) {
+			return null;
+		}
+
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
+			groupId, _portal.getClassNameId(AssetCategory.class), parentClassPK,
+			_language.getLanguageId(locale), decodedURLTitle);
 	}
 
 	private Locale _getLocale() {

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
@@ -68,6 +68,10 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 
 	@Test
 	public void testGetURLTitle() throws Exception {
+		_testGetURLTitleWithEncodedAssetVocabularyName(
+			"vocabulary name", "vocabulary%20name");
+		_testGetURLTitleWithEncodedAssetVocabularyName(
+			"vocabulario ñ", "vocabulario%20%C3%B1");
 		_testGetURLTitleWithMaximumLengthExceeded();
 		_testGetURLTitleWithMaximumLengthNotExceeded();
 	}
@@ -205,6 +209,40 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 		Assert.assertEquals(
 			assetCategory4,
 			layoutDisplayPageObjectProvider2.getDisplayObject());
+	}
+
+	private void _testGetURLTitleWithEncodedAssetVocabularyName(
+			String assetVocabularyName, String encodedAssetVocabularyName)
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(), assetVocabularyName);
+
+		String categoryURLTitle = StringUtil.toLowerCase(
+			StringUtil.randomString());
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			categoryURLTitle);
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider1 =
+			_getLayoutDisplayPageObjectProvider(assetCategory);
+
+		String urlTitle = layoutDisplayPageObjectProvider1.getURLTitle(
+			LocaleUtil.getDefault());
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				encodedAssetVocabularyName, StringPool.SLASH, categoryURLTitle),
+			urlTitle);
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider2 =
+			_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				_group.getGroupId(), urlTitle);
+
+		Assert.assertEquals(
+			assetCategory, layoutDisplayPageObjectProvider2.getDisplayObject());
 	}
 
 	private void _testGetURLTitleWithMaximumLengthExceeded() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100993

## What Is Being Fixed

Clicking **View Display Page** on a category did not open its display page when the vocabulary name contained a space or a character the browser percent encodes, such as an accent. The failure was silent: on a site with a default page the site home page was served with no error at all, and on a site without pages the request ended in a 404 rendered with the personal site chrome, so the Control Menu header read `My Dashboard`.

The friendly URL was composed from the raw `AssetVocabulary.getName()`, while the resolver matched that segment against the request URI, which `FriendlyURLServlet` never decodes because it reads `getRequestURI()`. The exact match finder behind `fetchGroupVocabulary` therefore never found the vocabulary, no display page was resolved, and the request fell through to the site default page. The category segment was unaffected because its `urlTitle` is already stored percent encoded.

The behavior regressed with `1981c929c`, "LPD-97350 Degate the LPD-70396 category friendly URL checks", which made the name based category friendly URLs unconditional. In the `[master] ci:test:content-management` routine the affected tests passed until the 2026-07-28 build and have failed on every build since 2026-07-29. It reaches the user through the admin UI with an accented vocabulary name, and through the JSONWS and headless APIs, which store the raw title as the vocabulary name and so keep spaces.

## How It Is Being Fixed

The composition now percent encodes the vocabulary segment, and the resolution decodes each segment as a fallback when the verbatim lookup misses, so the two operations are inverses of each other. Keeping the verbatim lookup first means the path that already worked costs the same single query as before and the fallback only runs for the broken case. Because the fix acts on the request rather than on the stored data, it needs no upgrade process and no data migration, and URLs that resolve today keep resolving.

Verified on a bundle built from `release-7.4.13.152`. The accented URL now forwards to the display page layout instead of the site home page, and the functional steps of `DisplayPageTemplatesForCategory#AddDisplayPageTemplateAndMarkItAsDefault` pass. `AssetCategoryLayoutDisplayPageProviderTest` covers a vocabulary name with a space and one with a non ASCII character, round tripping the composed URL back through the resolver.

A separate inconsistency remains worth its own ticket: `AssetVocabularyLocalServiceImpl.addVocabulary` stores the name verbatim while `updateVocabulary` normalizes it through `_generateVocabularyName`, which is why the API paths create vocabulary names that keep their spaces in the first place.

## PR Check

**pr-check: PASS** — tested on `826d1b598c6eeaebd7d6d66eb4a94741f72e8e85`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "826d1b598c6eeaebd7d6d66eb4a94741f72e8e85"} -->
