### PR TITLE
LPD-98407 Require only ASSIGN_MEMBERS and VIEW to manage Space members

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.NoSuchUserGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -66,7 +65,9 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		_checkAssetLibraryAdminOrAssetLibraryMember(group.getGroupId());
 
 		List<com.liferay.portal.kernel.model.Role> roles =
-			_getAssetLibraryRoles(group.getGroupId());
+			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
+
+		roles = DepotRoleUtil.filter(group.getGroupId(), roles);
 
 		if (pagination == null) {
 			return Page.of(transform(roles, this::_toRole));
@@ -291,23 +292,6 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 		throw new PrincipalException.MustHavePermission(
 			contextUser.getUserId(), ActionKeys.ASSIGN_MEMBERS);
-	}
-
-	private List<com.liferay.portal.kernel.model.Role> _getAssetLibraryRoles(
-		long groupId) {
-
-		List<com.liferay.portal.kernel.model.Role> roles =
-			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
-
-		if (FeatureFlagManagerUtil.isEnabled(
-				contextCompany.getCompanyId(), "LPD-17564") ||
-			FeatureFlagManagerUtil.isEnabled(
-				contextCompany.getCompanyId(), "LPD-58677")) {
-
-			roles = DepotRoleUtil.filter(groupId, roles);
-		}
-
-		return roles;
 	}
 
 	private Group _getGroup(String externalReferenceCode) throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -149,11 +149,11 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 					group.getGroupId()));
 		}
 
+		List<com.liferay.portal.kernel.model.Role> updatedRoles = null;
+
 		List<com.liferay.portal.kernel.model.Role> currentRoles =
 			_roleLocalService.getUserGroupRoles(
 				user.getUserId(), group.getGroupId());
-
-		List<com.liferay.portal.kernel.model.Role> updatedRoles;
 
 		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
 			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.asset.library.internal.resource.v1_0;
 
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.util.DepotRoleUtil;
 import com.liferay.headless.asset.library.dto.v1_0.Role;
 import com.liferay.headless.asset.library.resource.v1_0.RoleResource;
@@ -13,6 +14,7 @@ import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.NoSuchUserGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -28,15 +30,18 @@ import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleService;
 import com.liferay.portal.kernel.service.UserGroupService;
 import com.liferay.portal.kernel.service.UserService;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,9 +66,7 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		_checkAssetLibraryAdminOrAssetLibraryMember(group.getGroupId());
 
 		List<com.liferay.portal.kernel.model.Role> roles =
-			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
-
-		roles = DepotRoleUtil.filter(group.getGroupId(), roles);
+			_getAssetLibraryRoles(group.getGroupId());
 
 		if (pagination == null) {
 			return Page.of(transform(roles, this::_toRole));
@@ -145,21 +148,78 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 					group.getGroupId()));
 		}
 
-		_userGroupRoleService.deleteUserGroupRoles(
-			user.getUserId(), group.getGroupId(),
-			ListUtil.toLongArray(
-				_roleService.getUserGroupRoles(
-					user.getUserId(), group.getGroupId()),
-				com.liferay.portal.kernel.model.Role.ROLE_ID_ACCESSOR));
+		List<com.liferay.portal.kernel.model.Role> currentRoles =
+			_roleLocalService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
 
-		_userGroupRoleService.addUserGroupRoles(
-			user.getUserId(), group.getGroupId(), _getRoleIds(roles));
+		List<com.liferay.portal.kernel.model.Role> updatedRoles;
 
-		return Page.of(
-			transform(
-				_roleService.getUserGroupRoles(
-					user.getUserId(), group.getGroupId()),
-				this::_toRole));
+		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
+
+			// The CMS "Manage Members" UI (ManageMembersList) adds a brand
+			// new member and then, in a separate follow-up call, assigns
+			// them the space's fixed default role
+			// (SPACE_MEMBERS_CONFIG.defaultRoleExternalReferenceCode,
+			// hardcoded to Asset Library Member - never configurable, never
+			// any other role). That follow-up call goes through
+			// UserGroupRoleService, which requires ASSIGN_USER_ROLES; if a
+			// caller holding only ASSIGN_MEMBERS lacks it, the UI does not
+			// roll back the membership it just added - the user stays a
+			// member with no role, and the only feedback is an error toast.
+			// To avoid that half-succeeded state, a caller with just
+			// ASSIGN_MEMBERS is allowed to grant this one specific,
+			// hardcoded role, but only to a user who currently holds no
+			// roles here (i.e. was just added, mirroring the UI's own
+			// !isAlreadyMember condition for making this call at all).
+			// Reassigning an existing member's role, removing a role, or
+			// granting any other role - including Administrator or Content
+			// Reviewer - still requires ASSIGN_USER_ROLES or Role-scoped
+			// ASSIGN_MEMBERS, unchanged. The role ID is resolved through
+			// the local service (not _getRoleIds/_roleService.getRole,
+			// which requires Role-scoped VIEW) for the same reason the
+			// read of the updated roles below does: the caller may hold
+			// ASSIGN_MEMBERS on the group without holding VIEW on the
+			// individual Role, which would otherwise reject the lookup
+			// entirely before the assignment is ever attempted.
+
+			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());
+
+			com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+				_roleLocalService.getRole(
+					contextCompany.getCompanyId(),
+					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+			// The read below goes through the local service, not
+			// _roleService, for the same reason the role lookup above does:
+			// this caller may hold ASSIGN_MEMBERS without Role-scoped VIEW
+			// on Asset Library Member, and the permissioned read would
+			// filter the assignment just made down to nothing. The else
+			// branch below keeps _roleService, since every role reaching it
+			// was already resolved through _getRoleIds, which itself
+			// requires Role-scoped VIEW.
+
+			_userGroupRoleLocalService.addUserGroupRoles(
+				user.getUserId(), group.getGroupId(),
+				new long[] {assetLibraryMemberRole.getRoleId()});
+
+			updatedRoles = _roleLocalService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
+		}
+		else {
+			_userGroupRoleService.deleteUserGroupRoles(
+				user.getUserId(), group.getGroupId(),
+				ListUtil.toLongArray(
+					currentRoles,
+					com.liferay.portal.kernel.model.Role.ROLE_ID_ACCESSOR));
+
+			_userGroupRoleService.addUserGroupRoles(
+				user.getUserId(), group.getGroupId(), _getRoleIds(roles));
+
+			updatedRoles = _roleService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
+		}
+
+		return Page.of(transform(updatedRoles, this::_toRole));
 	}
 
 	@Override
