### PR TITLE
LPD-83769 Show an icon beside every blog entry action

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/servlet/taglib/util/BlogsEntryActionDropdownItemsProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/servlet/taglib/util/BlogsEntryActionDropdownItemsProvider.java
@@ -199,6 +199,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				).setParameter(
 					"entryId", blogsEntry.getEntryId()
 				).buildString());
+			dropdownItem.setIcon("trash");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "delete"));
 		};
@@ -231,7 +232,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				"mvcRenderCommandName", "/blogs/edit_entry", "redirect",
 				_getRedirectURL(), "portletResource", portletResource,
 				"entryId", blogsEntry.getEntryId());
-			dropdownItem.setIcon("edit");
+			dropdownItem.setIcon("pencil");
 			dropdownItem.setLabel(LanguageUtil.get(_resourceBundle, "edit"));
 		};
 	}
@@ -254,6 +255,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				).setParameter(
 					"entryId", blogsEntry.getEntryId()
 				).buildString());
+			dropdownItem.setIcon("trash");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "delete"));
 		};
@@ -266,6 +268,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 			dropdownItem.putData("action", "permissions");
 			dropdownItem.putData(
 				"permissionsURL", _getPermissionsURL(blogsEntry));
+			dropdownItem.setIcon("password-policies");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "permissions"));
 		};
@@ -301,6 +304,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				).setParameter(
 					"entryId", blogsEntry.getEntryId()
 				).buildString());
+			dropdownItem.setIcon("live");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "publish-to-live"));
 		};

--- a/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
@@ -780,3 +780,30 @@ test(
 		await expect(page.locator('.cover-image')).toHaveCount(0);
 	}
 );
+
+test(
+	'Shows an icon beside every blog entry action',
+	{
+		tag: '@LPD-83769',
+	},
+	async ({apiHelpers, blogsPage, site}) => {
+		const headline = getRandomString();
+
+		await apiHelpers.headlessDelivery.postBlog(site.id, {
+			articleBody: 'Blogs Entry Content',
+			headline,
+		});
+
+		await blogsPage.goto(site.friendlyUrlPath);
+
+		await blogsPage.assertBlogEntryActionIcons(
+			[
+				{action: 'Edit', icon: 'pencil'},
+				{action: 'Share', icon: 'share'},
+				{action: 'Permissions', icon: 'password-policies'},
+				{action: 'Delete', icon: 'trash'},
+			],
+			headline
+		);
+	}
+);

--- a/modules/test/playwright/tests/blogs-web/main/pages/BlogsPage.ts
+++ b/modules/test/playwright/tests/blogs-web/main/pages/BlogsPage.ts
@@ -11,6 +11,7 @@ import {PORTLET_URLS} from '../../../../utils/portletUrls';
 export class BlogsPage {
 	readonly blogName: (title: string) => Locator;
 	readonly deleteAllBlogEntriesButton: Locator;
+	readonly moreActionsButton: (title: string) => Locator;
 	readonly page: Page;
 	readonly permissionsFrameLocator: FrameLocator;
 	readonly searchInput: Locator;
@@ -22,6 +23,11 @@ export class BlogsPage {
 		this.deleteAllBlogEntriesButton = page.getByRole('button', {
 			name: 'Delete',
 		});
+		this.moreActionsButton = (title: string) =>
+			page
+				.locator('.card')
+				.filter({hasText: title})
+				.getByLabel('More actions');
 		this.page = page;
 		this.permissionsFrameLocator = page.frameLocator(
 			'iframe[title="Permissions"]'
@@ -44,11 +50,7 @@ export class BlogsPage {
 	}
 
 	async goToBlogEntryAction(action: string, title: string) {
-		await this.page
-			.locator('.card')
-			.filter({hasText: title})
-			.getByLabel('More actions')
-			.waitFor();
+		await this.moreActionsButton(title).waitFor();
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,
@@ -56,10 +58,7 @@ export class BlogsPage {
 				exact: true,
 				name: action,
 			}),
-			trigger: this.page
-				.locator('.card')
-				.filter({hasText: title})
-				.getByLabel('More actions'),
+			trigger: this.moreActionsButton(title),
 		});
 	}
 
@@ -70,15 +69,38 @@ export class BlogsPage {
 				exact: true,
 				name: 'Delete',
 			}),
-			trigger: this.page
-				.locator('.card')
-				.filter({hasText: title})
-				.getByLabel('More actions'),
+			trigger: this.moreActionsButton(title),
 		});
 
 		await expect(
 			this.page.getByRole('menuitem', {exact: true, name: action})
 		).toBeHidden();
+	}
+
+	async assertBlogEntryActionIcons(
+		actionIcons: {action: string; icon: string}[],
+		title: string
+	) {
+		await this.moreActionsButton(title).waitFor();
+
+		await clickAndExpectToBeVisible({
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: actionIcons[0].action,
+			}),
+			trigger: this.moreActionsButton(title),
+		});
+
+		for (const actionIcon of actionIcons) {
+			await expect(
+				this.page
+					.getByRole('menuitem', {
+						exact: true,
+						name: actionIcon.action,
+					})
+					.locator(`svg.lexicon-icon-${actionIcon.icon}`)
+			).toBeVisible();
+		}
 	}
 
 	async assertBlogEntryPermissions(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83769

## What Is Being Fixed

Every action in a blog entry's kebab menu was missing its icon except Share, so the menu rendered as a column of bare labels.

Two distinct defects were behind it. The Edit action did set an icon, but it pointed at `edit`, an id that does not exist in the Clay spritemap (the closest real id is `edit-layout`). Clay still emitted the `<use>` element, so the icon resolved to nothing and left an empty gap rather than failing loudly, which is why this went unnoticed since 2019. The Permissions, Delete/Move to Trash and Publish to Live actions set no icon at all.

Both originate in the JSP to Java migration of LPS-90507. The old `blogs_admin/entry_action.jsp` passed `message="edit"` to `liferay-ui:icon`, where `message` only fed the text label, and that language key was carried over into the icon slot as well. Delete is a genuine regression from that migration: `liferay-ui:icon-delete` used to set `trash` on its own, and the port dropped it.

## How It Is Being Fixed

The four actions now use the same ids `JournalArticleActionDropdownItemsProvider` already applies to the very same actions in Web Content, so the two apps read alike: Edit becomes `pencil`, Permissions `password-policies`, both delete variants `trash`, and Publish to Live `live`.

Manage Collaborators is deliberately left alone. It is also missing its icon, but it comes from `SharingDropdownItemFactoryImpl`, a factory shared with Documents and Media and Shared Assets, so changing it would alter the kebab of several unrelated applications.

The second commit covers this with a Playwright test that asserts the concrete expected class per action rather than the mere presence of an `svg`. That distinction matters: Clay derives the `lexicon-icon-<id>` class from whatever name it is given, whether or not the symbol exists in the sprite, so a test that only checked for an icon element would have passed against the broken `edit` id. The test was validated in both directions, failing with the fix reverted and passing with it applied. Share is included as a regression guard even though it already worked. Publish to Live is not covered because it only renders on a staged site.

## PR Check

**pr-check: PASS** — tested on `c98ad8dafd1f98ef34ce4e095226196953920ac4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c98ad8dafd1f98ef34ce4e095226196953920ac4"} -->
