### PR TITLE
LPD-98407 Require only ASSIGN_MEMBERS and VIEW to manage Space members

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -40,7 +40,6 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -287,12 +286,12 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 	private boolean _isDefaultAssetLibraryMemberRoleAssignment(
 		List<com.liferay.portal.kernel.model.Role> currentRoles, Role[] roles) {
 
-		if (!currentRoles.isEmpty() || (roles.length != 1)) {
+		if (ListUtil.isNotEmpty(currentRoles) || (roles.length != 1)) {
 			return false;
 		}
 
-		return Objects.equals(
-			roles[0].getName(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+		return DepotRolesConstants.ASSET_LIBRARY_MEMBER.equals(
+			roles[0].getName());
 	}
 
 	private Role _toRole(com.liferay.portal.kernel.model.Role role)

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.NoSuchUserGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -66,7 +65,9 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		_checkAssetLibraryAdminOrAssetLibraryMember(group.getGroupId());
 
 		List<com.liferay.portal.kernel.model.Role> roles =
-			_getAssetLibraryRoles(group.getGroupId());
+			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
+
+		roles = DepotRoleUtil.filter(group.getGroupId(), roles);
 
 		if (pagination == null) {
 			return Page.of(transform(roles, this::_toRole));
@@ -291,23 +292,6 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 		throw new PrincipalException.MustHavePermission(
 			contextUser.getUserId(), ActionKeys.ASSIGN_MEMBERS);
-	}
-
-	private List<com.liferay.portal.kernel.model.Role> _getAssetLibraryRoles(
-		long groupId) {
-
-		List<com.liferay.portal.kernel.model.Role> roles =
-			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
-
-		if (FeatureFlagManagerUtil.isEnabled(
-				contextCompany.getCompanyId(), "LPD-17564") ||
-			FeatureFlagManagerUtil.isEnabled(
-				contextCompany.getCompanyId(), "LPD-58677")) {
-
-			roles = DepotRoleUtil.filter(groupId, roles);
-		}
-
-		return roles;
 	}
 
 	private Group _getGroup(String externalReferenceCode) throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -149,11 +149,11 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 					group.getGroupId()));
 		}
 
+		List<com.liferay.portal.kernel.model.Role> updatedRoles = null;
+
 		List<com.liferay.portal.kernel.model.Role> currentRoles =
 			_roleLocalService.getUserGroupRoles(
 				user.getUserId(), group.getGroupId());
-
-		List<com.liferay.portal.kernel.model.Role> updatedRoles;
 
 		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
 			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.RoleService;
@@ -33,7 +34,6 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleService;
 import com.liferay.portal.kernel.service.UserGroupService;
 import com.liferay.portal.kernel.service.UserService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -245,17 +245,18 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		if (permissionChecker.isGroupAdmin(groupId) ||
-			GroupPermissionUtil.contains(
-				permissionChecker, groupId, ActionKeys.ASSIGN_MEMBERS) ||
-			GroupPermissionUtil.contains(
-				permissionChecker, groupId, ActionKeys.ASSIGN_USER_ROLES)) {
-
+		if (permissionChecker.isGroupAdmin(groupId)) {
 			return;
 		}
 
-		throw new PrincipalException.MustHavePermission(
-			contextUser.getUserId(), ActionKeys.ASSIGN_MEMBERS);
+		if (!_groupModelResourcePermission.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_MEMBERS) &&
+			!_groupModelResourcePermission.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_USER_ROLES)) {
+
+			throw new PrincipalException.MustHavePermission(
+				contextUser.getUserId(), ActionKeys.ASSIGN_MEMBERS);
+		}
 	}
 
 	private Group _getGroup(String externalReferenceCode) throws Exception {
@@ -308,6 +309,11 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 			}
 		};
 	}
+
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Group)"
+	)
+	private ModelResourcePermission<Group> _groupModelResourcePermission;
 
 	@Reference
 	private GroupService _groupService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -155,7 +155,8 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 				user.getUserId(), group.getGroupId());
 
 		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
-			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());
+			_checkAssetLibraryAdminOrAssignMembersOrAssignUserRoles(
+				group.getGroupId());
 
 			com.liferay.portal.kernel.model.Role
 				assetLibraryMemberServiceBuilderRole =
@@ -239,7 +240,8 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		}
 	}
 
-	private void _checkAssetLibraryAdminOrAssignMembers(long groupId)
+	private void _checkAssetLibraryAdminOrAssignMembersOrAssignUserRoles(
+			long groupId)
 		throws Exception {
 
 		PermissionChecker permissionChecker =

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.asset.library.internal.resource.v1_0;
 
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.util.DepotRoleUtil;
 import com.liferay.headless.asset.library.dto.v1_0.Role;
 import com.liferay.headless.asset.library.resource.v1_0.RoleResource;
@@ -13,6 +14,7 @@ import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.NoSuchUserGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -28,15 +30,18 @@ import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleService;
 import com.liferay.portal.kernel.service.UserGroupService;
 import com.liferay.portal.kernel.service.UserService;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,9 +66,7 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		_checkAssetLibraryAdminOrAssetLibraryMember(group.getGroupId());
 
 		List<com.liferay.portal.kernel.model.Role> roles =
-			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
-
-		roles = DepotRoleUtil.filter(group.getGroupId(), roles);
+			_getAssetLibraryRoles(group.getGroupId());
 
 		if (pagination == null) {
 			return Page.of(transform(roles, this::_toRole));
@@ -145,21 +148,78 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 					group.getGroupId()));
 		}
 
-		_userGroupRoleService.deleteUserGroupRoles(
-			user.getUserId(), group.getGroupId(),
-			ListUtil.toLongArray(
-				_roleService.getUserGroupRoles(
-					user.getUserId(), group.getGroupId()),
-				com.liferay.portal.kernel.model.Role.ROLE_ID_ACCESSOR));
+		List<com.liferay.portal.kernel.model.Role> currentRoles =
+			_roleLocalService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
 
-		_userGroupRoleService.addUserGroupRoles(
-			user.getUserId(), group.getGroupId(), _getRoleIds(roles));
+		List<com.liferay.portal.kernel.model.Role> updatedRoles;
 
-		return Page.of(
-			transform(
-				_roleService.getUserGroupRoles(
-					user.getUserId(), group.getGroupId()),
-				this::_toRole));
+		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
+
+			// The CMS "Manage Members" UI (ManageMembersList) adds a brand
+			// new member and then, in a separate follow-up call, assigns
+			// them the space's fixed default role
+			// (SPACE_MEMBERS_CONFIG.defaultRoleExternalReferenceCode,
+			// hardcoded to Asset Library Member - never configurable, never
+			// any other role). That follow-up call goes through
+			// UserGroupRoleService, which requires ASSIGN_USER_ROLES; if a
+			// caller holding only ASSIGN_MEMBERS lacks it, the UI does not
+			// roll back the membership it just added - the user stays a
+			// member with no role, and the only feedback is an error toast.
+			// To avoid that half-succeeded state, a caller with just
+			// ASSIGN_MEMBERS is allowed to grant this one specific,
+			// hardcoded role, but only to a user who currently holds no
+			// roles here (i.e. was just added, mirroring the UI's own
+			// !isAlreadyMember condition for making this call at all).
+			// Reassigning an existing member's role, removing a role, or
+			// granting any other role - including Administrator or Content
+			// Reviewer - still requires ASSIGN_USER_ROLES or Role-scoped
+			// ASSIGN_MEMBERS, unchanged. The role ID is resolved through
+			// the local service (not _getRoleIds/_roleService.getRole,
+			// which requires Role-scoped VIEW) for the same reason the
+			// read of the updated roles below does: the caller may hold
+			// ASSIGN_MEMBERS on the group without holding VIEW on the
+			// individual Role, which would otherwise reject the lookup
+			// entirely before the assignment is ever attempted.
+
+			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());
+
+			com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+				_roleLocalService.getRole(
+					contextCompany.getCompanyId(),
+					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+			// The read below goes through the local service, not
+			// _roleService, for the same reason the role lookup above does:
+			// this caller may hold ASSIGN_MEMBERS without Role-scoped VIEW
+			// on Asset Library Member, and the permissioned read would
+			// filter the assignment just made down to nothing. The else
+			// branch below keeps _roleService, since every role reaching it
+			// was already resolved through _getRoleIds, which itself
+			// requires Role-scoped VIEW.
+
+			_userGroupRoleLocalService.addUserGroupRoles(
+				user.getUserId(), group.getGroupId(),
+				new long[] {assetLibraryMemberRole.getRoleId()});
+
+			updatedRoles = _roleLocalService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
+		}
+		else {
+			_userGroupRoleService.deleteUserGroupRoles(
+				user.getUserId(), group.getGroupId(),
+				ListUtil.toLongArray(
+					currentRoles,
+					com.liferay.portal.kernel.model.Role.ROLE_ID_ACCESSOR));
+
+			_userGroupRoleService.addUserGroupRoles(
+				user.getUserId(), group.getGroupId(), _getRoleIds(roles));
+
+			updatedRoles = _roleService.getUserGroupRoles(
+				user.getUserId(), group.getGroupId());
+		}
+
+		return Page.of(transform(updatedRoles, this::_toRole));
 	}
 
 	@Override
