### PR TITLE
LPD-101211 Keep Space creation working when there is no principal

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
@@ -33,12 +33,14 @@ import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -97,6 +99,32 @@ public class DepotEntryLocalServiceTest {
 			_addStagedDepotEntry(DepotConstants.TYPE_ASSET_LIBRARY), 0);
 		_assertObjectEntryFolders(
 			_addStagedDepotEntry(DepotConstants.TYPE_SPACE), 2);
+	}
+
+	@Test
+	@TestInfo("LPD-101211")
+	public void testAddDepotEntryWithoutPrincipal() throws Exception {
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(null);
+
+		try {
+			DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+			_assertObjectEntryFolders(depotEntry, 2);
+
+			Group group = depotEntry.getGroup();
+
+			Repository repository = _repositoryLocalService.fetchRepository(
+				group.getGroupId(), TempFileEntryUtil.class.getName(),
+				TempFileEntryUtil.class.getName());
+
+			Assert.assertEquals(
+				group.getCreatorUserId(), repository.getUserId());
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+		}
 	}
 
 	@Test

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -128,7 +127,7 @@ public class ObjectEntryFolderUtil {
 		attachmentManager.getDLFolder(
 			objectDefinition.getCompanyId(), group.getGroupId(),
 			objectDefinition.getPortletId(), serviceContext,
-			PrincipalThreadLocal.getUserId());
+			group.getCreatorUserId());
 
 		try (SafeCloseable safeCloseable =
 				DLAppHelperThreadLocal.setEnabledWithSafeCloseable(false)) {
@@ -142,7 +141,7 @@ public class ObjectEntryFolderUtil {
 			}
 
 			RepositoryLocalServiceUtil.addRepository(
-				null, PrincipalThreadLocal.getUserId(), group.getGroupId(),
+				null, group.getCreatorUserId(), group.getGroupId(),
 				PortalUtil.getClassNameId(
 					TemporaryFileEntryRepository.class.getName()),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintScopeContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintScopeContributorTest.java
@@ -160,7 +160,10 @@ public class SXPBlueprintScopeContributorTest {
 	public void testSpaceScope() throws Exception {
 		_configureSXPBlueprint(_spaceGroup.getExternalReferenceCode());
 
-		_assertSearch(ListUtil.toList(_SPACE_TITLE));
+		_assertSearch(
+			Arrays.asList(
+				_SPACE_CONTENTS_OBJECT_ENTRY_FOLDER_TITLE,
+				_SPACE_FILES_OBJECT_ENTRY_FOLDER_TITLE, _SPACE_TITLE));
 	}
 
 	private static DepotEntry _addDepotEntry(int type) throws Exception {
@@ -256,6 +259,12 @@ public class SXPBlueprintScopeContributorTest {
 
 	private static final String _LOCALIZED_TITLE_FIELD =
 		"localized_title_en_US";
+
+	private static final String _SPACE_CONTENTS_OBJECT_ENTRY_FOLDER_TITLE =
+		"contents";
+
+	private static final String _SPACE_FILES_OBJECT_ENTRY_FOLDER_TITLE =
+		"files";
 
 	private static final String _SPACE_TITLE = "space title";
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101211

## What Is Being Fixed

Creating a Space fails on any thread with no authenticated actor. `ObjectEntryFolderUtil` read the acting user from `PrincipalThreadLocal.getUserId()`, which returns 0 when no principal is bound, and `addRepository` then threw `NoSuchUserException: No User exists with the primary key 0` while provisioning the temporary file entry repository of the new Space.

No product path is affected. The CMS UI and the headless API both create Spaces through `POST /o/headless-asset-library/v1.0/asset-libraries`, and any request has the principal set by `PermissionCheckerUtil.setThreadValues`. The batch engine and background tasks re-establish it, and `BundleSiteInitializer` already depends on it. Only contexts with no authenticated actor are exposed: service layer tests, unattended schedulers, upgrade processes and portal instance lifecycle listeners.

The branch became reachable on every Space creation with LPD-99210, which removed the LPD-17564 feature flag checks. Before that it was skipped whenever the CMS feature was disabled, which is why the defect surfaced now, as the release test failure LPD-100908.

## How It Is Being Fixed

The acting user is resolved from `group.getCreatorUserId()` in both calls. In every path that works today the value is identical, because `DepotEntryLocalServiceImpl.addDepotEntry` creates the group with the service context user id, so there is no behavior change. It cannot be 0 either, because both `addGroup` and the `getUser(serviceContext.getUserId())` call in the same method validate it before the wrapper runs. It is also the source every other place in the module already uses, from the sibling method in the same file to the CMS upgrade process and the PIM twin.

The second commit covers it where the coverage of this path already lives, in `DepotEntryLocalServiceTest`: it creates a Space with no principal and asserts that the temporary file entry repository exists and is owned by the group creator.

The third commit adapts `SXPBlueprintScopeContributorTest`, which the first commit unblocks. That test asserted the exact set of documents a Space contributes to the index, which held only while the CMS default object entry folders were hidden behind the feature flag. Both folders are searchable content, so a search scoped to a Space returns them alongside the article. Restricting the search to journal articles was tried first, through the blueprint `searchableAssetTypes` and through `modelIndexerClasses` on the search request; both combined with the scope clause leave the search with no results at all, so the expectation carries the folder titles instead. Those titles come from the folder names the CMS passes in code, not from the label map, so they do not vary with the locale.

Both integration test classes were run against a bundle built from `release-7.4.13.152`: `DepotEntryLocalServiceTest` fails 1 of 3 before the fix with the exact stack and passes 3 of 3 after, and `SXPBlueprintScopeContributorTest` goes from a class that never gets past `setUpClass` to 5 of 5.

## PR Check

**pr-check: PASS** — tested on `f83ac291e2e1aaf43864dc7975533301fab8c13b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f83ac291e2e1aaf43864dc7975533301fab8c13b"} -->
