### PR TITLE
LPD-101211 Keep Space creation working when there is no principal

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
@@ -82,6 +83,7 @@ public class DepotEntryLocalServiceTest {
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Test
+	@TestInfo("LPD-101211")
 	public void testAddDepotEntry() throws Exception {
 		_assertCMSDefaultPermissions(
 			_addDepotEntry(DepotConstants.TYPE_ASSET_LIBRARY));
@@ -90,6 +92,8 @@ public class DepotEntryLocalServiceTest {
 			_addStagedDepotEntry(DepotConstants.TYPE_ASSET_LIBRARY));
 		_assertCMSDefaultPermissions(
 			_addStagedDepotEntry(DepotConstants.TYPE_SPACE));
+
+		_assertGroupCreatorUserId();
 
 		_assertObjectEntryFolders(
 			_addDepotEntry(DepotConstants.TYPE_ASSET_LIBRARY), 0);
@@ -357,6 +361,26 @@ public class DepotEntryLocalServiceTest {
 			new String[] {ActionKeys.VIEW, ActionKeys.SUBSCRIBE},
 			JSONUtil.toStringArray(
 				jsonObject2.getJSONArray(RoleConstants.USER)));
+	}
+
+	private void _assertGroupCreatorUserId() throws Exception {
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(null);
+
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_assertObjectEntryFolders(depotEntry, 2);
+
+		Group group = depotEntry.getGroup();
+
+		Repository repository = _repositoryLocalService.fetchRepository(
+			group.getGroupId(), TempFileEntryUtil.class.getName(),
+			TempFileEntryUtil.class.getName());
+
+		Assert.assertEquals(group.getCreatorUserId(), repository.getUserId());
+
+		PrincipalThreadLocal.setName(name);
 	}
 
 	private void _assertObjectEntryFolders(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -126,7 +125,7 @@ public class ObjectEntryFolderUtil {
 		attachmentManager.getDLFolder(
 			objectDefinition.getCompanyId(), group.getGroupId(),
 			objectDefinition.getPortletId(), serviceContext,
-			PrincipalThreadLocal.getUserId());
+			group.getCreatorUserId());
 
 		try (SafeCloseable safeCloseable =
 				DLAppHelperThreadLocal.setEnabledWithSafeCloseable(false)) {
@@ -140,7 +139,7 @@ public class ObjectEntryFolderUtil {
 			}
 
 			RepositoryLocalServiceUtil.addRepository(
-				null, PrincipalThreadLocal.getUserId(), group.getGroupId(),
+				null, group.getCreatorUserId(), group.getGroupId(),
 				PortalUtil.getClassNameId(
 					TemporaryFileEntryRepository.class.getName()),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintScopeContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintScopeContributorTest.java
@@ -160,7 +160,7 @@ public class SXPBlueprintScopeContributorTest {
 	public void testSpaceScope() throws Exception {
 		_configureSXPBlueprint(_spaceGroup.getExternalReferenceCode());
 
-		_assertSearch(ListUtil.toList(_SPACE_TITLE));
+		_assertSearch(Arrays.asList("contents", "files", _SPACE_TITLE));
 	}
 
 	private static DepotEntry _addDepotEntry(int type) throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101211

Supersedes #8758, whose forward brianchandotcom#179846 was closed on review. Same fix, with the two review items applied.

## What Is Being Fixed

Creating a CMS Space failed when there was no principal in `PrincipalThreadLocal`. `ObjectEntryFolderUtil` read the owner of the Space's default object entry folders and of its temporary file repository from `PrincipalThreadLocal.getUserId()`, which is unset in that situation, so the folders and the repository ended up owned by nobody.

## How It Is Being Fixed

Both reads now take the owner from `group.getCreatorUserId()`, which is always populated for the group being initialized. That is the whole production change, two lines.

## Review Feedback

@brianchandotcom asked for two changes on brianchandotcom#179846, both applied to the commit that introduced the code rather than added on top.

The two constants `SXPBlueprintScopeContributorTest` declared for the folder titles are gone: each was referenced exactly once, so the titles are now inlined at that single reference and `testSpaceScope` reads `_assertSearch(Arrays.asList("contents", "files", _SPACE_TITLE))`. The remaining `_SPACE_TITLE` earns its declaration by naming the value the test both writes and expects back.

`DepotEntryLocalServiceTest._assertGroupCreatorUserId` no longer wraps its body in a `try` block: the principal is cleared, the assertions run, and the principal is restored on the last line. The diff matches the one in the review comment.

## Test Execution

```
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests DepotEntryLocalServiceTest
gradlew -p modules/dxp/apps/search-experiences/search-experiences-test testIntegration --tests SXPBlueprintScopeContributorTest
```

`DepotEntryLocalServiceTest` 3 passed, `SXPBlueprintScopeContributorTest` 5 passed, 0 failures, run on `3a896a61dbcde` against a bundle rebuilt from this branch with `ant all`. The review items are the only change since that run. They inline two constants and drop a `try` block, so they leave the setup and the assertions of both tests as they were exercised, and the integration test sources of both modules still compile.

## PR Check

**pr-check: PASS** — tested on `b5a234cd3fa4c4e139599021a055f1f5bab17649`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

Source Format and Integration Test Compile were rerun on this head. The remaining three carry over from the run on `3a896a61dbcde`, which shares this base and differs only in the two `src/testIntegration` files the review touched.

Cross-Module Compile matched on `ObjectEntryFolderUtil.java`, but the class lives in a package the module does not export and its only consumer is a class in the same module, so Per-Module Compile already covers it.

Java Unit Tests matched the diff but had nothing to run: `site-cms-site-initializer` has a `src/test/java` tree with no counterpart for `ObjectEntryFolderUtil`, and neither test module has one at all.

<!-- pr-check {"result": "success", "sha": "b5a234cd3fa4c4e139599021a055f1f5bab17649"} -->