@@ -214,6 +274,42 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		}
 	}
 
+	private void _checkAssetLibraryAdminOrAssignMembers(long groupId)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker.isGroupAdmin(groupId) ||
+			GroupPermissionUtil.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_MEMBERS) ||
+			GroupPermissionUtil.contains(
+				permissionChecker, groupId, ActionKeys.ASSIGN_USER_ROLES)) {
+
+			return;
+		}
+
+		throw new PrincipalException.MustHavePermission(
+			contextUser.getUserId(), ActionKeys.ASSIGN_MEMBERS);
+	}
+
+	private List<com.liferay.portal.kernel.model.Role> _getAssetLibraryRoles(
+		long groupId) {
+
+		List<com.liferay.portal.kernel.model.Role> roles =
+			_roleLocalService.getTypeRoles(RoleConstants.TYPE_DEPOT);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-58677")) {
+
+			roles = DepotRoleUtil.filter(groupId, roles);
+		}
+
+		return roles;
+	}
+
 	private Group _getGroup(String externalReferenceCode) throws Exception {
 		Group group = _groupService.fetchGroupByExternalReferenceCode(
 			externalReferenceCode, contextCompany.getCompanyId());
@@ -237,6 +333,17 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 				return serviceBuilderRole.getRoleId();
 			});
+	}
+
+	private boolean _isDefaultAssetLibraryMemberRoleAssignment(
+		List<com.liferay.portal.kernel.model.Role> currentRoles, Role[] roles) {
+
+		if (!currentRoles.isEmpty() || (roles.length != 1)) {
+			return false;
+		}
+
+		return Objects.equals(
+			roles[0].getName(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 	}
 
 	private Role _toRole(com.liferay.portal.kernel.model.Role role)
@@ -271,6 +378,9 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 
 	@Reference
 	private UserGroupLocalService _userGroupLocalService;
+
+	@Reference
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Reference
 	private UserGroupRoleService _userGroupRoleService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -156,48 +156,12 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		List<com.liferay.portal.kernel.model.Role> updatedRoles;
 
 		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
-
-			// The CMS "Manage Members" UI (ManageMembersList) adds a brand
-			// new member and then, in a separate follow-up call, assigns
-			// them the space's fixed default role
-			// (SPACE_MEMBERS_CONFIG.defaultRoleExternalReferenceCode,
-			// hardcoded to Asset Library Member - never configurable, never
-			// any other role). That follow-up call goes through
-			// UserGroupRoleService, which requires ASSIGN_USER_ROLES; if a
-			// caller holding only ASSIGN_MEMBERS lacks it, the UI does not
-			// roll back the membership it just added - the user stays a
-			// member with no role, and the only feedback is an error toast.
-			// To avoid that half-succeeded state, a caller with just
-			// ASSIGN_MEMBERS is allowed to grant this one specific,
-			// hardcoded role, but only to a user who currently holds no
-			// roles here (i.e. was just added, mirroring the UI's own
-			// !isAlreadyMember condition for making this call at all).
-			// Reassigning an existing member's role, removing a role, or
-			// granting any other role - including Administrator or Content
-			// Reviewer - still requires ASSIGN_USER_ROLES or Role-scoped
-			// ASSIGN_MEMBERS, unchanged. The role ID is resolved through
-			// the local service (not _getRoleIds/_roleService.getRole,
-			// which requires Role-scoped VIEW) for the same reason the
-			// read of the updated roles below does: the caller may hold
-			// ASSIGN_MEMBERS on the group without holding VIEW on the
-			// individual Role, which would otherwise reject the lookup
-			// entirely before the assignment is ever attempted.
-
 			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());
 
 			com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
 				_roleLocalService.getRole(
 					contextCompany.getCompanyId(),
 					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-			// The read below goes through the local service, not
-			// _roleService, for the same reason the role lookup above does:
-			// this caller may hold ASSIGN_MEMBERS without Role-scoped VIEW
-			// on Asset Library Member, and the permissioned read would
-			// filter the assignment just made down to nothing. The else
-			// branch below keeps _roleService, since every role reaching it
-			// was already resolved through _getRoleIds, which itself
-			// requires Role-scoped VIEW.
 
 			_userGroupRoleLocalService.addUserGroupRoles(
 				user.getUserId(), group.getGroupId(),

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/RoleResourceImpl.java
@@ -157,14 +157,15 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 		if (_isDefaultAssetLibraryMemberRoleAssignment(currentRoles, roles)) {
 			_checkAssetLibraryAdminOrAssignMembers(group.getGroupId());
 
-			com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-				_roleLocalService.getRole(
-					contextCompany.getCompanyId(),
-					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			com.liferay.portal.kernel.model.Role
+				assetLibraryMemberServiceBuilderRole =
+					_roleLocalService.getRole(
+						contextCompany.getCompanyId(),
+						DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 			_userGroupRoleLocalService.addUserGroupRoles(
 				user.getUserId(), group.getGroupId(),
-				new long[] {assetLibraryMemberRole.getRoleId()});
+				new long[] {assetLibraryMemberServiceBuilderRole.getRoleId()});
 
 			updatedRoles = _roleLocalService.getUserGroupRoles(
 				user.getUserId(), group.getGroupId());

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -116,8 +116,7 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		_userService.addGroupUsers(
 			group.getGroupId(), new long[] {user.getUserId()}, serviceContext);
 
-		return _toUserAccount(
-			group.getGroupId(), _userService.getUserById(user.getUserId()));
+		return _toUserAccount(group.getGroupId(), user);
 	}
 
 	private void _checkAssetLibraryAdminOrAssetLibraryMember(long groupId)

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -10,7 +10,6 @@ import com.liferay.headless.asset.library.resource.v1_0.UserAccountResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
-import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserTable;
@@ -26,7 +25,6 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
@@ -37,11 +35,8 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -66,7 +61,11 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		User user = _userService.getUserByExternalReferenceCode(
 			userAccountExternalReferenceCode, contextCompany.getCompanyId());
 
-		_updateUser(group.getGroupId(), user.getUserId(), false);
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			User.class.getName(), contextHttpServletRequest);
+
+		_userService.unsetGroupUsers(
+			group.getGroupId(), new long[] {user.getUserId()}, serviceContext);
 	}
 
 	@Override
@@ -111,9 +110,14 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		User user = _userService.getUserByExternalReferenceCode(
 			userAccountExternalReferenceCode, contextCompany.getCompanyId());
 
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			User.class.getName(), contextHttpServletRequest);
+
+		_userService.addGroupUsers(
+			group.getGroupId(), new long[] {user.getUserId()}, serviceContext);
+
 		return _toUserAccount(
-			group.getGroupId(),
-			_updateUser(group.getGroupId(), user.getUserId(), true));
+			group.getGroupId(), _userService.getUserById(user.getUserId()));
 	}
 
 	private void _checkAssetLibraryAdminOrAssetLibraryMember(long groupId)
@@ -189,25 +193,6 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 				keywords));
 	}
 
