### PR TITLE
LPD-101398 Stop enabling the removed LPD-17564 feature flag

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/servlet/taglib/util/BlogsEntryActionDropdownItemsProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/servlet/taglib/util/BlogsEntryActionDropdownItemsProvider.java
@@ -199,6 +199,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				).setParameter(
 					"entryId", blogsEntry.getEntryId()
 				).buildString());
+			dropdownItem.setIcon("trash");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "delete"));
 		};
@@ -231,7 +232,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				"mvcRenderCommandName", "/blogs/edit_entry", "redirect",
 				_getRedirectURL(), "portletResource", portletResource,
 				"entryId", blogsEntry.getEntryId());
-			dropdownItem.setIcon("edit");
+			dropdownItem.setIcon("pencil");
 			dropdownItem.setLabel(LanguageUtil.get(_resourceBundle, "edit"));
 		};
 	}
@@ -254,6 +255,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				).setParameter(
 					"entryId", blogsEntry.getEntryId()
 				).buildString());
+			dropdownItem.setIcon("trash");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "delete"));
 		};
@@ -266,6 +268,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 			dropdownItem.putData("action", "permissions");
 			dropdownItem.putData(
 				"permissionsURL", _getPermissionsURL(blogsEntry));
+			dropdownItem.setIcon("password-policies");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "permissions"));
 		};
@@ -301,6 +304,7 @@ public class BlogsEntryActionDropdownItemsProvider {
 				).setParameter(
 					"entryId", blogsEntry.getEntryId()
 				).buildString());
+			dropdownItem.setIcon("live");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "publish-to-live"));
 		};

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/UserAccountResourceTest.java
@@ -51,9 +51,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Pedro Leite
  */
-@FeatureFlags(
-	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-58677")}
-)
+@FeatureFlags(featureFlags = @FeatureFlag("LPD-58677"))
 @RunWith(Arquillian.class)
 public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 

--- a/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
@@ -780,3 +780,30 @@ test(
 		await expect(page.locator('.cover-image')).toHaveCount(0);
 	}
 );
+
+test(
+	'Shows an icon beside every blog entry action',
+	{
+		tag: '@LPD-83769',
+	},
+	async ({apiHelpers, blogsPage, site}) => {
+		const headline = getRandomString();
+
+		await apiHelpers.headlessDelivery.postBlog(site.id, {
+			articleBody: 'Blogs Entry Content',
+			headline,
+		});
+
+		await blogsPage.goto(site.friendlyUrlPath);
+
+		await blogsPage.assertBlogEntryActionIcons(
+			[
+				{action: 'Edit', icon: 'pencil'},
+				{action: 'Share', icon: 'share'},
+				{action: 'Permissions', icon: 'password-policies'},
+				{action: 'Delete', icon: 'trash'},
+			],
+			headline
+		);
+	}
+);

--- a/modules/test/playwright/tests/blogs-web/main/pages/BlogsPage.ts
+++ b/modules/test/playwright/tests/blogs-web/main/pages/BlogsPage.ts
@@ -11,6 +11,7 @@ import {PORTLET_URLS} from '../../../../utils/portletUrls';
 export class BlogsPage {
 	readonly blogName: (title: string) => Locator;
 	readonly deleteAllBlogEntriesButton: Locator;
+	readonly moreActionsButton: (title: string) => Locator;
 	readonly page: Page;
 	readonly permissionsFrameLocator: FrameLocator;
 	readonly searchInput: Locator;
@@ -22,6 +23,11 @@ export class BlogsPage {
 		this.deleteAllBlogEntriesButton = page.getByRole('button', {
 			name: 'Delete',
 		});
+		this.moreActionsButton = (title: string) =>
+			page
+				.locator('.card')
+				.filter({hasText: title})
+				.getByLabel('More actions');
 		this.page = page;
 		this.permissionsFrameLocator = page.frameLocator(
 			'iframe[title="Permissions"]'
@@ -44,11 +50,7 @@ export class BlogsPage {
 	}
 
 	async goToBlogEntryAction(action: string, title: string) {
-		await this.page
-			.locator('.card')
-			.filter({hasText: title})
-			.getByLabel('More actions')
-			.waitFor();
+		await this.moreActionsButton(title).waitFor();
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,
@@ -56,10 +58,7 @@ export class BlogsPage {
 				exact: true,
 				name: action,
 			}),
-			trigger: this.page
-				.locator('.card')
-				.filter({hasText: title})
-				.getByLabel('More actions'),
+			trigger: this.moreActionsButton(title),
 		});
 	}
 