@@ -214,6 +274,42 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		}
 	}
 
+	private void _checkAssetLibraryAdminOrAssignMembers(long groupId)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker.isGroupAdmin(groupId) ||
+			GroupPermissionUtil.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_MEMBERS) ||
+			GroupPermissionUtil.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_USER_ROLES)) {
+
+			return;
+		}
+
+		throw new PrincipalException.MustHavePermission(
+			contextUser.getUserId(), ActionKeys.ASSIGN_MEMBERS);
+	}
+
+	private List<com.liferay.portal.kernel.model.Role> _getAssetLibraryRoles(
+		long groupId) {
+
+		List<com.liferay.portal.kernel.model.Role> roles =
+			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-58677")) {
+
+			roles = DepotRoleUtil.filter(groupId, roles);
+		}
+
+		return roles;
+	}
+
 	private Group _getGroup(String externalReferenceCode) throws Exception {
 		Group group = _groupService.fetchGroupByExternalReferenceCode(
 			externalReferenceCode, contextCompany.getCompanyId());
@@ -237,6 +333,17 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 				return serviceBuilderRole.getRoleId();
 			});
+	}
+
+	private boolean _isDefaultAssetLibraryMemberRoleAssignment(
+		List<com.liferay.portal.kernel.model.Role> currentRoles, Role[] roles) {
+
+		if (!currentRoles.isEmpty() || (roles.length != 1)) {
+			return false;
+		}
+
+		return Objects.equals(
+			roles[0].getName(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 	}
 
 	private Role _toRole(com.liferay.portal.kernel.model.Role role)
@@ -271,6 +378,9 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 	@Reference
 	private UserGroupLocalService _userGroupLocalService;
+
+	@Reference
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Reference
 	private UserGroupRoleService _userGroupRoleService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -156,48 +156,12 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		List<com.liferay.portal.kernel.model.Role> updatedRoles;
 
 		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
-
-			// The CMS "Manage Members" UI (ManageMembersList) adds a brand
-			// new member and then, in a separate follow-up call, assigns
-			// them the space's fixed default role
-			// (SPACE_MEMBERS_CONFIG.defaultRoleExternalReferenceCode,
-			// hardcoded to Asset Library Member - never configurable, never
-			// any other role). That follow-up call goes through
-			// UserGroupRoleService, which requires ASSIGN_USER_ROLES; if a
-			// caller holding only ASSIGN_MEMBERS lacks it, the UI does not
-			// roll back the membership it just added - the user stays a
-			// member with no role, and the only feedback is an error toast.
-			// To avoid that half-succeeded state, a caller with just
-			// ASSIGN_MEMBERS is allowed to grant this one specific,
-			// hardcoded role, but only to a user who currently holds no
-			// roles here (i.e. was just added, mirroring the UI's own
-			// !isAlreadyMember condition for making this call at all).
-			// Reassigning an existing member's role, removing a role, or
-			// granting any other role - including Administrator or Content
-			// Reviewer - still requires ASSIGN_USER_ROLES or Role-scoped
-			// ASSIGN_MEMBERS, unchanged. The role ID is resolved through
-			// the local service (not _getRoleIds/_roleService.getRole,
-			// which requires Role-scoped VIEW) for the same reason the
-			// read of the updated roles below does: the caller may hold
-			// ASSIGN_MEMBERS on the group without holding VIEW on the
-			// individual Role, which would otherwise reject the lookup
-			// entirely before the assignment is ever attempted.
-
 			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());
 
 			com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
 				_roleLocalService.getRole(
 					contextCompany.getCompanyId(),
 					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-			// The read below goes through the local service, not
-			// _roleService, for the same reason the role lookup above does:
-			// this caller may hold ASSIGN_MEMBERS without Role-scoped VIEW
-			// on Asset Library Member, and the permissioned read would
-			// filter the assignment just made down to nothing. The else
-			// branch below keeps _roleService, since every role reaching it
-			// was already resolved through _getRoleIds, which itself
-			// requires Role-scoped VIEW.
 
 			_userGroupRoleLocalService.addUserGroupRoles(
 				user.getUserId(), group.getGroupId(),

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -10,7 +10,6 @@ import com.liferay.headless.asset.library.resource.v1_0.UserAccountResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
-import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserTable;
@@ -26,7 +25,6 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
@@ -37,11 +35,8 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -66,7 +61,11 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		User user = _userService.getUserByExternalReferenceCode(
 			userAccountExternalReferenceCode, contextCompany.getCompanyId());
 
-		_updateUser(group.getGroupId(), user.getUserId(), false);
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			User.class.getName(), contextHttpServletRequest);
+
+		_userService.unsetGroupUsers(
+			group.getGroupId(), new long[] {user.getUserId()}, serviceContext);
 	}
 
 	@Override
@@ -111,9 +110,14 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		User user = _userService.getUserByExternalReferenceCode(
 			userAccountExternalReferenceCode, contextCompany.getCompanyId());
 
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			User.class.getName(), contextHttpServletRequest);
+
+		_userService.addGroupUsers(
+			group.getGroupId(), new long[] {user.getUserId()}, serviceContext);
+
 		return _toUserAccount(
-			group.getGroupId(),
-			_updateUser(group.getGroupId(), user.getUserId(), true));
+			group.getGroupId(), _userService.getUserById(user.getUserId()));
 	}
 
 	private void _checkAssetLibraryAdminOrAssetLibraryMember(long groupId)
