### PR TITLE
LPD-100530 Fix bulk delete over an expanded Select All selection

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -100,6 +100,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -372,8 +373,10 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			null, true, null, null, search, filter, pagination,
 			new Sort[] {sort});
 
+		Collection<SearchResult> searchResults = searchPage.getItems();
+
 		List<BulkActionItem> bulkActionItems = transform(
-			searchPage.getItems(),
+			searchResults,
 			searchResult -> {
 				JSONObject jsonObject = _jsonFactory.createJSONObject(
 					String.valueOf(searchResult.getEmbedded()));
@@ -385,7 +388,11 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			bulkActionItems = _sortBulkActionItems(bulkActionItems, sort);
 		}
 
-		return Page.of(bulkActionItems, pagination, searchPage.getTotalCount());
+		int unresolvedCount = searchResults.size() - bulkActionItems.size();
+
+		return Page.of(
+			bulkActionItems, pagination,
+			searchPage.getTotalCount() - unresolvedCount);
 	}
 
 	private Page<BulkActionItem> _getBulkActionItemPreviewPage(
@@ -397,20 +404,16 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			bulkActionItem -> _toBulkActionItem(
 				GetterUtil.getLong(bulkActionItem.getClassPK())));
 
-		long totalCount = bulkActionItems1.size();
-
 		if (Validator.isNotNull(search)) {
 			bulkActionItems2 = ListUtil.filter(
 				bulkActionItems2,
 				bulkActionItem -> StringUtil.containsIgnoreCase(
 					bulkActionItem.getName(), search, StringPool.BLANK));
-
-			totalCount = bulkActionItems2.size();
 		}
 
 		return Page.of(
 			_sortBulkActionItems(bulkActionItems2, sort), pagination,
-			totalCount);
+			bulkActionItems2.size());
 	}
 
 	private BulkSelectionAction<Object> _getBulkSelectionAction(
@@ -1040,8 +1043,14 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			return _toBulkActionItem(objectEntry);
 		}
 
-		return _toBulkActionItem(
-			_objectEntryFolderLocalService.fetchObjectEntryFolder(classPK));
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(classPK);
+
+		if (objectEntryFolder == null) {
+			return null;
+		}
+
+		return _toBulkActionItem(objectEntryFolder);
 	}
 
 	private BulkActionItem _toBulkActionItem(ObjectEntry objectEntry) {

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -86,6 +86,7 @@ import com.liferay.portal.search.rest.dto.v1_0.SearchResult;
 import com.liferay.portal.search.rest.resource.v1_0.SearchResultResource;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.Permission;
@@ -344,6 +345,8 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			contextHttpServletRequest);
 
 		dynamicServletRequest.setParameter("nestedFields", "embedded");