@@ -70,15 +69,38 @@ export class BlogsPage {
 				exact: true,
 				name: 'Delete',
 			}),
-			trigger: this.page
-				.locator('.card')
-				.filter({hasText: title})
-				.getByLabel('More actions'),
+			trigger: this.moreActionsButton(title),
 		});
 
 		await expect(
 			this.page.getByRole('menuitem', {exact: true, name: action})
 		).toBeHidden();
+	}
+
+	async assertBlogEntryActionIcons(
+		actionIcons: {action: string; icon: string}[],
+		title: string
+	) {
+		await this.moreActionsButton(title).waitFor();
+
+		await clickAndExpectToBeVisible({
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: actionIcons[0].action,
+			}),
+			trigger: this.moreActionsButton(title),
+		});
+
+		for (const actionIcon of actionIcons) {
+			await expect(
+				this.page
+					.getByRole('menuitem', {
+						exact: true,
+						name: actionIcon.action,
+					})
+					.locator(`svg.lexicon-icon-${actionIcon.icon}`)
+			).toBeVisible();
+		}
 	}
 
 	async assertBlogEntryPermissions(

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/brokenRelationReference.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/brokenRelationReference.spec.ts
@@ -8,7 +8,6 @@ import {readFileSync} from 'fs';
 import path from 'path';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
@@ -17,9 +16,6 @@ import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/stru
 const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
 	loginTest(),
 	structureBuilderPagesTest
 );

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentEditing.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentEditing.spec.ts
@@ -6,20 +6,12 @@
 import {Page, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
 import {openSecondCmsEditor} from './openSecondCmsEditor';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 test(
 	'When two users concurrently edit and publish a Basic Web Content entry, the last publish wins',

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentStructuredEditing.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/concurrentStructuredEditing.spec.ts
@@ -22,7 +22,6 @@ const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-17564': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fieldValidation.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fieldValidation.spec.ts
@@ -6,7 +6,6 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
@@ -15,9 +14,6 @@ import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/stru
 const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
 	loginTest(),
 	structureBuilderPagesTest
 );

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fileUploadValidation.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/fileUploadValidation.spec.ts
@@ -6,7 +6,6 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
@@ -15,9 +14,6 @@ import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/stru
 const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
 	loginTest(),
 	structureBuilderPagesTest
 );

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/friendlyUrlConflict.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/friendlyUrlConflict.spec.ts
@@ -6,19 +6,11 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 test(
 	'Setting a friendly URL already used by another entry in the same Space is blocked',

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/missingWorkflowSubmission.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/missingWorkflowSubmission.spec.ts
@@ -6,7 +6,6 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
@@ -15,9 +14,6 @@ import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/stru
 const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
 	loginTest(),
 	structureBuilderPagesTest
 );

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/spaceDeletionWarning.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/spaceDeletionWarning.spec.ts
@@ -22,7 +22,6 @@ const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-17564': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/validation/structureDeletionWarning.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/validation/structureDeletionWarning.spec.ts
@@ -8,7 +8,6 @@ import {readFileSync} from 'fs';
 import path from 'path';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