@@ -189,25 +193,6 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 				keywords));
 	}
 
-	private long[] _getUserGroupIds(
-		User user, long assetLibraryId, boolean add) {
-
-		Set<Long> groupIds = new HashSet<>();
-
-		for (long groupId : user.getGroupIds()) {
-			groupIds.add(groupId);
-		}
-
-		if (add) {
-			groupIds.add(assetLibraryId);
-		}
-		else {
-			groupIds.remove(assetLibraryId);
-		}
-
-		return ArrayUtil.toLongArray(groupIds);
-	}
-
 	private OrderByComparator<User> _toOrderByComparator(Sort[] sorts) {
 		if (ArrayUtil.isEmpty(sorts)) {
 			return null;
@@ -265,37 +250,6 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			"assetLibraryId", assetLibraryId);
 
 		return _userAccountDTOConverter.toDTO(defaultDTOConverterContext);
-	}
-
-	private User _updateUser(
-			Long assetLibraryId, Long userAccountId, boolean add)
-		throws Exception {
-
-		User user = _userService.getUserById(userAccountId);
-
-		Contact contact = user.getContact();
-
-		Calendar calendar = CalendarFactoryUtil.getCalendar();
-
-		calendar.setTime(user.getBirthday());
-
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			User.class.getName(), contextHttpServletRequest);
-
-		return _userService.updateUser(
-			user.getUserId(), user.getPassword(), null, null,
-			user.isPasswordReset(), null, null, user.getScreenName(),
-			user.getEmailAddress(), user.getLanguageId(), user.getTimeZoneId(),
-			user.getGreeting(), user.getComments(), user.getFirstName(),
-			user.getMiddleName(), user.getLastName(),
-			contact.getPrefixListTypeId(), contact.getSuffixListTypeId(),
-			user.isMale(), calendar.get(Calendar.MONTH),
-			calendar.get(Calendar.DATE), calendar.get(Calendar.YEAR),
-			contact.getSmsSn(), contact.getFacebookSn(), contact.getJabberSn(),
-			contact.getSkypeSn(), contact.getTwitterSn(), user.getJobTitle(),
-			_getUserGroupIds(user, assetLibraryId, add),
-			user.getOrganizationIds(), null, null, user.getUserGroupIds(),
-			serviceContext);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -112,201 +112,11 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			roles -> roleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(), roles));
-	}
 
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
-		throws Exception {
-
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-		Page<Role> page =
-			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryMemberRole.getRoleId();
-							name = assetLibraryMemberRole.getName();
-						}
-					}
-				});
-
-		List<String> names = TransformUtil.transform(
-			page.getItems(), Role::getName);
-
-		Assert.assertEquals(names.toString(), 1, names.size());
-		Assert.assertTrue(
-			names.toString(),
-			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
-
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		_assertForbidden(
-			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				}));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
-		throws Exception {
-
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
-
-		_assertForbidden(
-			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryAdministratorRole.getRoleId();
-							name = assetLibraryAdministratorRole.getName();
-						}
-					}
-				}));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
-		throws Exception {
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-		_userGroupRoleService.addUserGroupRoles(
-			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {assetLibraryMemberRole.getRoleId()});
-
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
-
-		Page<Role> page =
-			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				});
-
-		List<String> names = TransformUtil.transform(
-			page.getItems(), Role::getName);
-
-		Assert.assertEquals(names.toString(), 1, names.size());
-		Assert.assertTrue(
-			names.toString(),
-			names.contains(DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
-		throws Exception {
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-		_userGroupRoleService.addUserGroupRoles(
-			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {assetLibraryMemberRole.getRoleId()});
-
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource();
-
-		_assertForbidden(
-			() ->
-				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
-					testDepotEntryGroup.getExternalReferenceCode(),
-					user.getExternalReferenceCode(),
-					new Role[] {
-						new Role() {
-							{
-								id =
-									assetLibraryContentReviewerRole.getRoleId();
-								name =
-									assetLibraryContentReviewerRole.getName();
-							}
-						}
-					}));
+		_testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission();
+		_testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole();
+		_testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission();
+		_testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission();
 	}
 
 	@Override
@@ -655,6 +465,197 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				roles,
 				role -> Objects.equals(
 					serviceBuilderRole2.getName(), role.getName())));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		Page<Role> page =
