### PR TITLE
LPD-100338 Prevent editing another user's comment in a project

### DIFF
--- a/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBDiscussionPermissionImpl.java
+++ b/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBDiscussionPermissionImpl.java
@@ -11,6 +11,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.message.boards.model.MBMessage;
@@ -141,7 +142,8 @@ public class MBDiscussionPermissionImpl extends BaseDiscussionPermission {
 
 		try {
 			Object infoItem = infoItemObjectProvider.getInfoItem(
-				new ClassPKInfoItemIdentifier(message.getClassPK()));
+				new ClassPKInfoItemIdentifier(
+					message.getClassPK(), InfoItemIdentifier.VERSION_LATEST));
 
 			if (!(infoItem instanceof GroupedModel)) {
 				return DepotConstants.TYPE_ANY;

--- a/modules/apps/message-boards/message-boards-test/build.gradle
+++ b/modules/apps/message-boards/message-boards-test/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-verify-test-util")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")
+	testIntegrationImplementation project(":apps:site:site-cmp-site-initializer-test-util")
 	testIntegrationImplementation project(":apps:social:social-activity-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":apps:subscription:subscription-api")

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/comment/test/MBDiscussionPermissionImplTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/comment/test/MBDiscussionPermissionImplTest.java
@@ -24,6 +24,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.comment.DiscussionPermission;
 import com.liferay.portal.kernel.model.Group;
@@ -47,6 +48,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -57,6 +59,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
 
 import java.io.Serializable;
 
@@ -191,6 +194,88 @@ public class MBDiscussionPermissionImplTest {
 	}
 
 	@Test
+	@TestInfo("LPD-100338")
+	public void testUserCannotUpdateSomeoneElseCommentInProject()
+		throws Exception {
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String originalName = PrincipalThreadLocal.getName();
+
+		try {
+			PrincipalThreadLocal.setName(_user.getUserId());
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(_user));
+
+			long commentId = _addProjectComment(_siteUser1);
+
+			Comment comment = _commentManager.fetchComment(commentId);
+
+			_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+			_resourcePermissionLocalService.setResourcePermissions(
+				TestPropsValues.getCompanyId(), comment.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(comment.getClassPK()), _role.getRoleId(),
+				new String[] {
+					ActionKeys.DELETE_DISCUSSION, ActionKeys.UPDATE_DISCUSSION,
+					ActionKeys.VIEW
+				});
+
+			RoleLocalServiceUtil.addUserRole(
+				_siteUser2.getUserId(), _role.getRoleId());
+
+			PermissionChecker permissionChecker =
+				PermissionCheckerFactoryUtil.create(_siteUser2);
+
+			Assert.assertFalse(
+				_discussionPermission.hasUpdatePermission(
+					permissionChecker, commentId));
+			Assert.assertTrue(
+				_discussionPermission.hasDeletePermission(
+					permissionChecker, commentId));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+			PrincipalThreadLocal.setName(originalName);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-100338")
+	public void testUserCanUpdateAndDeleteHisCommentInProject()
+		throws Exception {
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String originalName = PrincipalThreadLocal.getName();
+
+		try {
+			PrincipalThreadLocal.setName(_user.getUserId());
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(_user));
+
+			long commentId = _addProjectComment(_siteUser1);
+
+			PermissionChecker permissionChecker =
+				PermissionCheckerFactoryUtil.create(_siteUser1);
+
+			Assert.assertTrue(
+				_discussionPermission.hasUpdatePermission(
+					permissionChecker, commentId));
+			Assert.assertTrue(
+				_discussionPermission.hasDeletePermission(
+					permissionChecker, commentId));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+			PrincipalThreadLocal.setName(originalName);
+		}
+	}
+
+	@Test
 	@TestInfo("LPD-93071")
 	public void testUserCanUpdateAndDeleteHisCommentInSpace() throws Exception {
 		PermissionChecker originalPermissionChecker =
@@ -289,6 +374,27 @@ public class MBDiscussionPermissionImplTest {
 			StringUtil.randomString(), serviceContextFunction);
 	}
 
+	private long _addProjectComment(User user) throws Exception {
+		CMPTestUtil.getOrAddGroup(MBDiscussionPermissionImplTest.class);
+
+		ObjectEntry objectEntry = CMPTestUtil.addCMPProjectObjectEntry();
+
+		_depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			objectEntry.getGroupId());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		return _commentManager.addComment(
+			user.getUserId(), objectEntry.getGroupId(),
+			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
+			StringUtil.randomString(),
+			new IdentityServiceContextFunction(
+				ServiceContextTestUtil.getServiceContext(
+					objectEntry.getGroupId(), user.getUserId())));
+	}
+
 	private void _withAlwaysEditableByOwnerEnabled(
 			UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
@@ -356,6 +462,9 @@ public class MBDiscussionPermissionImplTest {
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@DeleteAfterTestRun
+	private Role _role;
 
 	@DeleteAfterTestRun
 	private User _siteUser1;

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
@@ -92,11 +92,15 @@ const initialComments: Comment[] = [
 	},
 ];
 
-const renderComponent = (addCommentURL = 'addCommentURL', readOnly = false) => {
+const renderComponent = (
+	addCommentURL = 'addCommentURL',
+	readOnly = false,
+	comments = initialComments
+) => {
 	return render(
 		<CommentsPanel
 			addCommentURL={addCommentURL}
-			comments={initialComments}
+			comments={comments}
 			deleteCommentURL="deleteCommentURL"
 			editCommentURL="editCommentURL"
 			editorConfig={{}}
@@ -135,6 +139,17 @@ describe('CommentsPanel', () => {
 			screen.queryByTitle('rate-this-as-good')
 		).not.toBeInTheDocument();
 		expect(screen.queryByTitle('rate-this-as-bad')).not.toBeInTheDocument();
+	});
+
+	it('hides the edit action when the comment cannot be updated', async () => {
+		renderComponent('addCommentURL', false, [
+			{...initialComments[0], children: [], hasUpdatePermission: false},
+		]);
+
+		await userEvent.click(screen.getByTitle('actions'));
+
+		expect(screen.getByText('delete')).toBeInTheDocument();
+		expect(screen.queryByText('edit')).not.toBeInTheDocument();
 	});
 
 	it('deletes the child comment', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100338

## What Is Being Fixed

- The project comment rules shipped separately under LPD-97900 without automated coverage: in a CMP Project, only the comment author can edit their comment, while delete stays available to users with the delete permission.
  - Previous PRs: https://github.com/liferay-content-management/liferay-portal/pull/8722, https://github.com/liferay-content-management/liferay-portal/pull/8729
- This PR adds that coverage at the integration and frontend levels.

## How It Is Being Fixed

### Integration Tests

- New tests in `MBDiscussionPermissionImplTest` cover both project cases: the author can update and delete their comment, and a non-author gets update denied while delete still goes through.
- The project fixture goes through `CMPTestUtil`, since a project holds `L_CMP_PROJECT` and `L_CMP_TASK` entries that sit outside any object entry folder, which is also why the test module now depends on `site-cmp-site-initializer-test-util`.

### Frontend Test

- A new Jest test covers the comments panel hiding the edit action when the comment reports no update permission.

### Why MBDiscussionPermissionImpl Also Changes

- The tests create their Projects and Tasks through `CMPTestUtil`, which saves them with `WorkflowConstants.ACTION_SAVE_DRAFT`, so every entry the tests comment on is a draft.
- The depot type lookup asked the info item provider for the commented entry without an explicit version, which only returns the latest approved version. For a draft-only entry the lookup throws, the depot type falls back to `TYPE_ANY`, and the project comment rules never apply, so the new tests could not exercise the behavior they guard.
- Resolving the entry with `VERSION_LATEST` returns it whatever its workflow status. Only the entry's group is read, which is the same across every version.

## PR Check

**pr-check: PASS** — tested on `2c811b25ba1ea10ec5189bcde54235b0962c9bd7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2c811b25ba1ea10ec5189bcde54235b0962c9bd7"} -->