@@ -17,9 +16,6 @@ import {structureBuilderPagesTest} from '../../../site-cms-site-initializer/stru
 const test = mergeTests(
 	cmsPagesTest,
 	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
 	loginTest(),
 	structureBuilderPagesTest
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categorizationManagement.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categorizationManagement.spec.ts
@@ -8,7 +8,6 @@ import {readFileSync} from 'fs';
 import path from 'path';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../../utils/getRandomString';
@@ -19,9 +18,6 @@ const test = mergeTests(
 	categorizationPagesTest,
 	cmsPagesTest,
 	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
 	loginTest()
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categorizationPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categorizationPermissions.spec.ts
@@ -6,7 +6,6 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import getRandomString from '../../../../utils/getRandomString';
@@ -14,13 +13,7 @@ import {performLoginViaApi} from '../../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {registerUserCredentials} from '../spaces/helpers/roleMembership';
 
-const test = mergeTests(
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(dataApiHelpersTest, loginTest());
 
 async function createSpaceUserWithRole(
 	apiHelpers: DataApiHelpers,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categorizationSearchFiltering.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categorizationSearchFiltering.spec.ts
@@ -15,7 +15,6 @@ import getRandomString from '../../../../utils/getRandomString';
 const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-17564': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({type: 'portlet'}),

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
@@ -6,20 +6,12 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {applyFDSSelectionFilter} from '../../../../utils/applyFDSSelectionFilter';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 test(
 	'Combining Space, content type, and keyword filters in the All section narrows to only matching items',

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/combinedFilters.spec.ts
@@ -20,6 +20,8 @@ test(
 		const applicationName = 'cms/basic-web-contents';
 		const keyword = getRandomString();
 		const matchingTitle = `${keyword} Match`;
+		const matchingFileTitle = `${keyword} Document`;
+		const otherSpaceTitle = `${keyword} Other Space`;
 		const wrongKeywordTitle = getRandomString();
 
 		let space1Name: string;
@@ -61,10 +63,10 @@ test(
 				{
 					file: {
 						fileBase64: 'R0lGODlhAQABAAAAACw=',
-						name: `${matchingTitle} File.png`,
+						name: `${matchingFileTitle}.png`,
 					},
 					objectEntryFolderExternalReferenceCode: 'L_FILES',
-					title: `${matchingTitle} File`,
+					title: matchingFileTitle,
 				},
 				'cms/basic-documents',
 				space1.name
@@ -73,7 +75,7 @@ test(
 			await apiHelpers.objectEntry.postObjectEntry(
 				{
 					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: `${keyword} Other Space`,
+					title: otherSpaceTitle,
 				},
 				applicationName,
 				space2.name
@@ -101,14 +103,20 @@ test(
 		});
 
 		await test.step('Only the item matching all three criteria remains', async () => {
-			await expect(assetsPage.getItem(matchingTitle)).toBeVisible();
-			await expect(assetsPage.getItem(wrongKeywordTitle)).toBeHidden();
-			await expect(
-				assetsPage.getItem(`${matchingTitle} File`)
-			).toBeHidden();
-			await expect(
-				assetsPage.getItem(`${keyword} Other Space`)
-			).toBeHidden();
+			await expect(async () => {
+				await expect(assetsPage.getItem(matchingTitle)).toBeVisible({
+					timeout: 5000,
+				});
+				await expect(assetsPage.getItem(wrongKeywordTitle)).toBeHidden({
+					timeout: 5000,
+				});
+				await expect(assetsPage.getItem(matchingFileTitle)).toBeHidden({
+					timeout: 5000,
+				});
+				await expect(assetsPage.getItem(otherSpaceTitle)).toBeHidden({
+					timeout: 5000,
+				});
+			}).toPass({timeout: 30000});
 		});
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
@@ -6,21 +6,13 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import {applyFDSSelectionFilter} from '../../../../utils/applyFDSSelectionFilter';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 async function createStructuredContentStructure(
 	apiHelpers: DataApiHelpers,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
@@ -6,20 +6,12 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {applyFDSSelectionFilter} from '../../../../utils/applyFDSSelectionFilter';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 test(
 	'Filtering the Files section by an image extension excludes non-image files',

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/keywordSearch.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/keywordSearch.spec.ts
@@ -6,19 +6,11 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 test(
 	'Searching a keyword in the All section returns matching content and files from all Spaces',

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/metadataSearch.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/metadataSearch.spec.ts
@@ -6,20 +6,12 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 async function createFileStructureWithDescription(
 	apiHelpers: DataApiHelpers,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/searchScopeByRole.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/searchScopeByRole.spec.ts
@@ -6,21 +6,13 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 import {addRoleMemberAndSwitch} from '../spaces/helpers/roleMembership';
 
-const test = mergeTests(
-	cmsPagesTest,
-	dataApiHelpersTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-	}),
-	loginTest()
-);
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 const APPLICATION_NAME = 'cms/basic-web-contents';
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101398

## What Is Being Fixed

LPD-99210 deleted the `LPD-17564` feature flag definition from `portal.properties`, but references to it kept landing afterwards. Eighteen Playwright specs still enabled it through the `featureFlagsTest` fixture, and one integration test still declared it through `@FeatureFlags`.

The Playwright fixture posts to `/o/com-liferay-feature-flag-web/is-enabled`, which returns 404 for an unknown key, and the fixture rejects on 404. Since it is registered `auto: true`, every test in those eighteen files failed during setup with `page.evaluate: Feature flag "LPD-17564" is not available`. The integration test annotation was inert, because `FeatureFlagTestRule` only calls `PropsUtil.set` on a property nothing reads, but it still advertised the flag as live.

This is the third cleanup pass, after LPD-98462 and LPD-98407, so the aim is zero references rather than one spec at a time.

## How It Is Being Fixed

The flag entry is dropped from every spec. Where it was the only flag, the `featureFlagsTest` call and its import go too; four specs keep the fixture because they still need `LPS-178052` or `LPD-57283`. No substitute flag is needed anywhere, because `LPD-17564` *was* the CMS release flag, so its deletion means the CMS is unconditionally on and the specs get the same behavior with no flag at all. The integration test is reduced to `@FeatureFlags(featureFlags = @FeatureFlag("LPD-58677"))`, matching the sibling style in `TaskStatisticsResourceTest`.

The second commit fixes `combinedFilters.spec.ts`, which had never actually run before, since the removed flag failed its setup. It asserted immediately after submitting the keyword search, so a slow dataset refresh left the pre-filter rows on screen; the assertions now retry via `toPass`. Its file was also titled as a superstring of the content it had to be distinguished from, which made the substring row locator match both rows and report a strict mode violation instead of the real problem.

`designLibraryHome.spec.ts` is deliberately untouched. LPD-101385 already covers it in brianchandotcom/liferay-portal#179821 with a byte-identical hunk, so one reference remains on master until that PR lands.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/searchFiltering
yarn test tests/site-cms-site-initializer/main/categorization
yarn test tests/e2e-cms-dxp/main/validation
```

93 tests pass across those three groups, with no occurrence of the feature flag setup error.

`UserAccountResourceTest` compiles but could not be run locally. `headless-cmp-api`, `-impl`, and `-client` carry only `.lfrbuild-ci` and `.lfrbuild-cms-standalone`, no `.lfrbuild-portal`, so they are excluded from the portal build and never land in a standard bundle; the test bundle then fails to resolve `Import-Package: com.liferay.headless.cmp.dto.v1_0`.

## PR Check

**pr-check: PASS** — tested on `905e17f9a1a2d3a57891645bedd8071341395b1b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile matched the diff but was omitted: the diff touches no module source, only test sources, and Integration Test Compile already covers the one Java file. `modules/test/playwright` has no Jest suite, so JavaScript Unit Tests is covered by the TypeScript project check inside Source Format.

<!-- pr-check {"result": "success", "sha": "905e17f9a1a2d3a57891645bedd8071341395b1b"} -->
