### PR TITLE
LPD-101262 Fix Depot Space creation outside an HTTP request

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
@@ -97,6 +98,23 @@ public class DepotEntryLocalServiceTest {
 			_addStagedDepotEntry(DepotConstants.TYPE_ASSET_LIBRARY), 0);
 		_assertObjectEntryFolders(
 			_addStagedDepotEntry(DepotConstants.TYPE_SPACE), 2);
+	}
+
+	@Test
+	public void testAddDepotEntryWhenPrincipalThreadLocalUserIdIsZero()
+		throws Exception {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(null);
+
+		try {
+			_assertObjectEntryFolders(
+				_addDepotEntry(DepotConstants.TYPE_SPACE), 2);
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+		}
 	}
 
 	@Test

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -125,10 +124,15 @@ public class ObjectEntryFolderUtil {
 			serviceContext = new ServiceContext();
 		}
 
+		long userId = serviceContext.getUserId();
+
+		if (userId == 0) {
+			userId = group.getCreatorUserId();
+		}
+
 		attachmentManager.getDLFolder(
 			objectDefinition.getCompanyId(), group.getGroupId(),
-			objectDefinition.getPortletId(), serviceContext,
-			PrincipalThreadLocal.getUserId());
+			objectDefinition.getPortletId(), serviceContext, userId);
 
 		try (SafeCloseable safeCloseable =
 				DLAppHelperThreadLocal.setEnabledWithSafeCloseable(false)) {
@@ -142,7 +146,7 @@ public class ObjectEntryFolderUtil {
 			}
 
 			RepositoryLocalServiceUtil.addRepository(
-				null, PrincipalThreadLocal.getUserId(), group.getGroupId(),
+				null, userId, group.getGroupId(),
 				PortalUtil.getClassNameId(
 					TemporaryFileEntryRepository.class.getName()),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101262

LPD-99210 removed the LPD-17564 feature-flag guard in `CMSObjectEntryFolderDepotEntryLocalServiceWrapper.addDepotEntry`, so `ObjectEntryFolderUtil.addObjectEntryFolders` now always runs for `DepotConstants.TYPE_SPACE`. That exposed a latent defect: `_addObjectEntryFolderFileRepository` derived the userId from `PrincipalThreadLocal`, which is only populated by the servlet filter chain. Any caller with no request thread (integration tests, scheduled jobs, migration tooling) got userId 0 and `RepositoryLocalServiceImpl.addRepository` threw `NoSuchUserException: No User exists with the primary key 0`. A quieter second symptom: `attachmentManager.getDLFolder` uses the userId only as the DL folder name, so off-request it silently created a folder named `"0"`.

The fix derives the userId from the `ServiceContext`, falling back to `group.getCreatorUserId()` — matching the sibling `_addObjectEntryFolder` method — and passes it to both call sites.

Verification (local bundle on current master):

- New `DepotEntryLocalServiceTest#testAddDepotEntryWhenPrincipalThreadLocalUserIdIsZero` nulls `PrincipalThreadLocal` to simulate a non-request thread; it fails with the ticket's exact `NoSuchUserException` without the fix and passes with it.
- Full `DepotEntryLocalServiceTest` class: 3/3 pass.
- The ticket's original repro, `SiteScopeResourceTest#testGetPlanInternalClassNameKeySiteScopesPage` (batch-planner-rest-test), now passes.

**pr-check: PASS** — tested on `aea33b33cdcbb0717f3eca883a8b13ec319a994f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "aea33b33cdcbb0717f3eca883a8b13ec319a994f"} -->
