### PR TITLE
LPD-98635 Fix testGetDDMFormValues CT collection and transaction setup

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFieldLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFieldLocalServiceTest.java
@@ -6,6 +6,8 @@
 package com.liferay.dynamic.data.mapping.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMFieldAttribute;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
@@ -35,6 +37,10 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -82,7 +88,7 @@ public class DDMFieldLocalServiceTest {
 	}
 
 	@Test
-	public void testGetDDMFormValues() throws Exception {
+	public void testGetDDMFormValues() throws Throwable {
 		DDMForm ddmForm = new DDMForm();
 
 		Locale locale = LocaleUtil.getSiteDefault();
@@ -111,39 +117,51 @@ public class DDMFieldLocalServiceTest {
 		_ddmFieldLocalService.updateDDMFormValues(
 			ddmStructure.getStructureId(), _STORAGE_ID, ddmFormValues);
 
-		long ctCollectionId = RandomTestUtil.randomLong();
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		long ctCollectionId = _ctCollection.getCtCollectionId();
 
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					ctCollectionId)) {
 
-			for (DDMFieldAttribute ddmFieldAttribute :
-					_ddmFieldAttributePersistence.findByStorageId(
-						_STORAGE_ID)) {
+			TransactionInvokerUtil.invoke(
+				TransactionConfig.Factory.create(
+					Propagation.REQUIRED, new Class<?>[] {Exception.class}),
+				() -> {
+					for (DDMFieldAttribute ddmFieldAttribute :
+							_ddmFieldAttributePersistence.findByStorageId(
+								_STORAGE_ID)) {
 
-				DDMFieldAttribute publicationDDMFieldAttribute =
-					_ddmFieldAttributePersistence.create(
-						RandomTestUtil.randomLong());
+						DDMFieldAttribute publicationDDMFieldAttribute =
+							_ddmFieldAttributePersistence.create(
+								RandomTestUtil.randomLong());
 
-				publicationDDMFieldAttribute.setCtCollectionId(ctCollectionId);
-				publicationDDMFieldAttribute.setCompanyId(
-					ddmFieldAttribute.getCompanyId());
-				publicationDDMFieldAttribute.setFieldId(
-					ddmFieldAttribute.getFieldId());
-				publicationDDMFieldAttribute.setStorageId(
-					ddmFieldAttribute.getStorageId());
-				publicationDDMFieldAttribute.setAttributeName(
-					ddmFieldAttribute.getAttributeName());
-				publicationDDMFieldAttribute.setLanguageId(
-					ddmFieldAttribute.getLanguageId());
-				publicationDDMFieldAttribute.setLargeAttributeValue(
-					ddmFieldAttribute.getLargeAttributeValue());
-				publicationDDMFieldAttribute.setSmallAttributeValue(
-					ddmFieldAttribute.getSmallAttributeValue());
+						publicationDDMFieldAttribute.setCtCollectionId(
+							ctCollectionId);
+						publicationDDMFieldAttribute.setCompanyId(
+							ddmFieldAttribute.getCompanyId());
+						publicationDDMFieldAttribute.setFieldId(
+							ddmFieldAttribute.getFieldId());
+						publicationDDMFieldAttribute.setStorageId(
+							ddmFieldAttribute.getStorageId());
+						publicationDDMFieldAttribute.setAttributeName(
+							ddmFieldAttribute.getAttributeName());
+						publicationDDMFieldAttribute.setLanguageId(
+							ddmFieldAttribute.getLanguageId());
+						publicationDDMFieldAttribute.setLargeAttributeValue(
+							ddmFieldAttribute.getLargeAttributeValue());
+						publicationDDMFieldAttribute.setSmallAttributeValue(
+							ddmFieldAttribute.getSmallAttributeValue());
 
-				_ddmFieldAttributePersistence.update(
-					publicationDDMFieldAttribute);
-			}
+						_ddmFieldAttributePersistence.update(
+							publicationDDMFieldAttribute);
+					}
+
+					return null;
+				});
 		}
 
 		try (SafeCloseable safeCloseable =
@@ -740,6 +758,12 @@ public class DDMFieldLocalServiceTest {
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private CTCollection _ctCollection;
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@Inject
 	private DDMFieldAttributePersistence _ddmFieldAttributePersistence;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98635

## What Is Being Fixed

`DDMFieldLocalServiceTest#testGetDDMFormValues` has never passed since LPD-94756 added it. The publication row copy block has two defects: it calls `_ddmFieldAttributePersistence.findByStorageId` outside any transaction, so `VerifySessionFactoryWrapper` rejects the session with "No current transaction executor" (deterministic, because the random change tracking collection id always misses the finder cache), and the rows it writes reference a `ctCollectionId` from `RandomTestUtil.randomLong()` for which no CTCollection exists, which fails with `NoSuchCollectionException` once a transaction is present. Both defects are in test code; product callers reach the finder through transactional services, so no product change is involved.

## How It Is Being Fixed

The copy block now runs inside `TransactionInvokerUtil.invoke` and against a real change tracking collection created with `CTCollectionLocalService.addCTCollection` and removed by `@DeleteAfterTestRun`. Both are established sibling patterns: the transaction wrap mirrors `CTScoreLocalServiceTest` and the collection setup mirrors `DDMTemplateVersionConstraintResolverTest` in the same module. An empty collection still reads production rows in a change tracking scope, so the copy loop seeds the same publication rows the test always intended.

The fix was verified in three steps against a local bundle: the test passes; with the LPD-94756 production `where` clause temporarily reverted it fails, proving it still guards that fix; and the whole `DDMFieldLocalServiceTest` class passes (9 tests, 0 failures).

## PR Check

**pr-check: FAIL** — tested on `cc051a4e7385986fc404ca2326a1a21448eac655`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | FAIL |

**Transaction Usage failure note:** the diff adds a new `TransactionInvokerUtil` usage (import plus one call) in `DDMFieldLocalServiceTest`. Per the validation, any new transaction usage must be reviewed by the Core Infrastructure team. This one is test-only and mirrors the existing usage in `CTScoreLocalServiceTest`; flagging it here so the reviewer can decide whether that sign-off is needed for test code.

Per-Module Compile and Java Unit Tests produce no additional signal here: `dynamic-data-mapping-test` is a test-only module (its `testIntegration` compile ran as part of the verification runs above), and the module has no unit test counterpart for the changed class.

<!-- pr-check {"result": "failure", "sha": "cc051a4e7385986fc404ca2326a1a21448eac655"} -->
