### PR TITLE
LPD-100554 Check the view permission when reading a thread by id

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -223,9 +223,12 @@ public class MessageBoardThreadResourceImpl
 		MBThread mbThread = _mbThreadLocalService.getMBThread(
 			messageBoardThreadId);
 
+		MBMessage mbMessage = _mbMessageService.getMessage(
+			mbThread.getRootMessageId());
+
 		_checkPermission(
-			mbThread.getCompanyId(), mbThread.getGroupId(),
-			mbThread.getStatus(), mbThread.getUserId());
+			mbMessage.getCompanyId(), mbMessage.getGroupId(),
+			mbMessage.getStatus(), mbMessage.getUserId());
 
 		_viewCountManager.incrementViewCount(
 			contextCompany.getCompanyId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardThread;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.headless.delivery.client.resource.v1_0.MessageBoardThreadResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardThreadSerDes;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
@@ -17,11 +18,15 @@ import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
 import com.liferay.message.boards.service.MBThreadLocalServiceUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalServiceUtil;
 
 import java.util.Arrays;
@@ -82,6 +87,24 @@ public class MessageBoardThreadResourceTest
 			messageBoardThreadResource.
 				deleteMessageBoardThreadMyRatingHttpResponse(
 					irrelevantMessageBoardThread.getId()));
+	}
+
+	@Override
+	@Test
+	public void testGetMessageBoardThread() throws Exception {
+		super.testGetMessageBoardThread();
+
+		MessageBoardThread messageBoardThread =
+			testGetMessageBoardThread_addMessageBoardThread();
+
+		assertHttpResponseStatusCode(
+			404,
+			_getUserWithoutPermissionsMessageBoardThreadResource().
+				getMessageBoardThreadHttpResponse(messageBoardThread.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			messageBoardThreadResource.getMessageBoardThreadHttpResponse(
+				messageBoardThread.getId()));
 	}
 
 	@Override
@@ -268,6 +291,25 @@ public class MessageBoardThreadResourceTest
 
 		return testPostMessageBoardSectionMessageBoardThread_addMessageBoardThread(
 			randomMessageBoardThread());
+	}
+
+	private MessageBoardThreadResource
+			_getUserWithoutPermissionsMessageBoardThreadResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		return MessageBoardThreadResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private MBCategory _mbCategory;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100554

## What Is Being Fixed

`GET /o/headless-delivery/v1.0/message-board-threads/{id}` did not apply the VIEW permission check that every other read path on `MessageBoardThreadResourceImpl` applies, so the by-id read could disagree with the listing for the very same thread.

`getMessageBoardThread` resolved the thread through `MBThreadLocalService`, which does no permission checking, and then called `_checkPermission`. That helper only guards a thread whose workflow status is not approved, so an approved thread reached the DTO converter with no VIEW check at all. Every sibling read already gates on VIEW of the thread's root message: the site listing and the section listing through `_getSiteMessageBoardThreadsPage`, the ranked page, `getSiteMessageBoardThreadByFriendlyUrlPath`, and the `my-rating` resource all call `MBMessageService.getMessage`. The by-id read was the only path that skipped it, which is also why `_toMessageBoardThread` could return an empty `actions` map while still serving the body: the action links were computed from a real permission check that the read itself never consulted.

The read is not side effect free either, so the inconsistent path also incremented `viewCount` and added a thread flag.

## How It Is Being Fixed

The first commit resolves the thread's root message through the permission-checked `MBMessageService` and passes that message's fields to `_checkPermission`, making the by-id read structurally identical to `getSiteMessageBoardThreadByFriendlyUrlPath`. `MBMessageService` is already injected, so this adds no reference and no new class, and `_toMessageBoardThread(mbThread, false)` is untouched, so the response body is unchanged.

`_checkPermission` is deliberately kept rather than deleted as redundant. The MBMessage VIEW check does cover workflow status through `WorkflowedModelPermissionLogic`, but that rule is not identical to the existing owner-or-content-reviewer rule, and narrowing the read path is the goal here rather than reshaping the draft and pending path.

Worth noting for reviewers, since it is the natural question: the non-approved path is preserved, not tightened. For a pending item `WorkflowPermissionUtil` grants VIEW to content reviewers and to the author, which are exactly the two parties `_checkPermission` admits. For a draft, `WorkflowedModelPermissionLogic` requires UPDATE, and MBMessage declares no `owner-defaults`, so `ResourceActionsImpl` falls back to all supported actions and the author retains UPDATE.

## Test Execution

```
gradlew -p modules/apps/headless/headless-delivery/headless-delivery-test testIntegration --tests MessageBoardThreadResourceTest
```

64 tests, 0 failures, 0 errors, 3 skipped. The 3 skips are the pre-existing `@Ignore` annotations already on `master`.

The second commit adds a `testGetMessageBoardThread` override following the existing precedent in this module, `MessageBoardAttachmentResourceTest`, which builds a client for a freshly added user and asserts the status code. 404 rather than 403 is the expected denial, because `PrincipalExceptionMapper` deliberately converts a `PrincipalException` to 404 on GET so that a denied read does not disclose whether the resource exists.

The new test was verified to fail against the unfixed resource, `expected:<404> but was:<200>`, so it genuinely guards the change rather than passing incidentally.

Manually confirmed against a local bundle that the by-id read and the listing now agree in both directions. A thread left at the default `viewableBy` returns 404 by id and `totalCount: 0` in the listing, and a thread created with `viewableBy: Anyone` returns 200 with its body by id and `totalCount: 1` in the listing, so the intended audience keeps full access.

## Haiku

Mikel, buen mozo,
el hilo ya no se ve
sin el permiso.

## PR Check

**pr-check: PASS** — tested on `1abd248ef8b7f994d9cff257897a9fc7ac2a6c4c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1abd248ef8b7f994d9cff257897a9fc7ac2a6c4c"} -->
