### PR TITLE
LPD-101002 Fix ranked page date casts and the journal UUID map race

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -59,8 +59,6 @@ import com.liferay.portlet.asset.service.permission.AssetTagsPermission;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import java.sql.Timestamp;
-
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -644,18 +642,14 @@ public class KeywordResourceImpl
 				}
 
 				setCompanyId((long)assetTags[1]);
-				setCreateDate(_toDate((Timestamp)assetTags[2]));
+				setCreateDate((Date)assetTags[2]);
 				setGroupId((long)assetTags[3]);
-				setModifiedDate(_toDate((Timestamp)assetTags[4]));
+				setModifiedDate((Date)assetTags[4]);
 				setName((String)assetTags[5]);
 				setTagId((long)assetTags[6]);
 				setUserId((long)assetTags[7]);
 			}
 		};
-	}
-
-	private Date _toDate(Timestamp timestamp) {
-		return new Date(timestamp.getTime());
 	}
 
 	private Keyword _toKeyword(AssetTag assetTag) throws Exception {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -75,8 +75,6 @@ import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import java.sql.Timestamp;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -1131,21 +1129,17 @@ public class TaxonomyCategoryResourceImpl
 			{
 				setCategoryId((long)assetCategory[1]);
 				setCompanyId((long)assetCategory[2]);
-				setCreateDate(_toDate((Timestamp)assetCategory[3]));
+				setCreateDate((Date)assetCategory[3]);
 				setDescription((String)assetCategory[4]);
 				setExternalReferenceCode((String)assetCategory[5]);
 				setGroupId((long)assetCategory[6]);
-				setModifiedDate(_toDate((Timestamp)assetCategory[7]));
+				setModifiedDate((Date)assetCategory[7]);
 				setName((String)assetCategory[8]);
 				setParentCategoryId((long)assetCategory[9]);
 				setUserId((long)assetCategory[10]);
 				setVocabularyId((long)assetCategory[11]);
 			}
 		};
-	}
-
-	private Date _toDate(Timestamp timestamp) {
-		return new Date(timestamp.getTime());
 	}
 
 	private String[] _toStringArray(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Vendel Toreki
@@ -63,7 +64,7 @@ public class AssetDisplayPageEntryUpgradeProcess extends UpgradeProcess {
 		long liveGroupId = _liveGroupIdsMap.getOrDefault(groupId, groupId);
 
 		Map<String, String> uuids = _uuidsMaps.computeIfAbsent(
-			liveGroupId, key -> new HashMap<>());
+			liveGroupId, key -> new ConcurrentHashMap<>());
 
 		return uuids.computeIfAbsent(
 			journalArticleUuid, key -> PortalUUIDUtil.generate());
@@ -173,6 +174,7 @@ public class AssetDisplayPageEntryUpgradeProcess extends UpgradeProcess {
 	private final CompanyLocalService _companyLocalService;
 	private final Map<Long, Long> _liveGroupIdsMap = new HashMap<>();
 	private final Set<Long> _stagedGroupIds = new HashSet<>();
-	private final Map<Long, Map<String, String>> _uuidsMaps = new HashMap<>();
+	private final Map<Long, Map<String, String>> _uuidsMaps =
+		new ConcurrentHashMap<>();
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101002
https://liferay.atlassian.net/browse/LPD-101003
https://liferay.atlassian.net/browse/LPD-101004

## What Is Being Fixed

Three release test failures found under LPD-100696, from two unrelated root causes.

LPD-101002 and LPD-101003 are a regression in the ranked page endpoints of `headless-admin-taxonomy`. Both `GET /o/headless-admin-taxonomy/v1.0/keywords/ranked` and `GET /o/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked` return a 500 response for any request matching at least one row. Each resource builds its entity from a Hibernate `DynamicQuery` projection and casts the date columns to `java.sql.Timestamp`. Since LPD-98521 introduced the `TimestampType` user type, Hibernate normalizes every date it returns to a `java.util.Date`, so the cast throws a `ClassCastException`. These are published endpoints, so client integrations break on upgrade.

LPD-101004 is a concurrency defect in the journal `v1_1_6` asset display page entry upgrade. `_generateLocalStagingAwareUUID` mutates a plain `HashMap` of plain `HashMap` values from the several `UpgradeDataExecutor` threads that `processConcurrently` uses. The race is long standing, but LPD-98666 replaced the `containsKey`/`put`/`get` sequence with nested `computeIfAbsent` calls, and `HashMap.computeIfAbsent` checks `modCount` and throws, so a previously silent race now fails the upgrade outright. When it does not throw, a corrupted map loses a cached UUID and a staged article and its live counterpart receive different asset display page entry UUIDs.

## How It Is Being Fixed

For the two ranked page endpoints, the redundant `_toDate(Timestamp)` helper and its `java.sql.Timestamp` import are removed and the projection value is cast straight to `java.util.Date`. The contract established by LPD-98521 is that Hibernate always hands back a `java.util.Date`, so normalizing at the call site is dead weight. The plain cast also passes a null date through to the setter rather than raising an NPE, which the old helper would have done.

For the upgrade process, `_uuidsMaps` and its inner maps become `ConcurrentHashMap` so `computeIfAbsent` is atomic. The staged then live ordering in `doUpgrade` already guarantees that a staged article and its live counterpart share a UUID, so the map only needed to survive concurrent access. `_liveGroupIdsMap` and `_stagedGroupIds` stay plain, because `_init` writes them before the fan out and `processConcurrently` completes before the next company's `_init`, leaving them read only while the worker threads run. The nested `computeIfAbsent` is safe on `ConcurrentHashMap` here because the mapping function only touches a different map, so there is no re-entrancy.

Each fix is a separate commit so any one of the three can be reverted or cherry picked on its own.

## Why Are There No Tests?

All three are regressions caught by existing release tests that already assert the correct behavior. `KeywordResourceTest`, `TaxonomyCategoryResourceTest`, and `UpgradeAssetDisplayPageEntryTest` went from five failures to zero with no test edits. Adding new tests would duplicate coverage that already exists and already did its job.

Verified locally with the following, plus six additional consecutive runs of `UpgradeAssetDisplayPageEntryTest` to confirm the race is closed:

	gradlew -p modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test testIntegration --tests KeywordResourceTest --tests TaxonomyCategoryResourceTest
	gradlew -p modules/apps/journal/journal-test testIntegration --tests UpgradeAssetDisplayPageEntryTest

## PR Check

**pr-check: PASS** — tested on `3292dacb095999247f8b962bbc829f29ace34797`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3292dacb095999247f8b962bbc829f29ace34797"} -->