+
+		NestedFieldsSupplier.addNestedField("embedded");
 
 		SearchResultResource searchResultResource =
 			_searchResultResourceFactory.create(

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BulkActionResourceTest.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BulkActionResourceTest.java
@@ -195,6 +195,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 	public void testPostBulkActionItemPreviewPage() throws Exception {
 		_testPostBulkActionItemPreviewPage(_depotEntry1, "RECYCLE_BIN");
 		_testPostBulkActionItemPreviewPage(_depotEntry2, "PERMANENT_DELETION");
+		_testPostBulkActionItemPreviewPageWithNonexistentClassPK();
 	}
 
 	private DepotEntry _addDepotEntry(boolean trashEnabled) throws Exception {
@@ -669,6 +670,41 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 			items2.get(1), objectEntryFolder2.getObjectEntryFolderId(),
 			expectedDeletionType, 0L, null, objectEntryFolder2.getName(),
 			"FOLDER", null);
+	}
+
+	private void _testPostBulkActionItemPreviewPageWithNonexistentClassPK()
+		throws Exception {
+
+		BulkAction bulkAction = new DeleteObjectBulkSelectionAction();
+
+		bulkAction.setBulkActionItems(
+			new BulkActionItem[] {
+				new BulkActionItem() {
+					{
+						setClassName(
+							_cmsBasicWebContentObjectDefinition.getClassName());
+						setClassPK(RandomTestUtil.randomLong());
+					}
+				}
+			});
+		bulkAction.setType(BulkAction.Type.DELETE_OBJECT_BULK_SELECTION_ACTION);
+
+		SelectionScope selectionScope = new SelectionScope();
+
+		selectionScope.setSelectAll(false);
+
+		bulkAction.setSelectionScope(selectionScope);
+
+		Page<BulkActionItem> page =
+			bulkActionResource.postBulkActionItemPreviewPage(
+				false, null, null, Pagination.of(1, 10), "name:desc",
+				bulkAction);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		List<BulkActionItem> items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 0, items.size());
 	}
 
 	private void _testPostBulkActionItemPreviewPageWithSelectAllAndFilter(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100530

## What Is Being Fixed

Bulk delete over an expanded "Select All" selection never opens its confirmation modal, so nothing is deleted. `POST /o/bulk/v1.0/bulk-action-item/preview` returns HTTP 500 from a `NullPointerException`. This is a U152 release blocker and accounts for four release-test failures: LPD-100775 on the integration side, and LPD-100749, LPD-100750 and LPD-100751 in Playwright.

`BulkActionResourceImpl` resolves a `selectAll` selection through the search index and reads each id from the hit's embedded payload. LPD-96726 changed `SearchResultResourceImpl._setEmbedded` from an unconditional supplier to one wrapped in `NestedFieldsSupplier.supplyScopedUnsafeSupplier`, which consults the ThreadLocal `NestedFieldsContext` that `NestedFieldsContainerRequestFilter` builds from the real request's query parameters. The bulk resource asks for the payload by setting `nestedFields=embedded` on a `DynamicServletRequest` wrapper, which only satisfies `SearchResultResourceImpl._isEmbedded()`. That wrapper is invisible to the ThreadLocal, so the supplier yields null, `jsonObject.getLong("id")` returns 0, and 0 resolves to neither an `ObjectEntry` nor an `ObjectEntryFolder`. The bound method reference `objectEntryFolder::getExternalReferenceCode` then dereferences null while the `BulkActionItem` is being constructed, so a single unresolvable id fails the entire preview page.

The last passing build, `795eb371482b06c938932d226cfd740555b2e0b4`, proves the payload did resolve before this change, and LPD-96726 is the only commit touching this path in the 125-commit window up to the first failing build.

## How It Is Being Fixed

The first commit restores the payload by calling `NestedFieldsSupplier.addNestedField("embedded")` before invoking the search resource. This is the API `object-rest-impl` already uses when a resource needs a nested field the client did not ask for. The existing `DynamicServletRequest` parameter stays, because `_isEmbedded()` reads it and gates the DTO lookup entirely.

The second commit hardens the resolution independently of the regression. `_toBulkActionItem(long)` guarded the `ObjectEntry` branch but passed the folder fetch straight through, so an unresolvable id produced a 500 rather than a missing item. It now returns null, which `transform` drops. Because the page count was derived before any item could be dropped, the count and the items were then able to disagree, so the `Filter` overload subtracts the unresolved count from the search total and the `List` overload reports the resolved size.

One design question is worth flagging, and it has been raised with the Headless team. `SearchResultResourceImpl` carries two independent notions of "embedded", a request parameter honoured by `_isEmbedded()` and a ThreadLocal honoured by the supplier. This change closes the gap from the caller's side, which is the smallest change that unblocks the release, and bulk is the only caller in the repository using the wrapper route today. The gap itself stays open for the next resource that needs an internal nested field, so the durable fix may belong inside `portal-vulcan`.

## Test Execution

```
gradlew -p modules/apps/bulk/bulk-rest-test testIntegration --tests BulkActionResourceTest
```

```
cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/bulkActions.spec.ts
```

`testPostBulkActionItemPreviewPage` passes, including a new case covering an unresolvable class primary key. The Playwright file passes 29 of 29.

`testPostBulkAction` in the same class remains red, unrelated to this change and failing identically without it. LPD-100372 removed the `.lfrbuild-portal` markers from the CMP modules, so the CMP site initializer is absent from the portal bundle and `CMPTestUtil.getOrAddGroup` cannot initialize its group. That scenario needs relocating to a CMP-side test module under a separate ticket.

## PR Check

**pr-check: PASS** — tested on `f42aba503e2dc5d4fa34443b15891079c5d9d9a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Transaction Usage | PASS |

<!-- pr-check {"result": "success", "sha": "f42aba503e2dc5d4fa34443b15891079c5d9d9a5"} -->