-	private long[] _getUserGroupIds(
-		User user, long assetLibraryId, boolean add) {
-
-		Set<Long> groupIds = new HashSet<>();
-
-		for (long groupId : user.getGroupIds()) {
-			groupIds.add(groupId);
-		}
-
-		if (add) {
-			groupIds.add(assetLibraryId);
-		}
-		else {
-			groupIds.remove(assetLibraryId);
-		}
-
-		return ArrayUtil.toLongArray(groupIds);
-	}
-
 	private OrderByComparator<User> _toOrderByComparator(Sort[] sorts) {
 		if (ArrayUtil.isEmpty(sorts)) {
 			return null;
@@ -265,37 +250,6 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			"assetLibraryId", assetLibraryId);
 
 		return _userAccountDTOConverter.toDTO(defaultDTOConverterContext);
-	}
-
-	private User _updateUser(
-			Long assetLibraryId, Long userAccountId, boolean add)
-		throws Exception {
-
-		User user = _userService.getUserById(userAccountId);
-
-		Contact contact = user.getContact();
-
-		Calendar calendar = CalendarFactoryUtil.getCalendar();
-
-		calendar.setTime(user.getBirthday());
-
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			User.class.getName(), contextHttpServletRequest);
-
-		return _userService.updateUser(
-			user.getUserId(), user.getPassword(), null, null,
-			user.isPasswordReset(), null, null, user.getScreenName(),
-			user.getEmailAddress(), user.getLanguageId(), user.getTimeZoneId(),
-			user.getGreeting(), user.getComments(), user.getFirstName(),
-			user.getMiddleName(), user.getLastName(),
-			contact.getPrefixListTypeId(), contact.getSuffixListTypeId(),
-			user.isMale(), calendar.get(Calendar.MONTH),
-			calendar.get(Calendar.DATE), calendar.get(Calendar.YEAR),
-			contact.getSmsSn(), contact.getFacebookSn(), contact.getJabberSn(),
-			contact.getSkypeSn(), contact.getTwitterSn(), user.getJobTitle(),
-			_getUserGroupIds(user, assetLibraryId, add),
-			user.getOrganizationIds(), null, null, user.getUserGroupIds(),
-			serviceContext);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -112,201 +112,11 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			roles -> roleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(), roles));
-	}
 
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
-		throws Exception {
-
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-		Page<Role> page =
-			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryMemberRole.getRoleId();
-							name = assetLibraryMemberRole.getName();
-						}
-					}
-				});
-
-		List<String> names = TransformUtil.transform(
-			page.getItems(), Role::getName);
-
-		Assert.assertEquals(names.toString(), 1, names.size());
-		Assert.assertTrue(
-			names.toString(),
-			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
-
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		_assertForbidden(
-			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				}));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
-		throws Exception {
-
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
-
-		_assertForbidden(
-			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryAdministratorRole.getRoleId();
-							name = assetLibraryAdministratorRole.getName();
-						}
-					}
-				}));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
-		throws Exception {
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-		_userGroupRoleService.addUserGroupRoles(
-			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {assetLibraryMemberRole.getRoleId()});
-
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
-
-		Page<Role> page =
-			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				});
-
-		List<String> names = TransformUtil.transform(
-			page.getItems(), Role::getName);
-
-		Assert.assertEquals(names.toString(), 1, names.size());
-		Assert.assertTrue(
-			names.toString(),
-			names.contains(DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
-		throws Exception {
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-		_userGroupRoleService.addUserGroupRoles(
-			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {assetLibraryMemberRole.getRoleId()});
-
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource();
-
-		_assertForbidden(
-			() ->
-				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
-					testDepotEntryGroup.getExternalReferenceCode(),
-					user.getExternalReferenceCode(),
-					new Role[] {
-						new Role() {
-							{
-								id =
-									assetLibraryContentReviewerRole.getRoleId();
-								name =
-									assetLibraryContentReviewerRole.getName();
-							}
-						}
-					}));
+		_testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission();
+		_testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole();
+		_testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission();
+		_testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission();
 	}
 
 	@Override
@@ -655,6 +465,197 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				roles,
 				role -> Objects.equals(
 					serviceBuilderRole2.getName(), role.getName())));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		Page<Role> page =
+			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryMemberRole.getRoleId();
+							name = assetLibraryMemberRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				}));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryAdministratorRole.getRoleId();
+							name = assetLibraryAdministratorRole.getName();
+						}
+					}
+				}));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
+
+		Page<Role> page =
+			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER));
+	}
+
+	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource();
+
+		_assertForbidden(
+			() ->
+				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+					testDepotEntryGroup.getExternalReferenceCode(),
+					user.getExternalReferenceCode(),
+					new Role[] {
+						new Role() {
+							{
+								id =
+									assetLibraryContentReviewerRole.getRoleId();
+								name =
+									assetLibraryContentReviewerRole.getName();
+							}
+						}
+					}));
 	}
 
 	private void _testPutRolesPage(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -135,18 +135,20 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	protected Role randomRole() throws Exception {
 		long roleId = RoleTestUtil.addGroupRole(testGroup.getGroupId());
 
-		com.liferay.portal.kernel.model.Role role = _roleLocalService.fetchRole(
-			roleId);
+		com.liferay.portal.kernel.model.Role serviceBuilderRole =
+			_roleLocalService.fetchRole(roleId);
 
-		_roles.add(role);
+		_roles.add(serviceBuilderRole);
 
 		return new Role() {
 			{
-				externalReferenceCode = role.getExternalReferenceCode();
-				id = role.getRoleId();
-				name = role.getName();
-				name_i18n = LocalizedMapUtil.getI18nMap(role.getTitleMap());
-				roleType = role.getType();
+				externalReferenceCode =
+					serviceBuilderRole.getExternalReferenceCode();
+				id = serviceBuilderRole.getRoleId();
+				name = serviceBuilderRole.getName();
+				name_i18n = LocalizedMapUtil.getI18nMap(
+					serviceBuilderRole.getTitleMap());
+				roleType = serviceBuilderRole.getType();
 			}
 		};
 	}
@@ -156,17 +158,18 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			String assetLibraryExternalReferenceCode, Role role)
 		throws Exception {
 
-		com.liferay.portal.kernel.model.Role depotRole = RoleTestUtil.addRole(
-			RoleConstants.TYPE_DEPOT);
+		com.liferay.portal.kernel.model.Role depotServiceBuilderRole =
+			RoleTestUtil.addRole(RoleConstants.TYPE_DEPOT);
 
-		_roles.add(depotRole);
+		_roles.add(depotServiceBuilderRole);
 
 		return new Role() {
 			{
-				externalReferenceCode = depotRole.getExternalReferenceCode();
-				id = depotRole.getRoleId();
-				name = depotRole.getName();
-				roleType = depotRole.getType();
+				externalReferenceCode =
+					depotServiceBuilderRole.getExternalReferenceCode();
+				id = depotServiceBuilderRole.getRoleId();
+				name = depotServiceBuilderRole.getName();
+				roleType = depotServiceBuilderRole.getType();
 			}
 		};
 	}