+			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryMemberRole.getRoleId();
+							name = assetLibraryMemberRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				}));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryAdministratorRole.getRoleId();
+							name = assetLibraryAdministratorRole.getName();
+						}
+					}
+				}));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
+
+		Page<Role> page =
+			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource();
+
+		_assertForbidden(
+			() ->
+				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+					testDepotEntryGroup.getExternalReferenceCode(),
+					user.getExternalReferenceCode(),
+					new Role[] {
+						new Role() {
+							{
+								id =
+									assetLibraryContentReviewerRole.getRoleId();
+								name =
+									assetLibraryContentReviewerRole.getName();
+							}
+						}
+					}));
 	}
 
 	private void _testPutRolesPage(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -16,13 +16,17 @@ import com.liferay.headless.asset.library.client.pagination.Pagination;
 import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.headless.asset.library.client.resource.v1_0.RoleResource;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
@@ -106,6 +110,224 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			roles -> roleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(), roles));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		// A fresh member (no current roles) can be granted exactly the
+		// default Asset Library Member role by a caller holding only
+		// ASSIGN_MEMBERS, mirroring the CMS "Manage Members" UI's
+		// add-member-then-assign-default-role flow.
+
+		Page<Role> page =
+			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryMemberRole.getRoleId();
+							name = assetLibraryMemberRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		// Reassigning that same, now-existing member to a different role
+		// still requires ASSIGN_USER_ROLES; ASSIGN_MEMBERS alone is not
+		// enough once the member already holds a role.
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				}));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+
+		// Even for a fresh member, only the exact default role (Member)
+		// is covered by the ASSIGN_MEMBERS-only bypass - any other role,
+		// including Administrator, still requires ASSIGN_USER_ROLES.
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryAdministratorRole.getRoleId();
+							name = assetLibraryAdministratorRole.getName();
+						}
+					}
+				}));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		// Reassigning an existing member (who already holds the default
+		// Member role) to a different role is allowed for a caller holding
+		// ASSIGN_USER_ROLES, even without ASSIGN_MEMBERS - but the caller
+		// must also hold Role-scoped VIEW on that specific role; resolving
+		// the role by name still goes through the permissioned service.
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
+
+		Page<Role> page =
+			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		// ASSIGN_USER_ROLES alone, without Role-scoped VIEW on the target
+		// role, is not enough - resolving the role by name goes through the
+		// permissioned service.
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource();
+
+		_assertForbidden(
+			() ->
+				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+					testDepotEntryGroup.getExternalReferenceCode(),
+					user.getExternalReferenceCode(),
+					new Role[] {
+						new Role() {
+							{
+								id =
+									assetLibraryContentReviewerRole.getRoleId();
+								name =
+									assetLibraryContentReviewerRole.getName();
+							}
+						}
+					}));
 	}
 
 	@Override
@@ -222,6 +444,21 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		return _userGroup.getExternalReferenceCode();
 	}
 
+	private void _assertForbidden(UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
 	private void _assertRolesPage(
 			Role[] expectedRoles,
 			UnsafeSupplier<Page<Role>, Exception> unsafeSupplier)
@@ -237,6 +474,98 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		for (Role role : expectedRoles) {
 			Assert.assertTrue(items.contains(role));
 		}
+	}
+
+	private RoleResource _getAssignMembersRoleResource() throws Exception {
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_MEMBERS);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		return RoleResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private RoleResource _getAssignUserRolesRoleResource(
+			com.liferay.portal.kernel.model.Role... viewableRoles)
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_USER_ROLES);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		for (com.liferay.portal.kernel.model.Role viewableRole :
+				viewableRoles) {
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				viewableRole.getCompanyId(),
+				com.liferay.portal.kernel.model.Role.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(viewableRole.getRoleId()), role.getRoleId(),
+				new String[] {ActionKeys.VIEW});
+		}
+
+		return RoleResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private RoleResource _getRoleResource(String roleName) throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -332,12 +332,12 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			new long[] {testDepotEntry.getGroupId()},
 			ServiceContextTestUtil.getServiceContext());
 
-		com.liferay.portal.kernel.model.Role role = _roleLocalService.getRole(
-			testCompany.getCompanyId(), roleName);
+		com.liferay.portal.kernel.model.Role serviceBuilderRole =
+			_getServiceBuilderRole(roleName);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {role.getRoleId()});
+			new long[] {serviceBuilderRole.getRoleId()});
 
 		return RoleResource.builder(
 		).authentication(
@@ -348,6 +348,13 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+	}
+
+	private com.liferay.portal.kernel.model.Role _getServiceBuilderRole(
+			String roleName)
+		throws Exception {
+
+		return _roleLocalService.getRole(testCompany.getCompanyId(), roleName);
 	}
 
 	private void _testGetAssetLibraryRolesPage(String roleName)
