### PR TITLE
LPD-99972 Fix the 500 when patching an asset library friendly URL

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 12.0.1
+Bundle-Version: 12.1.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
@@ -380,6 +380,14 @@ public interface DepotEntryLocalService
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public DepotEntry updateDepotEntry(
+			long depotEntryId, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap,
 			Map<String, Boolean> depotAppCustomizationMap,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
@@ -401,4 +409,4 @@ public interface DepotEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:60896067
+// LIFERAY-SERVICE-BUILDER-HASH:-1869317324

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
@@ -443,6 +443,20 @@ public class DepotEntryLocalServiceUtil {
 	public static DepotEntry updateDepotEntry(
 			long depotEntryId, Map<java.util.Locale, String> nameMap,
 			Map<java.util.Locale, String> descriptionMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateDepotEntry(
+			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	public static DepotEntry updateDepotEntry(
+			long depotEntryId, Map<java.util.Locale, String> nameMap,
+			Map<java.util.Locale, String> descriptionMap,
 			Map<String, Boolean> depotAppCustomizationMap,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
@@ -463,4 +477,4 @@ public class DepotEntryLocalServiceUtil {
 			DepotEntryLocalServiceUtil.class, DepotEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:239845251
+// LIFERAY-SERVICE-BUILDER-HASH:-699419304

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
@@ -496,6 +496,22 @@ public class DepotEntryLocalServiceWrapper
 			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,
+			String friendlyURL,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _depotEntryLocalService.updateDepotEntry(
+			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	@Override
+	public DepotEntry updateDepotEntry(
+			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<String, Boolean> depotAppCustomizationMap,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -546,4 +562,4 @@ public class DepotEntryLocalServiceWrapper
 	private DepotEntryLocalService _depotEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2008945564
+// LIFERAY-SERVICE-BUILDER-HASH:835881915

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
@@ -98,10 +98,18 @@ public interface DepotEntryService extends BaseService {
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public DepotEntry updateDepotEntry(
+			long depotEntryId, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap,
 			Map<String, Boolean> depotAppCustomizationMap,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2012305632
+// LIFERAY-SERVICE-BUILDER-HASH:-1716017719

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
@@ -113,6 +113,20 @@ public class DepotEntryServiceUtil {
 	public static DepotEntry updateDepotEntry(
 			long depotEntryId, Map<java.util.Locale, String> nameMap,
 			Map<java.util.Locale, String> descriptionMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateDepotEntry(
+			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	public static DepotEntry updateDepotEntry(
+			long depotEntryId, Map<java.util.Locale, String> nameMap,
+			Map<java.util.Locale, String> descriptionMap,
 			Map<String, Boolean> depotAppCustomizationMap,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
@@ -132,4 +146,4 @@ public class DepotEntryServiceUtil {
 		new Snapshot<>(DepotEntryServiceUtil.class, DepotEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1376930221
+// LIFERAY-SERVICE-BUILDER-HASH:1192259330

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
@@ -123,6 +123,22 @@ public class DepotEntryServiceWrapper
 			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,
+			String friendlyURL,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _depotEntryService.updateDepotEntry(
+			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	@Override
+	public DepotEntry updateDepotEntry(
+			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<String, Boolean> depotAppCustomizationMap,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -146,4 +162,4 @@ public class DepotEntryServiceWrapper
 	private DepotEntryService _depotEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1245536009
+// LIFERAY-SERVICE-BUILDER-HASH:554587719

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.4.0
+version 3.5.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
@@ -450,6 +450,7 @@ public class DepotEntryServiceHttp {
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,
+			String friendlyURL,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -459,6 +460,54 @@ public class DepotEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "updateDepotEntry",
 				_updateDepotEntryParameterTypes10);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, depotEntryId, nameMap, descriptionMap,
+				depotAppCustomizationMap, friendlyURL,
+				typeSettingsUnicodeProperties, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.depot.model.DepotEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.depot.model.DepotEntry updateDepotEntry(
+			HttpPrincipal httpPrincipal, long depotEntryId,
+			java.util.Map<java.util.Locale, String> nameMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<String, Boolean> depotAppCustomizationMap,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DepotEntryServiceUtil.class, "updateDepotEntry",
+				_updateDepotEntryParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, depotEntryId, nameMap, descriptionMap,
@@ -530,10 +579,17 @@ public class DepotEntryServiceHttp {
 	private static final Class<?>[] _updateDepotEntryParameterTypes10 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
+			java.util.Map.class, String.class,
+			com.liferay.portal.kernel.util.UnicodeProperties.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _updateDepotEntryParameterTypes11 =
+		new Class[] {
+			long.class, java.util.Map.class, java.util.Map.class,
 			java.util.Map.class,
 			com.liferay.portal.kernel.util.UnicodeProperties.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-851994723
+// LIFERAY-SERVICE-BUILDER-HASH:1210175091

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -379,7 +379,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
-			Map<String, Boolean> depotAppCustomizationMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
@@ -439,7 +439,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		group = _groupLocalService.updateGroup(
 			depotEntry.getGroupId(), group.getParentGroupId(), nameMap,
 			descriptionMap, group.getType(), null, group.isManualMembership(),
-			group.getMembershipRestriction(), group.getFriendlyURL(),
+			group.getMembershipRestriction(), friendlyURL,
 			group.isInheritContent(), group.isActive(), serviceContext);
 
 		_groupLocalService.updateGroup(
@@ -447,6 +447,25 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 			currentTypeSettingsUnicodeProperties.toString());
 
 		return depotEntry;
+	}
+
+	@Override
+	public DepotEntry updateDepotEntry(
+			long depotEntryId, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap,
+			Map<String, Boolean> depotAppCustomizationMap,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		DepotEntry depotEntry = getDepotEntry(depotEntryId);
+
+		Group group = _groupLocalService.getGroup(depotEntry.getGroupId());
+
+		return updateDepotEntry(
+			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
+			group.getFriendlyURL(), typeSettingsUnicodeProperties,
+			serviceContext);
 	}
 
 	private String _getDefaultName(

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -225,6 +225,23 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_depotEntryModelResourcePermission.check(
+			getPermissionChecker(), depotEntryId, ActionKeys.UPDATE);
+
+		return depotEntryLocalService.updateDepotEntry(
+			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	@Override
+	public DepotEntry updateDepotEntry(
+			long depotEntryId, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap,
 			Map<String, Boolean> depotAppCustomizationMap,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -368,20 +368,28 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			_updateDLSizeLimitConfiguration(
 				assetLibrary, group.getGroupId(), mimeTypeSizeLimits);
 
-			DepotEntry updatedDepotEntry = _depotEntryService.updateDepotEntry(
-				depotEntry.getDepotEntryId(), nameMap, descriptionMap,
+			Map<String, Boolean> depotAppCustomizationMap =
 				_getDepotAppCustomizationMap(
-					depotEntry.getCompanyId(), externalReferenceCode),
+					depotEntry.getCompanyId(), externalReferenceCode);
+
+			UnicodeProperties typeSettingsUnicodeProperties =
 				UnicodePropertiesBuilder.create(
 					group.getTypeSettingsProperties(), true
 				).putAll(
 					unicodeProperties
-				).build(),
+				).build();
+
+			if (Validator.isNotNull(assetLibrary.getFriendlyURL())) {
+				return _depotEntryService.updateDepotEntry(
+					depotEntry.getDepotEntryId(), nameMap, descriptionMap,
+					depotAppCustomizationMap, assetLibrary.getFriendlyURL(),
+					typeSettingsUnicodeProperties, serviceContext);
+			}
+
+			return _depotEntryService.updateDepotEntry(
+				depotEntry.getDepotEntryId(), nameMap, descriptionMap,
+				depotAppCustomizationMap, typeSettingsUnicodeProperties,
 				serviceContext);
-
-			_updateFriendlyURL(assetLibrary, group.getGroupId());
-
-			return updatedDepotEntry;
 		}
 
 		if (Validator.isNotNull(externalReferenceCode)) {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -165,13 +165,19 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-99972")
 	public void testPatchAssetLibrary() throws Exception {
 		super.testPatchAssetLibrary();
 
 		_testPatchAssetLibraryPermissions();
 		_testPatchAssetLibrarySettings();
-		_testPatchAssetLibraryFriendlyURL();
 		_testPatchAssetLibraryFriendlyURLValidation();
+		_testPatchAssetLibraryName();
+		_testPatchAssetLibraryFriendlyURLUnchanged();
+		_testPatchAssetLibraryFriendlyURLChanged();
+		_testPatchAssetLibraryNameAndFriendlyURLUnchanged();
+		_testPatchAssetLibraryNameAndFriendlyURLChanged();
+		_testPatchAssetLibraryExternalReferenceCodeAndFriendlyURL();
 	}
 
 	@Override
@@ -190,6 +196,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 				}
 			});
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
+		_testPostAssetLibraryFriendlyURL();
 		_testPostAssetLibraryWithDuplicateExternalReferenceCode();
 		_testPostAssetLibraryWithExternalReferenceCode();
 		_testPostAssetLibraryWithMissingTrashEntriesMaxAge();
@@ -429,6 +436,28 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		return assetLibraryResource.postAssetLibrary(randomAssetLibrary());
 	}
 
+	private void _assertFriendlyURLAndName(
+			AssetLibrary assetLibrary, String expectedFriendlyURL,
+			String expectedName, AssetLibrary patchAssetLibrary)
+		throws Exception {
+
+		AssetLibrary patchedAssetLibrary =
+			assetLibraryResource.patchAssetLibrary(
+				assetLibrary.getExternalReferenceCode(), patchAssetLibrary);
+
+		Assert.assertEquals(
+			expectedFriendlyURL, patchedAssetLibrary.getFriendlyURL());
+		Assert.assertEquals(expectedName, patchedAssetLibrary.getName());
+
+		AssetLibrary persistedAssetLibrary =
+			assetLibraryResource.getAssetLibrary(
+				assetLibrary.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			expectedFriendlyURL, persistedAssetLibrary.getFriendlyURL());
+		Assert.assertEquals(expectedName, persistedAssetLibrary.getName());
+	}
+
 	private void _assertFriendlyURLValidationFailure(
 			String friendlyURL, String expectedType)
 		throws Exception {
@@ -574,22 +603,67 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		return assetLibrary;
 	}
 
-	private void _testPatchAssetLibraryFriendlyURL() throws Exception {
+	private String _randomFriendlyURL() {
+		return StringUtil.toLowerCase("/" + RandomTestUtil.randomString());
+	}
+
+	private void _testPatchAssetLibraryExternalReferenceCodeAndFriendlyURL()
+		throws Exception {
+
 		AssetLibrary assetLibrary = _addAssetLibrary();
 
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String friendlyURL = _randomFriendlyURL();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setExternalReferenceCode(externalReferenceCode);
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+
+		AssetLibrary patchedAssetLibrary =
+			assetLibraryResource.patchAssetLibrary(
+				assetLibrary.getExternalReferenceCode(), patchAssetLibrary);
+
 		Assert.assertEquals(
-			"/asset-library-" + assetLibrary.getId(),
-			assetLibrary.getFriendlyURL());
+			externalReferenceCode,
+			patchedAssetLibrary.getExternalReferenceCode());
+		Assert.assertEquals(friendlyURL, patchedAssetLibrary.getFriendlyURL());
 
-		String customFriendlyURL = StringUtil.toLowerCase(
-			"/cms-friendly-url-" + RandomTestUtil.randomString());
+		AssetLibrary persistedAssetLibrary =
+			assetLibraryResource.getAssetLibrary(externalReferenceCode);
 
-		assetLibrary.setFriendlyURL(customFriendlyURL);
+		Assert.assertEquals(
+			friendlyURL, persistedAssetLibrary.getFriendlyURL());
+		Assert.assertEquals(
+			assetLibrary.getName(), persistedAssetLibrary.getName());
+	}
 
-		assetLibrary = assetLibraryResource.patchAssetLibrary(
-			assetLibrary.getExternalReferenceCode(), assetLibrary);
+	private void _testPatchAssetLibraryFriendlyURLChanged() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
 
-		Assert.assertEquals(customFriendlyURL, assetLibrary.getFriendlyURL());
+		String friendlyURL = _randomFriendlyURL();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, assetLibrary.getName(),
+			patchAssetLibrary);
+	}
+
+	private void _testPatchAssetLibraryFriendlyURLUnchanged() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String friendlyURL = assetLibrary.getFriendlyURL();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, assetLibrary.getName(),
+			patchAssetLibrary);
 	}
 
 	private void _testPatchAssetLibraryFriendlyURLValidation()
@@ -616,6 +690,55 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 		_assertFriendlyURLValidationFailure(
 			existingFriendlyURL, "FRIENDLY_URL_DUPLICATE");
+	}
+
+	private void _testPatchAssetLibraryName() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String name = RandomTestUtil.randomString();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setName(name);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, assetLibrary.getFriendlyURL(), name,
+			patchAssetLibrary);
+	}
+
+	private void _testPatchAssetLibraryNameAndFriendlyURLChanged()
+		throws Exception {
+
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String friendlyURL = _randomFriendlyURL();
+		String name = RandomTestUtil.randomString();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+		patchAssetLibrary.setName(name);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, name, patchAssetLibrary);
+	}
+
+	private void _testPatchAssetLibraryNameAndFriendlyURLUnchanged()
+		throws Exception {
+
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String friendlyURL = assetLibrary.getFriendlyURL();
+
+		String name = RandomTestUtil.randomString();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+		patchAssetLibrary.setName(name);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, name, patchAssetLibrary);
 	}
 
 	private void _testPatchAssetLibraryPermissions() throws Exception {
@@ -748,6 +871,14 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			trashEnabled, trashEntriesMaxAge, useCustomLanguages);
 
 		_assertGroupDepotEntryType(assetLibrary);
+	}
+
+	private void _testPostAssetLibraryFriendlyURL() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		Assert.assertEquals(
+			"/asset-library-" + assetLibrary.getId(),
+			assetLibrary.getFriendlyURL());
 	}
 
 	private void _testPostAssetLibraryWithDuplicateExternalReferenceCode()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99972

## What Is Being Fixed

Patching an asset library returns HTTP 500 whenever the request carries a genuine friendly URL change, so editing a Space friendly URL is broken in the standalone CMS.

`AssetLibraryResourceImpl._addOrUpdateDepotEntry` wrote the group more than once per request, each write in its own transaction. `GroupLocalServiceImpl.updateFriendlyURL` then merged a group whose `mvccVersion` was already behind the row, and Hibernate raised a `StaleObjectStateException`. Hibernate only issues the versioned UPDATE when the merged entity is actually dirty, which is why the failure looked input dependent: it appeared only when the second write carried a real field change.

That is also why the earlier attempt under LPD-98285 did not work. Reordering the two writes only chose which payload was the dirty one, so it fixed a changed friendly URL and broke every Space rename instead. It was reverted, which returned this defect to master.

## How It Is Being Fixed

The extra write is removed rather than reordered. `DepotEntryLocalServiceImpl.updateDepotEntry` already forwarded a friendly URL into `GroupLocalServiceImpl.updateGroup`, but it forwarded the group's current value. A new overload takes the caller's value instead, so the friendly URL rides the group write that already happens and `_updateFriendlyURL` leaves the patch path entirely.

The existing six argument signature stays and delegates with the group's current friendly URL, so its behaviour is identical and no other caller changes. The alternative, changing the signature outright, would have forced `EditDepotEntryMVCActionCommand` and `BundleSiteInitializer` to supply a friendly URL neither of them has.

`AssetLibraryResourceImpl` selects the signature that matches the payload instead of filling the missing argument itself. A request carrying a friendly URL reaches the new overload; a request without one reaches the six argument signature, which reads the current value inside the write transaction. Forwarding the group instance the resource read earlier would turn every name only patch into a friendly URL write, and open a window where a concurrent rename is reverted without an error. The `Validator.isNotNull` check that chooses between the two is the one the removed helper used, because `GroupLocalServiceImpl.getFriendlyURL` treats a blank friendly URL as a request to generate a default one, so forwarding a blank value would silently rewrite the URL rather than leave it alone.

Validation behaviour is unchanged. `updateGroup` runs the same `getFriendlyURL` and `validateFriendlyURL` pair that `updateFriendlyURL` ran, so the same `GroupFriendlyURLException` subtypes still surface as `BAD_REQUEST`.

Collapsing the two writes into one also makes the patch atomic. A valid name combined with an invalid friendly URL used to persist the rename and then return `BAD_REQUEST`, because the two writes were two transactions. `validateFriendlyURL` now runs before the single `groupPersistence.update`, so a rejected request leaves nothing behind.

Changing the external reference code and the friendly URL in the same request still performs two group writes, through the external reference code branch added under LPD-98285, and it succeeds. The write that failed was the third one, `_updateFriendlyURL`, and removing it takes that failure with it. Two writes only break when the second merges an instance already behind the row.

## Tests

`AssetLibraryResourceTest` previously exercised only two of the five name and friendly URL payload permutations, which is why the rename regression reached master unnoticed. It now covers all five: name alone, an unchanged friendly URL alone, a changed friendly URL alone, and name combined with each. A sixth case pins the external reference code changing alongside the friendly URL, the permutation that still performs two group writes. Each asserts the patch response and a follow up read, so a write that does not persist cannot pass.

The two combined permutations are the regression guards for this ticket's history. Name with a changed friendly URL is the failure fixed here; name with an unchanged friendly URL is the Space rename that the reverted commit broke.

The assertion that a new asset library receives the generated `/asset-library-<id>` moved to `testPostAssetLibrary`, where the behaviour it describes belongs.

## Test Execution

```bash
gradlew -p modules/apps/headless/headless-asset-library/headless-asset-library-test \
	testIntegration --tests AssetLibraryResourceTest

gradlew -p modules/apps/depot/depot-test testIntegration --tests DepotEntryLocalServiceTest

gradlew -p modules/apps/depot/depot-test testIntegration --tests DepotEntryServiceTest
```

The Space rename path was also verified through Playwright:

```bash
cd modules/test/playwright && yarn test \
	tests/e2e-cms-dxp/main/space-configuration/spaceConfiguration.spec.ts \
	--project=e2e-cms-dxp.main -g "rename a Space"
```

## PR Check

**pr-check: PASS** — tested on `b9a569f052309dd4b2f5a0b9e54b825919b729c6`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b9a569f052309dd4b2f5a0b9e54b825919b729c6"} -->