@@ -267,7 +270,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 	private RoleResource _getDepotEntryRoleResource(
 			String actionId,
-			com.liferay.portal.kernel.model.Role... viewableRoles)
+			com.liferay.portal.kernel.model.Role... viewableServiceBuilderRoles)
 		throws Exception {
 
 		String password = RandomTestUtil.randomString();
@@ -299,14 +302,14 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
-		for (com.liferay.portal.kernel.model.Role viewableRole :
-				viewableRoles) {
+		for (com.liferay.portal.kernel.model.Role viewableServiceBuilderRole :
+				viewableServiceBuilderRoles) {
 
 			_resourcePermissionLocalService.setResourcePermissions(
-				viewableRole.getCompanyId(),
+				viewableServiceBuilderRole.getCompanyId(),
 				com.liferay.portal.kernel.model.Role.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(viewableRole.getRoleId()),
+				String.valueOf(viewableServiceBuilderRole.getRoleId()),
 				serviceBuilderRole.getRoleId(), new String[] {ActionKeys.VIEW});
 		}
 
@@ -446,14 +449,15 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+		com.liferay.portal.kernel.model.Role
+			assetLibraryMemberServiceBuilderRole = _getServiceBuilderRole(
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		Page<Role> page =
 			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				_toRoles(assetLibraryMemberRole));
+				_toRoles(assetLibraryMemberServiceBuilderRole));
 
 		List<String> names = TransformUtil.transform(
 			page.getItems(), Role::getName);
@@ -463,15 +467,16 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			names.toString(),
 			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
 
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_getServiceBuilderRole(
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+		com.liferay.portal.kernel.model.Role
+			assetLibraryContentReviewerServiceBuilderRole =
+				_getServiceBuilderRole(
+					DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				_toRoles(assetLibraryContentReviewerRole)));
+				_toRoles(assetLibraryContentReviewerServiceBuilderRole)));
 	}
 
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
@@ -482,15 +487,13 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
-		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
-			_getServiceBuilderRole(
-				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
-
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				_toRoles(assetLibraryAdministratorRole)));
+				_toRoles(
+					_getServiceBuilderRole(
+						DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR))));
 	}
 
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
@@ -498,25 +501,28 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+		com.liferay.portal.kernel.model.Role
+			assetLibraryMemberServiceBuilderRole = _getServiceBuilderRole(
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {assetLibraryMemberRole.getRoleId()});
+			new long[] {assetLibraryMemberServiceBuilderRole.getRoleId()});
 
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_getServiceBuilderRole(
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+		com.liferay.portal.kernel.model.Role
+			assetLibraryContentReviewerServiceBuilderRole =
+				_getServiceBuilderRole(
+					DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
-			ActionKeys.ASSIGN_USER_ROLES, assetLibraryContentReviewerRole);
+			ActionKeys.ASSIGN_USER_ROLES,
+			assetLibraryContentReviewerServiceBuilderRole);
 
 		Page<Role> page =
 			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				_toRoles(assetLibraryContentReviewerRole));
+				_toRoles(assetLibraryContentReviewerServiceBuilderRole));
 
 		List<String> names = TransformUtil.transform(
 			page.getItems(), Role::getName);
@@ -532,16 +538,18 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
-		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+		com.liferay.portal.kernel.model.Role
+			assetLibraryMemberServiceBuilderRole = _getServiceBuilderRole(
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {assetLibraryMemberRole.getRoleId()});
+			new long[] {assetLibraryMemberServiceBuilderRole.getRoleId()});
 
-		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_getServiceBuilderRole(
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+		com.liferay.portal.kernel.model.Role
+			assetLibraryContentReviewerServiceBuilderRole =
+				_getServiceBuilderRole(
+					DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
 			ActionKeys.ASSIGN_USER_ROLES);
@@ -551,7 +559,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 					testDepotEntryGroup.getExternalReferenceCode(),
 					user.getExternalReferenceCode(),
-					_toRoles(assetLibraryContentReviewerRole)));
+					_toRoles(assetLibraryContentReviewerServiceBuilderRole)));
 	}
 
 	private void _testPutRolesPage(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -16,13 +16,17 @@ import com.liferay.headless.asset.library.client.pagination.Pagination;
 import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.headless.asset.library.client.resource.v1_0.RoleResource;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
@@ -106,6 +110,224 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			roles -> roleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(), roles));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		// A fresh member (no current roles) can be granted exactly the
+		// default Asset Library Member role by a caller holding only
+		// ASSIGN_MEMBERS, mirroring the CMS "Manage Members" UI's
+		// add-member-then-assign-default-role flow.
+
+		Page<Role> page =
+			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryMemberRole.getRoleId();
+							name = assetLibraryMemberRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		// Reassigning that same, now-existing member to a different role
+		// still requires ASSIGN_USER_ROLES; ASSIGN_MEMBERS alone is not
+		// enough once the member already holds a role.
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				}));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
+		throws Exception {
+
+		RoleResource assignMembersRoleResource =
+			_getAssignMembersRoleResource();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+
+		// Even for a fresh member, only the exact default role (Member)
+		// is covered by the ASSIGN_MEMBERS-only bypass - any other role,
+		// including Administrator, still requires ASSIGN_USER_ROLES.
+
+		_assertForbidden(
+			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryAdministratorRole.getRoleId();
+							name = assetLibraryAdministratorRole.getName();
+						}
+					}
+				}));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		// Reassigning an existing member (who already holds the default
+		// Member role) to a different role is allowed for a caller holding
+		// ASSIGN_USER_ROLES, even without ASSIGN_MEMBERS - but the caller
+		// must also hold Role-scoped VIEW on that specific role; resolving
+		// the role by name still goes through the permissioned service.
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
+
+		Page<Role> page =
+			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				user.getExternalReferenceCode(),
+				new Role[] {
+					new Role() {
+						{
+							id = assetLibraryContentReviewerRole.getRoleId();
+							name = assetLibraryContentReviewerRole.getName();
+						}
+					}
+				});
+
+		List<String> names = TransformUtil.transform(
+			page.getItems(), Role::getName);
+
+		Assert.assertEquals(names.toString(), 1, names.size());
+		Assert.assertTrue(
+			names.toString(),
+			names.contains(DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {testDepotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_userGroupRoleService.addUserGroupRoles(
+			user.getUserId(), testDepotEntry.getGroupId(),
+			new long[] {assetLibraryMemberRole.getRoleId()});
+
+		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
+			_roleLocalService.getRole(
+				testCompany.getCompanyId(),
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		// ASSIGN_USER_ROLES alone, without Role-scoped VIEW on the target
+		// role, is not enough - resolving the role by name goes through the
+		// permissioned service.
+
+		RoleResource assignUserRolesRoleResource =
+			_getAssignUserRolesRoleResource();
+
+		_assertForbidden(
+			() ->
+				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
+					testDepotEntryGroup.getExternalReferenceCode(),
+					user.getExternalReferenceCode(),
+					new Role[] {
+						new Role() {
+							{
+								id =
+									assetLibraryContentReviewerRole.getRoleId();
+								name =
+									assetLibraryContentReviewerRole.getName();
+							}
+						}
+					}));
 	}
 
 	@Override
@@ -222,6 +444,21 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		return _userGroup.getExternalReferenceCode();
 	}
 
+	private void _assertForbidden(UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
 	private void _assertRolesPage(
 			Role[] expectedRoles,
 			UnsafeSupplier<Page<Role>, Exception> unsafeSupplier)
@@ -237,6 +474,98 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		for (Role role : expectedRoles) {
 			Assert.assertTrue(items.contains(role));
 		}
+	}
+
+	private RoleResource _getAssignMembersRoleResource() throws Exception {
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_MEMBERS);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		return RoleResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private RoleResource _getAssignUserRolesRoleResource(
+			com.liferay.portal.kernel.model.Role... viewableRoles)
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_USER_ROLES);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		for (com.liferay.portal.kernel.model.Role viewableRole :
+				viewableRoles) {
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				viewableRole.getCompanyId(),
+				com.liferay.portal.kernel.model.Role.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(viewableRole.getRoleId()), role.getRoleId(),
+				new String[] {ActionKeys.VIEW});
+		}
+
+		return RoleResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private RoleResource _getRoleResource(String roleName) throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -332,12 +332,12 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			new long[] {testDepotEntry.getGroupId()},
 			ServiceContextTestUtil.getServiceContext());
 
-		com.liferay.portal.kernel.model.Role role = _roleLocalService.getRole(
-			testCompany.getCompanyId(), roleName);
+		com.liferay.portal.kernel.model.Role serviceBuilderRole =
+			_getServiceBuilderRole(roleName);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
-			new long[] {role.getRoleId()});
+			new long[] {serviceBuilderRole.getRoleId()});
 
 		return RoleResource.builder(
 		).authentication(
@@ -348,6 +348,13 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+	}
+
+	private com.liferay.portal.kernel.model.Role _getServiceBuilderRole(
+			String roleName)
+		throws Exception {
+
+		return _roleLocalService.getRole(testCompany.getCompanyId(), roleName);
 	}
 
 	private void _testGetAssetLibraryRolesPage(String roleName)
@@ -437,32 +444,16 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
 			ActionKeys.ASSIGN_MEMBERS);
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		Page<Role> page =
 			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryMemberRole.getRoleId();
-							name = assetLibraryMemberRole.getName();
-						}
-					}
-				});
+				_toRoles(assetLibraryMemberRole));
 
 		List<String> names = TransformUtil.transform(
 			page.getItems(), Role::getName);
