### PR TITLE
LPD-100264 Hide project scope in vocabularies until CMP is enabled

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditGeneralInfo.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditGeneralInfo.tsx
@@ -380,14 +380,16 @@ export default function EditGeneralInfo({
 						setSpaceInputError={setSpaceInputError}
 					/>
 
-					<CategorizationProjects
-						checkboxText="vocabulary"
-						disabled={vocabulary.system}
-						projects={projects}
-						setProjectChange={setProjectChange}
-						setProjectInputError={setProjectInputError}
-						setSelectedProjects={onChangeSelectedProjects}
-					/>
+					{Liferay.FeatureFlags['LPD-58677'] && (
+						<CategorizationProjects
+							checkboxText="vocabulary"
+							disabled={vocabulary.system}
+							projects={projects}
+							setProjectChange={setProjectChange}
+							setProjectInputError={setProjectInputError}
+							setSelectedProjects={onChangeSelectedProjects}
+						/>
+					)}
 				</ClayForm.Group>
 			</ClayPanel>
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/vocabularies/EditGeneralInfo.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/vocabularies/EditGeneralInfo.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import ApiHelper from '../../../../../src/main/resources/META-INF/resources/js/common/services/ApiHelper';
+import SpaceService from '../../../../../src/main/resources/META-INF/resources/js/common/services/SpaceService';
+import EditGeneralInfo from '../../../../../src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditGeneralInfo';
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/common/services/SpaceService'
+);
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/common/services/ApiHelper'
+);
+
+const defaultProps = {
+	assetLibraries: [],
+	defaultLanguageId: 'en_US',
+	externalReferenceCodeInputError: '',
+	externalReferenceCodeMaxLength: 255,
+	isNew: true,
+	locales: [
+		{
+			id: 'en_US',
+			label: 'en-US',
+			name: 'English (United States)',
+			symbol: 'us',
+		},
+	],
+	nameInputError: '',
+	onChangeVocabulary: jest.fn(),
+	projects: [],
+	setExternalReferenceCodeInputError: jest.fn(),
+	setNameInputError: jest.fn(),
+	setProjectChange: jest.fn(),
+	setProjectInputError: jest.fn(),
+	setSpaceChange: jest.fn(),
+	setSpaceInputError: jest.fn(),
+	setVocabularyPermissions: jest.fn(),
+	showPermissions: false,
+	spritemap: '',
+	vocabulary: {
+		assetLibraries: [],
+		assetTypes: [],
+		multiValued: true,
+		name: '',
+		name_i18n: {'en-US': ''},
+		projects: [],
+		visibilityType: 'PUBLIC' as const,
+	},
+};
+
+describe('EditGeneralInfo', () => {
+	beforeEach(() => {
+		jest.spyOn(SpaceService, 'getSpaces').mockResolvedValue([] as any);
+		jest.spyOn(ApiHelper, 'getAll').mockResolvedValue([]);
+
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
+	});
+
+	afterEach(() => {
+		(global as any).Liferay.FeatureFlags = {};
+
+		jest.clearAllMocks();
+	});
+
+	it('does not render the project scope selector when the CMP feature flag is disabled', async () => {
+		render(<EditGeneralInfo {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(SpaceService.getSpaces).toHaveBeenCalled();
+		});
+
+		expect(screen.getByLabelText('space-selector')).toBeInTheDocument();
+
+		expect(
+			screen.queryByLabelText('project-selector')
+		).not.toBeInTheDocument();
+
+		expect(ApiHelper.getAll).not.toHaveBeenCalled();
+	});
+
+	it('renders the project scope selector when the CMP feature flag is enabled', async () => {
+		(global as any).Liferay.FeatureFlags = {'LPD-58677': true};
+
+		render(<EditGeneralInfo {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(ApiHelper.getAll).toHaveBeenCalled();
+		});
+
+		expect(screen.getByLabelText('project-selector')).toBeInTheDocument();
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/vocabularies/EditGeneralInfo.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/vocabularies/EditGeneralInfo.test.tsx
@@ -68,7 +68,7 @@ describe('EditGeneralInfo', () => {
 	});
 
 	afterEach(() => {
-		(global as any).Liferay.FeatureFlags = {};
+		Liferay.FeatureFlags['LPD-58677'] = false;
 
 		jest.clearAllMocks();
 	});
@@ -90,7 +90,7 @@ describe('EditGeneralInfo', () => {
 	});
 
 	it('renders the project scope selector when the CMP feature flag is enabled', async () => {
-		(global as any).Liferay.FeatureFlags = {'LPD-58677': true};
+		Liferay.FeatureFlags['LPD-58677'] = true;
 
 		render(<EditGeneralInfo {...defaultProps} />);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100264

## What Is Being Fixed

The Project scope option in the vocabulary editor lost its feature flag gate when LPD-99040 removed the retired LPD-86291 flag, leaving it visible regardless of whether the CMP feature is enabled.

## How It Is Being Fixed

Gate the Project scope selector behind the LPD-58677 feature flag, matching the check already used for the equivalent Project filter on the CMS content-list views. Added a test suite covering both the flag-disabled (selector hidden, space selector shown) and flag-enabled (selector shown) cases.

## PR Check

**pr-check: PASS** — tested on `0f34fbe5500541a1e5a804cad2481ee72965704f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Note: default shell Node (v16.20.2) is too old for this module's test tooling; verified under Node 18.20.8 instead. EditGeneralInfo.test.tsx passed cleanly across all runs; unrelated pre-existing tests showed non-deterministic timeout flakiness.

<!-- pr-check {"result": "success", "sha": "0f34fbe5500541a1e5a804cad2481ee72965704f"} -->