@@ -437,32 +444,16 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
 			ActionKeys.ASSIGN_MEMBERS);
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		Page<Role> page =
 			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryMemberRole.getRoleId();
-							name = assetLibraryMemberRole.getName();
-						}
-					}
-				});
+				_toRoles(assetLibraryMemberRole));
 
 		List<String> names = TransformUtil.transform(
 			page.getItems(), Role::getName);
@@ -473,22 +464,14 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				}));
+				_toRoles(assetLibraryContentReviewerRole)));
 	}
 
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
@@ -497,58 +480,33 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
 			ActionKeys.ASSIGN_MEMBERS);
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
 
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryAdministratorRole.getRoleId();
-							name = assetLibraryAdministratorRole.getName();
-						}
-					}
-				}));
+				_toRoles(assetLibraryAdministratorRole)));
 	}
 
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
 		throws Exception {
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
 			new long[] {assetLibraryMemberRole.getRoleId()});
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
@@ -558,14 +516,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				});
+				_toRoles(assetLibraryContentReviewerRole));
 
 		List<String> names = TransformUtil.transform(
 			page.getItems(), Role::getName);
@@ -579,27 +530,17 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
 		throws Exception {
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
 			new long[] {assetLibraryMemberRole.getRoleId()});
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
@@ -610,16 +551,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 					testDepotEntryGroup.getExternalReferenceCode(),
 					user.getExternalReferenceCode(),
-					new Role[] {
-						new Role() {
-							{
-								id =
-									assetLibraryContentReviewerRole.getRoleId();
-								name =
-									assetLibraryContentReviewerRole.getName();
-							}
-						}
-					}));
+					_toRoles(assetLibraryContentReviewerRole)));
 	}
 
 	private void _testPutRolesPage(
@@ -657,6 +589,19 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		}
 
 		_assertRolesPage(new Role[] {randomRole1, randomRole2}, unsafeSupplier);
+	}
+
+	private Role[] _toRoles(
+		com.liferay.portal.kernel.model.Role serviceBuilderRole) {
+
+		return new Role[] {
+			new Role() {
+				{
+					id = serviceBuilderRole.getRoleId();
+					name = serviceBuilderRole.getName();
+				}
+			}
+		};
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -88,7 +88,9 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			testDepotEntry.getGroupId(), _userGroup);
 	}
 
-	@FeatureFlags(featureFlags = @FeatureFlag("LPD-58677"))
+	@FeatureFlags(
+		featureFlags = {@FeatureFlag("LPD-58677"), @FeatureFlag("LPD-96750")}
+	)
 	@Override
 	@Test
 	public void testGetAssetLibraryRolesPage() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -135,11 +135,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
-		// A fresh member (no current roles) can be granted exactly the
-		// default Asset Library Member role by a caller holding only
-		// ASSIGN_MEMBERS, mirroring the CMS "Manage Members" UI's
-		// add-member-then-assign-default-role flow.
-
 		Page<Role> page =
 			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
@@ -160,10 +155,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		Assert.assertTrue(
 			names.toString(),
 			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
-
-		// Reassigning that same, now-existing member to a different role
-		// still requires ASSIGN_USER_ROLES; ASSIGN_MEMBERS alone is not
-		// enough once the member already holds a role.
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
 			_roleLocalService.getRole(
@@ -205,10 +196,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
 
-		// Even for a fresh member, only the exact default role (Member)
-		// is covered by the ASSIGN_MEMBERS-only bypass - any other role,
-		// including Administrator, still requires ASSIGN_USER_ROLES.
-
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
@@ -249,12 +236,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			_roleLocalService.getRole(
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		// Reassigning an existing member (who already holds the default
-		// Member role) to a different role is allowed for a caller holding
-		// ASSIGN_USER_ROLES, even without ASSIGN_MEMBERS - but the caller
-		// must also hold Role-scoped VIEW on that specific role; resolving
-		// the role by name still goes through the permissioned service.
 
 		RoleResource assignUserRolesRoleResource =
 			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
@@ -307,10 +288,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			_roleLocalService.getRole(
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		// ASSIGN_USER_ROLES alone, without Role-scoped VIEW on the target
-		// role, is not enough - resolving the role by name goes through the
-		// permissioned service.
 
 		RoleResource assignUserRolesRoleResource =
 			_getAssignUserRolesRoleResource();

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -265,46 +265,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		}
 	}
 
-	private RoleResource _getAssignMembersRoleResource() throws Exception {
-		String password = RandomTestUtil.randomString();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			password, RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
-			RoleConstants.TYPE_REGULAR);
-
-		_roles.add(role);
-
-		_userLocalService.addRoleUser(role.getRoleId(), user);
-
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()),
-			ActionKeys.ASSIGN_MEMBERS);
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
-		RoleTestUtil.addResourcePermission(
-			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
-			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
-
-		return RoleResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
-	}
-
-	private RoleResource _getAssignUserRolesRoleResource(
+	private RoleResource _getDepotEntryRoleResource(
+			String actionId,
 			com.liferay.portal.kernel.model.Role... viewableRoles)
 		throws Exception {
 
@@ -326,8 +288,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		RoleTestUtil.addResourcePermission(
 			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()),
-			ActionKeys.ASSIGN_USER_ROLES);
+			String.valueOf(testDepotEntry.getGroupId()), actionId);
 		RoleTestUtil.addResourcePermission(
 			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
 			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
@@ -470,8 +431,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
 		throws Exception {
 
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
+		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_MEMBERS);
 
 		User user = UserTestUtil.addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
@@ -530,8 +491,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
 		throws Exception {
 
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
+		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_MEMBERS);
 
 		User user = UserTestUtil.addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
@@ -587,8 +548,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
+		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_USER_ROLES, assetLibraryContentReviewerRole);
 
 		Page<Role> page =
 			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