@@ -473,22 +464,14 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				}));
+				_toRoles(assetLibraryContentReviewerRole)));
 	}
 
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
@@ -497,58 +480,33 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
 			ActionKeys.ASSIGN_MEMBERS);
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryAdministratorRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
 
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryAdministratorRole.getRoleId();
-							name = assetLibraryAdministratorRole.getName();
-						}
-					}
-				}));
+				_toRoles(assetLibraryAdministratorRole)));
 	}
 
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermission()
 		throws Exception {
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
 			new long[] {assetLibraryMemberRole.getRoleId()});
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
@@ -558,14 +516,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
-				new Role[] {
-					new Role() {
-						{
-							id = assetLibraryContentReviewerRole.getRoleId();
-							name = assetLibraryContentReviewerRole.getName();
-						}
-					}
-				});
+				_toRoles(assetLibraryContentReviewerRole));
 
 		List<String> names = TransformUtil.transform(
 			page.getItems(), Role::getName);
@@ -579,27 +530,17 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignUserRolesPermissionAndWithoutRoleViewPermission()
 		throws Exception {
 
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			new long[] {testDepotEntry.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
+		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
 		com.liferay.portal.kernel.model.Role assetLibraryMemberRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
-				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			_getServiceBuilderRole(DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		_userGroupRoleService.addUserGroupRoles(
 			user.getUserId(), testDepotEntry.getGroupId(),
 			new long[] {assetLibraryMemberRole.getRoleId()});
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
-			_roleLocalService.getRole(
-				testCompany.getCompanyId(),
+			_getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
@@ -610,16 +551,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 					testDepotEntryGroup.getExternalReferenceCode(),
 					user.getExternalReferenceCode(),
-					new Role[] {
-						new Role() {
-							{
-								id =
-									assetLibraryContentReviewerRole.getRoleId();
-								name =
-									assetLibraryContentReviewerRole.getName();
-							}
-						}
-					}));
+					_toRoles(assetLibraryContentReviewerRole)));
 	}
 
 	private void _testPutRolesPage(
@@ -657,6 +589,19 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		}
 
 		_assertRolesPage(new Role[] {randomRole1, randomRole2}, unsafeSupplier);
+	}
+
+	private Role[] _toRoles(
+		com.liferay.portal.kernel.model.Role serviceBuilderRole) {
+
+		return new Role[] {
+			new Role() {
+				{
+					id = serviceBuilderRole.getRoleId();
+					name = serviceBuilderRole.getName();
+				}
+			}
+		};
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -88,7 +88,9 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			testDepotEntry.getGroupId(), _userGroup);
 	}
 
-	@FeatureFlags(featureFlags = @FeatureFlag("LPD-58677"))
+	@FeatureFlags(
+		featureFlags = {@FeatureFlag("LPD-58677"), @FeatureFlag("LPD-96750")}
+	)
 	@Override
 	@Test
 	public void testGetAssetLibraryRolesPage() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -236,7 +236,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		return _userGroup.getExternalReferenceCode();
 	}
 
-	private void _assertForbidden(UnsafeRunnable<Exception> unsafeRunnable)
+	private void _assertProblemStatus(
+			String status, UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -247,7 +248,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+			Assert.assertEquals(status, problem.getStatus());
 		}
 	}
 
