### PR TITLE
LPD-98561 Disable personal pages for Standalone CMS companies

### DIFF
--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/instance/lifecycle/CMSPortalInstanceLifecycleListener.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/instance/lifecycle/CMSPortalInstanceLifecycleListener.java
@@ -11,6 +11,11 @@ import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.portlet.PortletPreferences;
 
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -40,6 +45,35 @@ public class CMSPortalInstanceLifecycleListener
 			).put(
 				"restEnabled", false
 			).build());
+
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			company.getCompanyId());
+
+		boolean modified = false;
+
+		if (Validator.isNull(
+				portletPreferences.getValue(
+					PropsKeys.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED, null))) {
+
+			portletPreferences.setValue(
+				PropsKeys.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED, "false");
+
+			modified = true;
+		}
+
+		if (Validator.isNull(
+				portletPreferences.getValue(
+					PropsKeys.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED, null))) {
+
+			portletPreferences.setValue(
+				PropsKeys.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED, "false");
+
+			modified = true;
+		}
+
+		if (modified) {
+			portletPreferences.store();
+		}
 	}
 
 	@Reference

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/test/java/com/liferay/site/cms/standalone/site/initializer/internal/instance/lifecycle/CMSPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/test/java/com/liferay/site/cms/standalone/site/initializer/internal/instance/lifecycle/CMSPortalInstanceLifecycleListenerTest.java
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.instance.lifecycle;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.util.PrefsProps;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Jan Brychta
+ */
+public class CMSPortalInstanceLifecycleListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-98561")
+	public void testPortalInstanceRegisteredDisablesUserLayoutsWhenNotAlreadySet()
+		throws Exception {
+
+		PortletPreferences portletPreferences = _getPortletPreferences();
+
+		_portalInstanceRegistered();
+
+		Mockito.verify(
+			portletPreferences
+		).setValue(
+			PropsKeys.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED, "false"
+		);
+
+		Mockito.verify(
+			portletPreferences
+		).setValue(
+			PropsKeys.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED, "false"
+		);
+
+		Mockito.verify(
+			portletPreferences
+		).store();
+	}
+
+	@Test
+	@TestInfo("LPD-98561")
+	public void testPortalInstanceRegisteredDoesNotOverrideUserLayoutsWhenAlreadySet()
+		throws Exception {
+
+		PortletPreferences portletPreferences = _getPortletPreferences();
+
+		Mockito.when(
+			portletPreferences.getValue(
+				PropsKeys.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED, null)
+		).thenReturn(
+			"true"
+		);
+
+		Mockito.when(
+			portletPreferences.getValue(
+				PropsKeys.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED, null)
+		).thenReturn(
+			"true"
+		);
+
+		_portalInstanceRegistered();
+
+		Mockito.verify(
+			portletPreferences, Mockito.never()
+		).setValue(
+			Mockito.anyString(), Mockito.anyString()
+		);
+
+		Mockito.verify(
+			portletPreferences, Mockito.never()
+		).store();
+	}
+
+	private PortletPreferences _getPortletPreferences() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		PrefsProps prefsProps = Mockito.mock(PrefsProps.class);
+
+		Mockito.when(
+			prefsProps.getPreferences(Mockito.anyLong())
+		).thenReturn(
+			portletPreferences
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			PrefsPropsUtil.class, "_prefsProps", prefsProps);
+
+		return portletPreferences;
+	}
+
+	private void _portalInstanceRegistered() throws Exception {
+		CMSPortalInstanceLifecycleListener cmsPortalInstanceLifecycleListener =
+			new CMSPortalInstanceLifecycleListener();
+
+		ConfigurationAdmin configurationAdmin = Mockito.mock(
+			ConfigurationAdmin.class);
+
+		Mockito.when(
+			configurationAdmin.createFactoryConfiguration(
+				Mockito.anyString(), Mockito.anyString())
+		).thenReturn(
+			Mockito.mock(Configuration.class)
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			cmsPortalInstanceLifecycleListener, "_configurationAdmin",
+			configurationAdmin);
+
+		Company company = Mockito.mock(Company.class);
+
+		Mockito.when(
+			company.getCompanyId()
+		).thenReturn(
+			1L
+		);
+
+		cmsPortalInstanceLifecycleListener.portalInstanceRegistered(company);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98561

## What Is Being Fixed

In Standalone CMS, the user menu's "My Profile" and "My Dashboard" entries led to a broken or empty page for normal users. Both entries point at widgets that are not part of the Standalone CMS build: "My Profile" renders contacts-web's profile portlet, and "My Dashboard" renders site-my-sites-web's My Sites portlet.

## How It Is Being Fixed

Rather than deploying those widgets into the Standalone CMS build, this removes the menu entries the way the product already supports it. `MyProfilePersonalMenuEntry` and `MyDashboardPersonalMenuEntry` (in users-admin-web) already hide themselves when a company has `layout.user.public.layouts.enabled`/`layout.user.private.layouts.enabled` disabled — which fits, since "My Profile" duplicates "Account Settings" and "My Dashboard" is meaningless without sites in Standalone CMS. `CMSPortalInstanceLifecycleListener`, which already sets other Standalone-CMS-specific company defaults on registration, now also disables these two properties for every company registered in a Standalone CMS build.

## PR Check

**pr-check: PASS** — tested on `d846b855c7286a130a69721895f7bdba7c6bdf3a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d846b855c7286a130a69721895f7bdba7c6bdf3a"} -->