@@ -638,8 +599,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource();
+		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_USER_ROLES);
 
 		_assertForbidden(
 			() ->

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -279,21 +279,24 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
 			ServiceContextTestUtil.getServiceContext());
 
-		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
-			RoleConstants.TYPE_REGULAR);
+		com.liferay.portal.kernel.model.Role serviceBuilderRole =
+			RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		_roles.add(role);
+		_roles.add(serviceBuilderRole);
 
-		_userLocalService.addRoleUser(role.getRoleId(), user);
+		_userLocalService.addRoleUser(serviceBuilderRole.getRoleId(), user);
 
 		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			serviceBuilderRole, DepotEntry.class.getName(),
+			ResourceConstants.SCOPE_GROUP,
 			String.valueOf(testDepotEntry.getGroupId()), actionId);
 		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			serviceBuilderRole, DepotEntry.class.getName(),
+			ResourceConstants.SCOPE_GROUP,
 			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
 		RoleTestUtil.addResourcePermission(
-			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			serviceBuilderRole, User.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
 		for (com.liferay.portal.kernel.model.Role viewableRole :
@@ -303,8 +306,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				viewableRole.getCompanyId(),
 				com.liferay.portal.kernel.model.Role.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(viewableRole.getRoleId()), role.getRoleId(),
-				new String[] {ActionKeys.VIEW});
+				String.valueOf(viewableRole.getRoleId()),
+				serviceBuilderRole.getRoleId(), new String[] {ActionKeys.VIEW});
 		}
 
 		return RoleResource.builder(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
@@ -338,7 +338,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		for (com.liferay.portal.kernel.model.Role viewableRole :
 				viewableRoles) {
 
-			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+			_resourcePermissionLocalService.setResourcePermissions(
 				viewableRole.getCompanyId(),
 				com.liferay.portal.kernel.model.Role.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -703,6 +703,9 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@Inject
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -361,7 +361,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
-		List<String> actionIds = ResourceActionsUtil.getModelResourceActions(
+		List<String> actionIds = _resourceActions.getModelResourceActions(
 			DepotEntry.class.getName());
 
 		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
@@ -498,6 +498,9 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		assertValid(putUserAccount);
 	}
+
+	@Inject
+	private ResourceActions _resourceActions;
 
 	@Inject
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -16,9 +16,12 @@ import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.headless.asset.library.client.resource.v1_0.UserAccountResource;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -87,6 +90,24 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testBatchEngineDeleteImportTask() {
 	}
 
+	@Test
+	public void testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		userAccountResource.putAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+
+		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+	}
+
 	@Override
 	@Test
 	public void testGetAssetLibraryUserAccount() throws Exception {
@@ -128,6 +149,41 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_spaceDepotEntry.getGroup(), cmsAdministratorUserAccountResource);
 
 		_testGetAssetLibraryUserAccountsPageWithSortId();
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
+			_getWithoutAssignMembersPermissionUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		_assertFailure(
+			"Forbidden",
+			() ->
+				withoutAssignMembersPermissionUserAccountResource.
+					putAssetLibraryUserAccount(
+						testDepotEntryGroup.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode()));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		UserAccount putUserAccount =
+			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				userAccount.getExternalReferenceCode());
+
+		assertValid(putUserAccount);
 	}
 
 	@Override
@@ -210,9 +266,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_testUser.getExternalReferenceCode());
 	}
 
-	private void _assertFailure(UnsafeRunnable<Exception> unsafeRunnable) {
+	private void _assertFailure(
+		String message, UnsafeRunnable<Exception> unsafeRunnable) {
+
 		AssertUtils.assertFailure(
-			Problem.ProblemException.class, null, unsafeRunnable);
+			Problem.ProblemException.class, message, unsafeRunnable);
+	}
+
+	private void _assertFailure(UnsafeRunnable<Exception> unsafeRunnable) {
+		_assertFailure(null, unsafeRunnable);
 	}
 
 	private UserAccountResource _getAssetLibraryMemberUserAccountResource(
@@ -274,6 +336,87 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		Group group = testDepotEntry.getGroup();
 
 		return group.getExternalReferenceCode();
+	}
+
+	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_MEMBERS);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		return UserAccountResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private UserAccountResource
+			_getWithoutAssignMembersPermissionUserAccountResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		List<String> actionIds = ResourceActionsUtil.getModelResourceActions(
+			DepotEntry.class.getName());
+
+		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
+
+		for (String actionId : actionIds) {
+			RoleTestUtil.addResourcePermission(
+				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+				String.valueOf(testDepotEntry.getGroupId()), actionId);
+		}
+
+		return UserAccountResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetAssetLibraryUserAccount(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -302,7 +302,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		return group.getExternalReferenceCode();
 	}
 