@@ -472,7 +473,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				_getServiceBuilderRole(
 					DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
-		_assertForbidden(
+		_assertProblemStatus(
+			"FORBIDDEN",
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
@@ -487,7 +489,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		User user = UserTestUtil.addUser(testDepotEntry.getGroupId());
 
-		_assertForbidden(
+		_assertProblemStatus(
+			"FORBIDDEN",
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
@@ -554,7 +557,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
 			ActionKeys.ASSIGN_USER_ROLES);
 
-		_assertForbidden(
+		_assertProblemStatus(
+			"FORBIDDEN",
 			() ->
 				assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 					testDepotEntryGroup.getExternalReferenceCode(),
@@ -585,16 +589,9 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			}
 		};
 
-		try {
-			unsafeBiConsumer.accept(new Role[] {randomRole3});
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-		}
+		_assertProblemStatus(
+			"NOT_FOUND",
+			() -> unsafeBiConsumer.accept(new Role[] {randomRole3}));
 
 		_assertRolesPage(new Role[] {randomRole1, randomRole2}, unsafeSupplier);
 	}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -135,11 +135,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
-		// A fresh member (no current roles) can be granted exactly the
-		// default Asset Library Member role by a caller holding only
-		// ASSIGN_MEMBERS, mirroring the CMS "Manage Members" UI's
-		// add-member-then-assign-default-role flow.
-
 		Page<Role> page =
 			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
@@ -160,10 +155,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		Assert.assertTrue(
 			names.toString(),
 			names.contains(DepotRolesConstants.ASSET_LIBRARY_MEMBER));
-
-		// Reassigning that same, now-existing member to a different role
-		// still requires ASSIGN_USER_ROLES; ASSIGN_MEMBERS alone is not
-		// enough once the member already holds a role.
 
 		com.liferay.portal.kernel.model.Role assetLibraryContentReviewerRole =
 			_roleLocalService.getRole(
@@ -205,10 +196,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
 
-		// Even for a fresh member, only the exact default role (Member)
-		// is covered by the ASSIGN_MEMBERS-only bypass - any other role,
-		// including Administrator, still requires ASSIGN_USER_ROLES.
-
 		_assertForbidden(
 			() -> assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
@@ -249,12 +236,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			_roleLocalService.getRole(
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		// Reassigning an existing member (who already holds the default
-		// Member role) to a different role is allowed for a caller holding
-		// ASSIGN_USER_ROLES, even without ASSIGN_MEMBERS - but the caller
-		// must also hold Role-scoped VIEW on that specific role; resolving
-		// the role by name still goes through the permissioned service.
 
 		RoleResource assignUserRolesRoleResource =
 			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
@@ -307,10 +288,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			_roleLocalService.getRole(
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
-
-		// ASSIGN_USER_ROLES alone, without Role-scoped VIEW on the target
-		// role, is not enough - resolving the role by name goes through the
-		// permissioned service.
 
 		RoleResource assignUserRolesRoleResource =
 			_getAssignUserRolesRoleResource();

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -366,12 +366,12 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		RoleResource roleResource = _getRoleResource(roleName);
 
-		Page<Role> page = roleResource.getAssetLibraryRolesPage(
+		Page<Role> rolesPage = roleResource.getAssetLibraryRolesPage(
 			testDepotEntryGroup.getExternalReferenceCode(),
 			Pagination.of(1, 10));
 
 		List<String> names = TransformUtil.transform(
-			page.getItems(), Role::getName);
+			rolesPage.getItems(), Role::getName);
 
 		Assert.assertTrue(
 			names.toString(),
@@ -416,10 +416,10 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		Group group = _depotEntry.getGroup();
 
-		Page<Role> page = roleResource.getAssetLibraryRolesPage(
+		Page<Role> rolesPage = roleResource.getAssetLibraryRolesPage(
 			group.getExternalReferenceCode(), Pagination.of(1, 100));
 
-		List<Role> roles = ListUtil.fromCollection(page.getItems());
+		List<Role> roles = ListUtil.fromCollection(rolesPage.getItems());
 
 		Assert.assertTrue(
 			roles.toString(),
@@ -454,14 +454,14 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			assetLibraryMemberServiceBuilderRole = _getServiceBuilderRole(
 				DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
-		Page<Role> page =
+		Page<Role> rolesPage =
 			assignMembersRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
 				_toRoles(assetLibraryMemberServiceBuilderRole));
 
 		List<String> names = TransformUtil.transform(
-			page.getItems(), Role::getName);
+			rolesPage.getItems(), Role::getName);
 
 		Assert.assertEquals(names.toString(), 1, names.size());
 		Assert.assertTrue(
@@ -521,14 +521,14 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			ActionKeys.ASSIGN_USER_ROLES,
 			assetLibraryContentReviewerServiceBuilderRole);
 
-		Page<Role> page =
+		Page<Role> rolesPage =
 			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				user.getExternalReferenceCode(),
 				_toRoles(assetLibraryContentReviewerServiceBuilderRole));
 
 		List<String> names = TransformUtil.transform(
-			page.getItems(), Role::getName);
+			rolesPage.getItems(), Role::getName);
 
 		Assert.assertEquals(names.toString(), 1, names.size());
 		Assert.assertTrue(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -265,46 +265,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		}
 	}
 
-	private RoleResource _getAssignMembersRoleResource() throws Exception {
-		String password = RandomTestUtil.randomString();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			password, RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
-			ServiceContextTestUtil.getServiceContext());
-
-		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
-			RoleConstants.TYPE_REGULAR);
-
-		_roles.add(role);
-
-		_userLocalService.addRoleUser(role.getRoleId(), user);
-
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()),
-			ActionKeys.ASSIGN_MEMBERS);
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
-		RoleTestUtil.addResourcePermission(
-			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
-			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
-
-		return RoleResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
-	}
-
-	private RoleResource _getAssignUserRolesRoleResource(
+	private RoleResource _getDepotEntryRoleResource(
+			String actionId,
 			com.liferay.portal.kernel.model.Role... viewableRoles)
 		throws Exception {
 
@@ -326,8 +288,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 		RoleTestUtil.addResourcePermission(
 			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()),
-			ActionKeys.ASSIGN_USER_ROLES);
+			String.valueOf(testDepotEntry.getGroupId()), actionId);
 		RoleTestUtil.addResourcePermission(
 			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
 			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
@@ -470,8 +431,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermission()
 		throws Exception {
 
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
+		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_MEMBERS);
 
 		User user = UserTestUtil.addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
@@ -530,8 +491,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	private void _testPutAssetLibraryUserAccountRolesPageWithAssignMembersPermissionAndAdministratorRole()
 		throws Exception {
 
-		RoleResource assignMembersRoleResource =
-			_getAssignMembersRoleResource();
+		RoleResource assignMembersRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_MEMBERS);
 
 		User user = UserTestUtil.addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
@@ -587,8 +548,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource(assetLibraryContentReviewerRole);
+		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_USER_ROLES, assetLibraryContentReviewerRole);
 
 		Page<Role> page =
 			assignUserRolesRoleResource.putAssetLibraryUserAccountRolesPage(
@@ -638,8 +599,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				testCompany.getCompanyId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
-		RoleResource assignUserRolesRoleResource =
-			_getAssignUserRolesRoleResource();
+		RoleResource assignUserRolesRoleResource = _getDepotEntryRoleResource(
+			ActionKeys.ASSIGN_USER_ROLES);
 
 		_assertForbidden(
 			() ->

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -279,21 +279,24 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
 			ServiceContextTestUtil.getServiceContext());
 
-		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
-			RoleConstants.TYPE_REGULAR);
+		com.liferay.portal.kernel.model.Role serviceBuilderRole =
+			RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		_roles.add(role);
+		_roles.add(serviceBuilderRole);
 
-		_userLocalService.addRoleUser(role.getRoleId(), user);
+		_userLocalService.addRoleUser(serviceBuilderRole.getRoleId(), user);
 
 		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			serviceBuilderRole, DepotEntry.class.getName(),
+			ResourceConstants.SCOPE_GROUP,
 			String.valueOf(testDepotEntry.getGroupId()), actionId);
 		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			serviceBuilderRole, DepotEntry.class.getName(),
+			ResourceConstants.SCOPE_GROUP,
 			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
 		RoleTestUtil.addResourcePermission(
-			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			serviceBuilderRole, User.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
 		for (com.liferay.portal.kernel.model.Role viewableRole :
@@ -303,8 +306,8 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 				viewableRole.getCompanyId(),
 				com.liferay.portal.kernel.model.Role.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(viewableRole.getRoleId()), role.getRoleId(),
-				new String[] {ActionKeys.VIEW});
+				String.valueOf(viewableRole.getRoleId()),
+				serviceBuilderRole.getRoleId(), new String[] {ActionKeys.VIEW});
 		}
 
 		return RoleResource.builder(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/RoleResourceTest.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
@@ -338,7 +338,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		for (com.liferay.portal.kernel.model.Role viewableRole :
 				viewableRoles) {
 
-			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+			_resourcePermissionLocalService.setResourcePermissions(
 				viewableRole.getCompanyId(),
 				com.liferay.portal.kernel.model.Role.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -703,6 +703,9 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@Inject
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -361,7 +361,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
-		List<String> actionIds = ResourceActionsUtil.getModelResourceActions(
+		List<String> actionIds = _resourceActions.getModelResourceActions(
 			DepotEntry.class.getName());
 
 		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
@@ -498,6 +498,9 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		assertValid(putUserAccount);
 	}
+
+	@Inject
+	private ResourceActions _resourceActions;
 
 	@Inject
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -365,18 +365,24 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
 		throws Exception {
 
-		UserAccountResource viewAndAssignMembersUserAccountResource =
-			_getViewAndAssignMembersUserAccountResource();
-
 		UserAccount userAccount = randomUserAccount();
 
 		userAccountResource.putAssetLibraryUserAccount(
 			testDepotEntryGroup.getExternalReferenceCode(),
 			userAccount.getExternalReferenceCode());
 
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
 		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
 			testDepotEntryGroup.getExternalReferenceCode(),
 			userAccount.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(
+			404,
+			userAccountResource.getAssetLibraryUserAccountHttpResponse(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				userAccount.getExternalReferenceCode()));
 	}
 
 	private void _testGetAssetLibraryUserAccount(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -95,7 +95,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testDeleteAssetLibraryUserAccount() throws Exception {
 		super.testDeleteAssetLibraryUserAccount();
 
-		_testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission();
+		_testDeleteAssetLibraryUserAccountWithAssignMembersAndViewPermission();
 	}
 
 	@Override
@@ -146,8 +146,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testPutAssetLibraryUserAccount() throws Exception {
 		super.testPutAssetLibraryUserAccount();
 
+		_testPutAssetLibraryUserAccountWithAssignMembersAndViewPermission();
 		_testPutAssetLibraryUserAccountWithoutAssignMembersPermission();
-		_testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission();
 	}
 
 	@Override
@@ -230,15 +230,9 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_testUser.getExternalReferenceCode());
 	}
 
-	private void _assertFailure(
-		String message, UnsafeRunnable<Exception> unsafeRunnable) {
-
-		AssertUtils.assertFailure(
-			Problem.ProblemException.class, message, unsafeRunnable);
-	}
-
 	private void _assertFailure(UnsafeRunnable<Exception> unsafeRunnable) {
-		_assertFailure(null, unsafeRunnable);
+		AssertUtils.assertFailure(
+			Problem.ProblemException.class, null, unsafeRunnable);
 	}
 
 	private UserAccountResource _getAssetLibraryMemberUserAccountResource(
@@ -343,26 +337,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		return group.getExternalReferenceCode();
 	}
 
-	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
-		throws Exception {
-
-		return _getDepotEntryUserAccountResource(
-			List.of(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
-	}
-
-	private UserAccountResource
-			_getWithoutAssignMembersPermissionUserAccountResource()
-		throws Exception {
-
-		List<String> actionIds = _resourceActions.getModelResourceActions(
-			DepotEntry.class.getName());
-
-		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
-
-		return _getDepotEntryUserAccountResource(actionIds);
-	}
-
-	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+	private void _testDeleteAssetLibraryUserAccountWithAssignMembersAndViewPermission()
 		throws Exception {
 
 		UserAccount userAccount = randomUserAccount();
@@ -371,10 +346,11 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			testDepotEntryGroup.getExternalReferenceCode(),
 			userAccount.getExternalReferenceCode());
 
-		UserAccountResource viewAndAssignMembersUserAccountResource =
-			_getViewAndAssignMembersUserAccountResource();
+		UserAccountResource assignMembersAndViewUserAccountResource =
+			_getDepotEntryUserAccountResource(
+				List.of(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
 
-		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
+		assignMembersAndViewUserAccountResource.deleteAssetLibraryUserAccount(
 			testDepotEntryGroup.getExternalReferenceCode(),
 			userAccount.getExternalReferenceCode());
 
@@ -451,37 +427,43 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			});
 	}
 
-	private void _testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
+	private void _testPutAssetLibraryUserAccountWithAssignMembersAndViewPermission()
 		throws Exception {
 
-		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
-			_getWithoutAssignMembersPermissionUserAccountResource();
-
-		UserAccount userAccount = randomUserAccount();
-
-		_assertFailure(
-			"Forbidden",
-			() ->
-				withoutAssignMembersPermissionUserAccountResource.
-					putAssetLibraryUserAccount(
-						testDepotEntryGroup.getExternalReferenceCode(),
-						userAccount.getExternalReferenceCode()));
-	}
-
-	private void _testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
-		throws Exception {
-
-		UserAccountResource viewAndAssignMembersUserAccountResource =
-			_getViewAndAssignMembersUserAccountResource();
+		UserAccountResource assignMembersAndViewUserAccountResource =
+			_getDepotEntryUserAccountResource(
+				List.of(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
 
 		UserAccount userAccount = randomUserAccount();
 
 		UserAccount putUserAccount =
-			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
+			assignMembersAndViewUserAccountResource.putAssetLibraryUserAccount(
 				testDepotEntryGroup.getExternalReferenceCode(),
 				userAccount.getExternalReferenceCode());
 
 		assertValid(putUserAccount);
+	}
+
+	private void _testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
+		throws Exception {
+
+		List<String> actionIds = _resourceActions.getModelResourceActions(
+			DepotEntry.class.getName());
+
+		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
+
+		UserAccountResource withoutAssignMembersUserAccountResource =
+			_getDepotEntryUserAccountResource(actionIds);
+
+		UserAccount userAccount = randomUserAccount();
+
+		AssertUtils.assertFailure(
+			Problem.ProblemException.class, "Forbidden",
+			() ->
+				withoutAssignMembersUserAccountResource.
+					putAssetLibraryUserAccount(
+						testDepotEntryGroup.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode()));
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -16,9 +16,12 @@ import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.headless.asset.library.client.resource.v1_0.UserAccountResource;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -87,6 +90,24 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testBatchEngineDeleteImportTask() {
 	}
 
+	@Test
+	public void testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		userAccountResource.putAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+
+		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+	}
+
 	@Override
 	@Test
 	public void testGetAssetLibraryUserAccount() throws Exception {
@@ -128,6 +149,41 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_spaceDepotEntry.getGroup(), cmsAdministratorUserAccountResource);
 
 		_testGetAssetLibraryUserAccountsPageWithSortId();
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
+			_getWithoutAssignMembersPermissionUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		_assertFailure(
+			"Forbidden",
+			() ->
+				withoutAssignMembersPermissionUserAccountResource.
+					putAssetLibraryUserAccount(
+						testDepotEntryGroup.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode()));
+	}
+
+	@Test
+	public void testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		UserAccount putUserAccount =
+			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				userAccount.getExternalReferenceCode());
+
+		assertValid(putUserAccount);
 	}
 
 	@Override
@@ -210,9 +266,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_testUser.getExternalReferenceCode());
 	}
 
-	private void _assertFailure(UnsafeRunnable<Exception> unsafeRunnable) {
+	private void _assertFailure(
+		String message, UnsafeRunnable<Exception> unsafeRunnable) {
+
 		AssertUtils.assertFailure(
-			Problem.ProblemException.class, null, unsafeRunnable);
+			Problem.ProblemException.class, message, unsafeRunnable);
+	}
+
+	private void _assertFailure(UnsafeRunnable<Exception> unsafeRunnable) {
+		_assertFailure(null, unsafeRunnable);
 	}
 
 	private UserAccountResource _getAssetLibraryMemberUserAccountResource(
@@ -274,6 +336,87 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		Group group = testDepotEntry.getGroup();
 
 		return group.getExternalReferenceCode();
+	}
+
+	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()),
+			ActionKeys.ASSIGN_MEMBERS);
+		RoleTestUtil.addResourcePermission(
+			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		return UserAccountResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private UserAccountResource
+			_getWithoutAssignMembersPermissionUserAccountResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		RoleTestUtil.addResourcePermission(
+			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		List<String> actionIds = ResourceActionsUtil.getModelResourceActions(
+			DepotEntry.class.getName());
+
+		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
+
+		for (String actionId : actionIds) {
+			RoleTestUtil.addResourcePermission(
+				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+				String.valueOf(testDepotEntry.getGroupId()), actionId);
+		}
+
+		return UserAccountResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetAssetLibraryUserAccount(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -302,7 +302,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		return group.getExternalReferenceCode();
 	}
 
-	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
+	private UserAccountResource _getUserAccountResource(List<String> actionIds)
 		throws Exception {
 
 		String password = RandomTestUtil.randomString();
@@ -318,13 +318,12 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		_userLocalService.addRoleUser(role.getRoleId(), user);
 
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()),
-			ActionKeys.ASSIGN_MEMBERS);
-		RoleTestUtil.addResourcePermission(
-			role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-			String.valueOf(testDepotEntry.getGroupId()), ActionKeys.VIEW);
+		for (String actionId : actionIds) {
+			RoleTestUtil.addResourcePermission(
+				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+				String.valueOf(testDepotEntry.getGroupId()), actionId);
+		}
+
 		RoleTestUtil.addResourcePermission(
 			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
@@ -340,47 +339,23 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
+	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
+		throws Exception {
+
+		return _getUserAccountResource(
+			List.of(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
+	}
+
 	private UserAccountResource
 			_getWithoutAssignMembersPermissionUserAccountResource()
 		throws Exception {
-
-		String password = RandomTestUtil.randomString();
-
-		User user = UserTestUtil.addUser(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			password, RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
-			ServiceContextTestUtil.getServiceContext());
-
-		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
-
-		_userLocalService.addRoleUser(role.getRoleId(), user);
-
-		RoleTestUtil.addResourcePermission(
-			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
-			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
 		List<String> actionIds = _resourceActions.getModelResourceActions(
 			DepotEntry.class.getName());
 
 		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
 
-		for (String actionId : actionIds) {
-			RoleTestUtil.addResourcePermission(
-				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
-				String.valueOf(testDepotEntry.getGroupId()), actionId);
-		}
-
-		return UserAccountResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
+		return _getUserAccountResource(actionIds);
 	}
 
 	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -90,22 +90,12 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testBatchEngineDeleteImportTask() {
 	}
 
+	@Override
 	@Test
-	public void testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
-		throws Exception {
+	public void testDeleteAssetLibraryUserAccount() throws Exception {
+		super.testDeleteAssetLibraryUserAccount();
 
-		UserAccountResource viewAndAssignMembersUserAccountResource =
-			_getViewAndAssignMembersUserAccountResource();
-
-		UserAccount userAccount = randomUserAccount();
-
-		userAccountResource.putAssetLibraryUserAccount(
-			testDepotEntryGroup.getExternalReferenceCode(),
-			userAccount.getExternalReferenceCode());
-
-		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
-			testDepotEntryGroup.getExternalReferenceCode(),
-			userAccount.getExternalReferenceCode());
+		_testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission();
 	}
 
 	@Override
@@ -151,39 +141,13 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		_testGetAssetLibraryUserAccountsPageWithSortId();
 	}
 
+	@Override
 	@Test
-	public void testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
-		throws Exception {
+	public void testPutAssetLibraryUserAccount() throws Exception {
+		super.testPutAssetLibraryUserAccount();
 
-		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
-			_getWithoutAssignMembersPermissionUserAccountResource();
-
-		UserAccount userAccount = randomUserAccount();
-
-		_assertFailure(
-			"Forbidden",
-			() ->
-				withoutAssignMembersPermissionUserAccountResource.
-					putAssetLibraryUserAccount(
-						testDepotEntryGroup.getExternalReferenceCode(),
-						userAccount.getExternalReferenceCode()));
-	}
-
-	@Test
-	public void testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
-		throws Exception {
-
-		UserAccountResource viewAndAssignMembersUserAccountResource =
-			_getViewAndAssignMembersUserAccountResource();
-
-		UserAccount userAccount = randomUserAccount();
-
-		UserAccount putUserAccount =
-			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				userAccount.getExternalReferenceCode());
-
-		assertValid(putUserAccount);
+		_testPutAssetLibraryUserAccountWithoutAssignMembersPermission();
+		_testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission();
 	}
 
 	@Override
@@ -419,6 +383,23 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
+	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		userAccountResource.putAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+
+		viewAndAssignMembersUserAccountResource.deleteAssetLibraryUserAccount(
+			testDepotEntryGroup.getExternalReferenceCode(),
+			userAccount.getExternalReferenceCode());
+	}
+
 	private void _testGetAssetLibraryUserAccount(
 			Group group, UserAccountResource getUserAccountResource)
 		throws Exception {
@@ -483,6 +464,39 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			EntityField.Type.ID,
 			(entityField, userAccount1, userAccount2) -> {
 			});
+	}
+
+	private void _testPutAssetLibraryUserAccountWithoutAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource withoutAssignMembersPermissionUserAccountResource =
+			_getWithoutAssignMembersPermissionUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		_assertFailure(
+			"Forbidden",
+			() ->
+				withoutAssignMembersPermissionUserAccountResource.
+					putAssetLibraryUserAccount(
+						testDepotEntryGroup.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode()));
+	}
+
+	private void _testPutAssetLibraryUserAccountWithViewAndAssignMembersPermission()
+		throws Exception {
+
+		UserAccountResource viewAndAssignMembersUserAccountResource =
+			_getViewAndAssignMembersUserAccountResource();
+
+		UserAccount userAccount = randomUserAccount();
+
+		UserAccount putUserAccount =
+			viewAndAssignMembersUserAccountResource.putAssetLibraryUserAccount(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				userAccount.getExternalReferenceCode());
+
+		assertValid(putUserAccount);
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
-import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
@@ -468,9 +467,6 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Inject
 	private ResourceActions _resourceActions;
-
-	@Inject
-	private RoleLocalService _roleLocalService;
 
 	private DepotEntry _spaceDepotEntry;
 	private User _testUser;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -280,10 +280,10 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
 			ServiceContextTestUtil.getServiceContext());
 
-		Role role = RoleTestUtil.addRole(
+		Role serviceBuilderRole = RoleTestUtil.addRole(
 			RoleConstants.CMS_ADMINISTRATOR, RoleConstants.TYPE_REGULAR);
 
-		_userLocalService.addRoleUser(role.getRoleId(), user);
+		_userLocalService.addRoleUser(serviceBuilderRole.getRoleId(), user);
 
 		return UserAccountResource.builder(
 		).authentication(
@@ -309,18 +309,21 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
 			ServiceContextTestUtil.getServiceContext());
 
-		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+		Role serviceBuilderRole = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
 
-		_userLocalService.addRoleUser(role.getRoleId(), user);
+		_userLocalService.addRoleUser(serviceBuilderRole.getRoleId(), user);
 
 		for (String actionId : actionIds) {
 			RoleTestUtil.addResourcePermission(
-				role, DepotEntry.class.getName(), ResourceConstants.SCOPE_GROUP,
+				serviceBuilderRole, DepotEntry.class.getName(),
+				ResourceConstants.SCOPE_GROUP,
 				String.valueOf(testDepotEntry.getGroupId()), actionId);
 		}
 
 		RoleTestUtil.addResourcePermission(
-			role, User.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			serviceBuilderRole, User.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
 
 		return UserAccountResource.builder(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -296,13 +296,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
-	private String _getGroupExternalReferenceCode() throws Exception {
-		Group group = testDepotEntry.getGroup();
-
-		return group.getExternalReferenceCode();
-	}
-
-	private UserAccountResource _getUserAccountResource(List<String> actionIds)
+	private UserAccountResource _getDepotEntryUserAccountResource(
+			List<String> actionIds)
 		throws Exception {
 
 		String password = RandomTestUtil.randomString();
@@ -339,10 +334,16 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		).build();
 	}
 
+	private String _getGroupExternalReferenceCode() throws Exception {
+		Group group = testDepotEntry.getGroup();
+
+		return group.getExternalReferenceCode();
+	}
+
 	private UserAccountResource _getViewAndAssignMembersUserAccountResource()
 		throws Exception {
 
-		return _getUserAccountResource(
+		return _getDepotEntryUserAccountResource(
 			List.of(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
 	}
 
@@ -355,7 +356,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		actionIds.remove(ActionKeys.ASSIGN_MEMBERS);
 
-		return _getUserAccountResource(actionIds);
+		return _getDepotEntryUserAccountResource(actionIds);
 	}
 
 	private void _testDeleteAssetLibraryUserAccountWithViewAndAssignMembersPermission()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98407

Supersedes #8745 by @jkappler, which superseded #8697 by @janbrychtadotcom. Their commits are carried here unchanged, including @brianchandotcom's own, with follow-up commits stacked on top addressing his review on brianchandotcom#179781.

## What Is Being Fixed

Adding or removing a member from a CMS Space (asset library group) routed through a private helper that performed a full `UserService.updateUser(...)` re-save of the entire user profile just to change one group ID. `UserService.updateUser` unconditionally requires `UPDATE` permission on the target `User` before it even inspects the group list, an extra requirement beyond the `ASSIGN_MEMBERS` permission on `Group` that the resource's own action flags advertise. Only depot Group admins bypassed this, forcing every other admin to be granted `UPDATE` on `User`, a much broader privilege, just to manage Space membership.

Separately, adding a member to a Space is immediately followed by assigning that member's default role through `putAssetLibraryUserAccountRolesPage`. That call went straight to the permissioned `UserGroupRoleService`, which requires `ASSIGN_USER_ROLES` on the group, so a Space Administrator holding only `ASSIGN_MEMBERS` could add a member but then fail to set their role.

## How It Is Being Fixed

The full-profile update is replaced with `UserService.addGroupUsers` and `UserService.unsetGroupUsers`, which gate on `ASSIGN_MEMBERS` on `Group`, matching what classic Site Membership management already does. `VIEW` on the `Group` and on the target `User` are still required.

For role assignment, only one case bypasses the standard permission checks: the CMS Manage Members flow of adding a brand new member and then, in a separate call, assigning them the space's fixed default role. Without it a caller holding only `ASSIGN_MEMBERS` ends up with a half-succeeded add, with no way to recover from the UI. That case is handled narrowly: only for a user who holds no roles yet, and only for that exact default role. Every other assignment goes through the original permissioned `UserGroupRoleService` path unchanged.

## Follow-Up Commits

`Inject the group model resource permission instead of using the static utility` replaces `GroupPermissionUtil`, which appears nowhere else in `headless-asset-library`, with the injected `ModelResourcePermission<Group>` every sibling resource in the module already uses, and reshapes the guard to match its sibling directly above it.

`Reuse the fetched user account instead of reading it back` drops a `getUserById` refetch of the user already in hand; `_toUserAccount` reads only `getGroupId` and `getUserId`, neither of which `addGroupUsers` changes.

`Simplify the default role assignment check` uses `ListUtil.isNotEmpty` and drops a null-safe `Objects.equals` around a constant that cannot be null.

`Name the Service Builder role local by convention`, `Name the Service Builder role locals by convention` and `Name the roles page after the method that returns it` apply @brianchandotcom's review on brianchandotcom#179781 across every remaining occurrence, so each kernel `Role` identifier in both files follows one convention.

`Name the permission check after every action it accepts` renames a check that also accepts `ASSIGN_USER_ROLES` but did not say so.

`Assert the problem status through one helper` folds a duplicated try/catch/assert block into a single helper. `Assert that the deleted user account is gone` adds the missing assertion to a scenario that only proved no exception was thrown. `Inline the single caller test helpers` and `Remove the unused role local service` drop members that no longer earn their place.

## Test Execution

```
gradlew -p modules/apps/headless/headless-asset-library/headless-asset-library-test testIntegration
```

The whole module was run, not only the two changed classes: 69 passed, 3 skipped, 1 failed. The lone failure is `AssetLibraryResourceTest.testPatchAssetLibrary`, which reproduces identically on a clean `master` with none of this branch applied, so it is not caused by this change.

`RoleResourceTest` 10 passed, `UserAccountResourceTest` 12 passed and 1 skipped.

## PR Check

**pr-check: PASS** — tested on `dcea5604cf40199f711858bae9c08433ae0a2ae0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

Java Unit Tests matched the diff but had nothing to run: neither `headless-asset-library-impl` nor `headless-asset-library-test` has a `src/test/java` tree, so the row is omitted rather than recorded as a trivial pass.

<!-- pr-check {"result": "success", "sha": "dcea5604cf40199f711858bae9c08433ae0a2ae0"} -->