-	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
+	private UserAccountResource _getUserAccountResource(List<String> actionIds)
 		throws Exception {
 
 		String password = RandomTestUtil.randomString();
@@ -318,13 +318,12 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		_userLocalService.addRoleUser(role.getRoleId(), user);
 
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()),
-			ActionKeys.ASSIGN_MEMBERS);
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		for (String actionId : actionIds) {
+			RoleTestUtil.addResourcePermission(
+				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+				String.valueOf(testDepotEntry.getGroupId()), actionId);
+		}
+
 		RoleTestUtil.addResourcePermission(
 			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
@@ -340,47 +339,23 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
+	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
+		throws Exception {
+
+		return _getUserAccountResource(
+			List.of(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
+	}
+
 	private UserAccountResource
 			_getWithoutAssignMembersPermissionUserAccountResource()
 		throws Exception {
-
-		String password = RandomTestUtil.randomString();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			password, RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
-			ServiceContextTestUtil.getServiceContext());
-
-		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
-
-		_userLocalService.addRoleUser(role.getRoleId(), user);
-
-		RoleTestUtil.addResourcePermission(
-			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
-			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
 		List<String> actionIds = _resourceActions.getModelResourceActions(
 			DepotEntry.class.getName());
 
 		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
 
-		for (String actionId : actionIds) {
-			RoleTestUtil.addResourcePermission(
-				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-				String.valueOf(testDepotEntry.getGroupId()), actionId);
-		}
-
-		return UserAccountResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
+		return _getUserAccountResource(actionIds);
 	}
 
 	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -90,22 +90,12 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testBatchEngineDeleteImportTask() {
 	}
 
+	@Override
 	@Test
-	public void testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
-		throws Exception {
+	public void testDeleteAssetLibraryUserAccount() throws Exception {
+		super.testDeleteAssetLibraryUserAccount();
 
-		UserAccountResource viewAndAssignMembersUserAccountResource =
-			_getViewAndAssignMembersUserAccountResource();
-
-		UserAccount userAccount = randomUserAccount();
-
-		userAccountResource.putAssetLibraryUserAccount(
-			testDepotEntryGroup.getExternalReferenceCode(),
-			userAccount.getExternalReferenceCode());
-
-		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
-			testDepotEntryGroup.getExternalReferenceCode(),
-			userAccount.getExternalReferenceCode());
+		_testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission();
 	}
 
 	@Override
@@ -151,39 +141,13 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		_testGetAssetLibraryUserAccountsPageWithSortId();
 	}
 
+	@Override
 	@Test
-	public void testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
-		throws Exception {
+	public void testPutAssetLibraryUserAccount() throws Exception {
+		super.testPutAssetLibraryUserAccount();
 
-		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
-			_getWithoutAssignMembersPermissionUserAccountResource();
-
-		UserAccount userAccount = randomUserAccount();
-
-		_assertFailure(
-			"Forbidden",
-			() ->
-				withoutAssignMembersPermissionUserAccountResource.
-					putAssetLibraryUserAccount(
-						testDepotEntryGroup.getExternalReferenceCode(),
-						userAccount.getExternalReferenceCode()));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
-		throws Exception {
-
-		UserAccountResource viewAndAssignMembersUserAccountResource =
-			_getViewAndAssignMembersUserAccountResource();
-
-		UserAccount userAccount = randomUserAccount();
-
-		UserAccount putUserAccount =
-			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				userAccount.getExternalReferenceCode());
-
-		assertValid(putUserAccount);
+		_testPutAssetLibraryUserAccountWithoutAssignMembersPermission();
+		_testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission();
 	}
 
 	@Override
@@ -419,6 +383,23 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
+	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		userAccountResource.putAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+
+		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+	}
+
 	private void _testGetAssetLibraryUserAccount(
 			Group group, UserAccountResource getUserAccountResource)
 		throws Exception {
@@ -483,6 +464,39 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			EntityField.Type.ID,
 			(entityField, userAccount1, userAccount2) -> {
 			});
+	}
+
+	private void _testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
+			_getWithoutAssignMembersPermissionUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		_assertFailure(
+			"Forbidden",
+			() ->
+				withoutAssignMembersPermissionUserAccountResource.
+					putAssetLibraryUserAccount(
+						testDepotEntryGroup.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode()));
+	}
+
+	private void _testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		UserAccount putUserAccount =
+			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				userAccount.getExternalReferenceCode());
+
+		assertValid(putUserAccount);
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -296,13 +296,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
-	private String _getGroupExternalReferenceCode() throws Exception {
-		Group group = testDepotEntry.getGroup();
-
-		return group.getExternalReferenceCode();
-	}
-
-	private UserAccountResource _getUserAccountResource(List<String> actionIds)
+	private UserAccountResource _getDepotEntryUserAccountResource(
+			List<String> actionIds)
 		throws Exception {
 
 		String password = RandomTestUtil.randomString();
@@ -339,10 +334,16 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
+	private String _getGroupExternalReferenceCode() throws Exception {
+		Group group = testDepotEntry.getGroup();
+
+		return group.getExternalReferenceCode();
+	}
+
 	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
 		throws Exception {
 
-		return _getUserAccountResource(
+		return _getDepotEntryUserAccountResource(
 			List.of(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
 	}
 
@@ -355,7 +356,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
 
-		return _getUserAccountResource(actionIds);
+		return _getDepotEntryUserAccountResource(actionIds);
 	}
 
 	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98407

Supersedes #8697 by @janbrychtadotcom. His four commits are carried here unchanged, with follow-up commits stacked on top, including one authored by @brianchandotcom from a previous review round. Jan, please close #8697 when you get a chance.

## What Is Being Fixed

Adding or removing a member from a CMS Space (asset library group) routed through a private helper that performed a full `UserService.updateUser(...)` re-save of the entire user profile just to change one group ID. `UserService.updateUser` unconditionally requires `UPDATE` permission on the target `User` before it even inspects the group list, an extra, undocumented requirement beyond the `ASSIGN_MEMBERS` permission on `Group` that the resource's own action flags advertise. Only depot Group admins bypassed this, forcing every other admin to be granted `UPDATE` on `User`, a much broader privilege, just to manage Space membership.

Separately, adding a member to a Space is immediately followed by assigning that member's default role (space-member, space-administrator, or space-content-reviewer) through `putAssetLibraryUserAccountRolesPage`. That call went straight to the permissioned `UserGroupRoleService`, which requires `ASSIGN_USER_ROLES` on the group before it touches anything, so a Space Administrator holding only `ASSIGN_MEMBERS` could add a member but then fail trying to set their role.

## How It Is Being Fixed

The full-profile update is replaced with `UserService.addGroupUsers` and `UserService.unsetGroupUsers`, which gate on `ASSIGN_MEMBERS` on `Group`, matching what classic Site Membership management already does for the same operation. `VIEW` on the `Group` and on the target `User` are still required, since both are looked up through permissioned service calls before the membership change is attempted.

For role assignment, only one case bypasses the standard permission checks: the CMS "Manage Members" UI's own flow of adding a brand new member and then, in a separate follow-up call, assigning them the space's fixed default role (`Asset Library Member`). Without a bypass there, a caller holding only `ASSIGN_MEMBERS` ends up with a half-succeeded add, member added and role assignment rejected, with no way to recover from the UI. That case is now handled narrowly: only for a user who currently holds no roles yet, and only for that exact default role, resolved through the unpermissioned local service so it cannot be blocked by a missing Role-scoped `VIEW` grant nobody would think to make.

Every other assignment, reassigning an existing member, removing a role, or assigning any role other than the default (including Administrator or Content Reviewer), goes through the original permissioned `UserGroupRoleService` path unchanged, requiring `ASSIGN_USER_ROLES` or Role-scoped `ASSIGN_MEMBERS` on the group, plus Role-scoped `VIEW` on the specific role being assigned.

For a `TYPE_DEPOT` role the permissioned service adds exactly one thing over the local service it delegates to, the `UserGroupRolePermissionUtil.check` call. Its membership policy hooks bucket only `TYPE_ORGANIZATION` and `TYPE_SITE` roles, so no policy enforcement is skipped by taking the local service directly.

## Follow-Up Commits

`Enable the LPD-96750 feature flag in the roles page test` fixes a failure in `testGetAssetLibraryRolesPage` that predates this work. Its subtype assertions expect `DepotRoleUtil.filter` to drop roles whose subtype does not match the depot entry, but that filtering is gated on `LPD-96750`, which the test never enabled.

`Don't reintroduce the LPD-17564 feature flag check` restores the unconditional filtering that LPD-99210 established in a57a60eb394d04117d354de38b696068ee05a1d3. Reintroducing the check would stop the filtering on any instance that has `LPD-96750` enabled without `LPD-17564` or `LPD-58677`.

`Remove the explanatory comments` drops the inline rationale blocks from `RoleResourceImpl` and `RoleResourceTest`.

`Declare the updated roles before the current roles` is @brianchandotcom's own commit from a previous round, carried here unchanged.

`Override the base tests and add the scenarios as private tests` folds the standalone permission tests into the generated `@Test` methods they belong to, dispatching each scenario from a private `_testXxx` helper.

`Inject the services instead of using the static utilities` replaces `ResourcePermissionLocalServiceUtil` and `ResourceActionsUtil` with `@Inject` fields.

`Consolidate the duplicated resource builders` and `Name the depot entry resource builders symmetrically` merge the per-permission resource builders into one `_getDepotEntryRoleResource` and `_getDepotEntryUserAccountResource` pair.

`Name the Service Builder role local by convention` renames the `com.liferay.portal.kernel.model.Role` local in `_getDepotEntryRoleResource` to `serviceBuilderRole`, per review feedback.

`Consolidate the duplicated test setup` removes the repeated user creation, role lookup, and role array construction from the scenario helpers, reusing the existing `UserTestUtil.addUser(long... groupIds)` overload.

## Test Execution

```
gradlew -p modules/apps/headless/headless-asset-library/headless-asset-library-test testIntegration --tests RoleResourceTest --tests UserAccountResourceTest
```

23 tests, 0 failures: `RoleResourceTest` 10 passed, `UserAccountResourceTest` 12 passed and 1 skipped.
