### PR TITLE
LPD-101896 Render entity names as text in toast and modal messages

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
+++ b/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
@@ -5,6 +5,8 @@
 
 // @ts-nocheck
 
+import {escapeHTML} from 'frontend-js-web';
+
 jest.mock('@ckeditor/ckeditor5-bookmark/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-clipboard/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-editor-decoupled/dist/index', () => ({}));
@@ -84,7 +86,7 @@ class MockBroadcastChannel {
 	},
 	Util: {
 		...(globalThis.Liferay.Util || {}),
-		escapeHTML: (str: string) => str,
+		escapeHTML,
 		formatStorage: (size: number) => `${size / 1024} KB`,
 	},
 	authToken: 'mocked-auth-token',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/toastUtil.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/toastUtil.ts
@@ -10,7 +10,10 @@ import {getFormattedLabel} from './getFormattedText';
 
 const displayCreateSuccessToast = (name: string) => {
 	openToast({
-		message: sub(Liferay.Language.get('x-was-created-successfully'), name),
+		message: sub(
+			Liferay.Language.get('x-was-created-successfully'),
+			Liferay.Util.escapeHTML(name)
+		),
 		type: 'success',
 	});
 };
@@ -42,7 +45,10 @@ const displayDeleteSuccessToast = (name: string) => {
 
 const displayEditSuccessToast = (name: string) => {
 	openToast({
-		message: sub(Liferay.Language.get('x-was-updated-successfully'), name),
+		message: sub(
+			Liferay.Language.get('x-was-updated-successfully'),
+			Liferay.Util.escapeHTML(name)
+		),
 		type: 'success',
 	});
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/MergeTagsModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/MergeTagsModal.tsx
@@ -77,7 +77,11 @@ export default function MergeTagsModalContent({
 
 	const _getConfirmationMessage = (tag: Tag) => {
 		const tagNames =
-			'"' + selectedTags.map((item) => item.label).join(', ') + '"';
+			'"' +
+			selectedTags
+				.map((item) => Liferay.Util.escapeHTML(item.label))
+				.join(', ') +
+			'"';
 		const intoTagName = '"' + Liferay.Util.escapeHTML(tag.label) + '"';
 
 		return sub(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditVocabulary.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditVocabulary.tsx
@@ -238,7 +238,7 @@ export default function EditVocabulary({
 			Liferay.Util.openToast({
 				message: Liferay.Util.sub(
 					Liferay.Language.get('x-was-published-successfully'),
-					vocabulary.name
+					Liferay.Util.escapeHTML(vocabulary.name)
 				),
 				type: 'success',
 			});
@@ -247,7 +247,7 @@ export default function EditVocabulary({
 			Liferay.Util.openToast({
 				message: Liferay.Util.sub(
 					Liferay.Language.get('x-was-updated-successfully'),
-					vocabulary.name
+					Liferay.Util.escapeHTML(vocabulary.name)
 				),
 				type: 'success',
 			});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/find_and_replace/components/Preview.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/find_and_replace/components/Preview.tsx
@@ -134,7 +134,7 @@ export function Preview() {
 		openToast({
 			message: sub(
 				Liferay.Language.get('changes-applied-to-x'),
-				item.title
+				Liferay.Util.escapeHTML(item.title)
 			),
 			type: 'success',
 		});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/find_and_replace/components/Summary.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/find_and_replace/components/Summary.tsx
@@ -202,7 +202,7 @@ function ListItem({item}: {item: ReplaceItem}) {
 		openToast({
 			message: sub(
 				Liferay.Language.get('changes-applied-to-x'),
-				item.title
+				Liferay.Util.escapeHTML(item.title)
 			),
 			type: 'success',
 		});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
@@ -18,6 +18,7 @@ import {required, validate} from '../../common/components/forms/validations';
 import FolderService, {TFolder} from '../../common/services/FolderService';
 import SpaceService from '../../common/services/SpaceService';
 import {Space} from '../../common/types/Space';
+import {getFormattedLabel} from '../../common/utils/getFormattedText';
 
 interface EditFolderProps {
 	backURL: string;
@@ -95,7 +96,7 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 				openToast({
 					message: sub(
 						Liferay.Language.get('x-was-updated-successfully'),
-						`<strong>${formValues.folderName}</strong>`
+						getFormattedLabel(formValues.folderName)
 					),
 					type: 'success',
 				});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
@@ -155,7 +155,7 @@ const displayToast = (
 					: Liferay.Language.get(
 							'x-could-not-be-moved.-please-ensure-the-structure-it-is-using-exists-in-the-destination-space'
 						),
-				itemData.title
+				Liferay.Util.escapeHTML(itemData.title)
 			);
 		}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllSpacesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllSpacesFDSPropsTransformer.ts
@@ -158,7 +158,7 @@ export default function AllSpacesFDSPropsTransformer({
 					},
 					successMessage: sub(
 						Liferay.Language.get('x-was-successfully-deleted'),
-						itemData.name
+						Liferay.Util.escapeHTML(itemData.name)
 					),
 					title: sub(
 						Liferay.Language.get('delete-space-confirmation-title'),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import {openAssetUsageListModal} from '../../common/components/asset_usage/utils';
 import {OBJECT_ENTRY_FOLDER_CLASS_NAME} from '../../common/utils/constants';
+import {getFormattedLabel} from '../../common/utils/getFormattedText';
 import {openCMSModal} from '../../common/utils/openCMSModal';
 import DefaultPermissionModalContent from '../default_permission/DefaultPermissionModalContent';
 import openResetAssetPermissionModal from '../default_permission/ResetPermissionModalContent';
@@ -174,13 +175,13 @@ export default function HomeRecentAssetsFDSPropsTransformer({
 								Liferay.Language.get(
 									'delete-folder-confirmation-body'
 								),
-								title
+								getFormattedLabel(title)
 							)
 						: sub(
 								Liferay.Language.get(
 									'delete-asset-confirmation-body'
 								),
-								title
+								getFormattedLabel(title)
 							);
 
 				if (additionalProps.brokenLinksCheckerEnabled) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/createFolderAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/createFolderAction.ts
@@ -8,6 +8,7 @@ import {sub} from 'frontend-js-web';
 
 import FolderService from '../../../common/services/FolderService';
 import {AssetLibrary} from '../../../common/types/AssetLibrary';
+import {getFormattedLabel} from '../../../common/utils/getFormattedText';
 import {openCMSModal} from '../../../common/utils/openCMSModal';
 import CreationModalContent from '../../modal/CreationModalContent';
 
@@ -58,8 +59,8 @@ export default function createFolderAction(
 									'x-was-created-successfully-to-x-space'
 								),
 								[
-									`<a href="${data.baseFolderViewURL}${folderId}" class="alert-link lead"><strong>${folderName}</strong></a>`,
-									`<a href="${data.baseAssetLibraryViewURL}${groupId}" class="alert-link lead"><strong>${spaceName}</strong></a>`,
+									`<a href="${data.baseFolderViewURL}${folderId}" class="alert-link lead">${getFormattedLabel(folderName ?? '')}</a>`,
+									`<a href="${data.baseAssetLibraryViewURL}${groupId}" class="alert-link lead">${getFormattedLabel(spaceName ?? '')}</a>`,
 								]
 							),
 							type: 'success',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -126,7 +126,7 @@ export default function SpaceGeneralSettings({
 				openToast({
 					message: Liferay.Util.sub(
 						Liferay.Language.get('x-was-saved-successfully'),
-						name
+						Liferay.Util.escapeHTML(name)
 					),
 					type: 'success',
 				});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceLanguageSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceLanguageSettings.tsx
@@ -94,7 +94,7 @@ export default function SpaceLanguageSettings({
 				openToast({
 					message: Liferay.Util.sub(
 						Liferay.Language.get('x-was-saved-successfully'),
-						space.name
+						Liferay.Util.escapeHTML(space.name)
 					),
 					type: 'success',
 				});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/SpacesSelector.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/SpacesSelector.tsx
@@ -76,7 +76,7 @@ export default function SpacesSelector({
 					Liferay.Language.get(
 						'the-space-x-cannot-be-removed-because-it-has-content-created-from-this-structure'
 					),
-					space.name
+					Liferay.Util.escapeHTML(space.name)
 				),
 				type: 'danger',
 			});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/picklist_builder/PicklistBuilderToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/picklist_builder/PicklistBuilderToolbar.tsx
@@ -96,7 +96,7 @@ export default function PicklistBuilderToolbar() {
 			openToast({
 				message: Liferay.Util.sub(
 					Liferay.Language.get('x-was-saved-successfully'),
-					localizedName
+					Liferay.Util.escapeHTML(localizedName)
 				),
 				type: 'success',
 			});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handlePublishStructure.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handlePublishStructure.tsx
@@ -219,7 +219,7 @@ export default async function handlePublishStructure({
 			openToast({
 				message: Liferay.Util.sub(
 					Liferay.Language.get('x-was-published-successfully'),
-					localizedLabel
+					Liferay.Util.escapeHTML(localizedLabel)
 				),
 				type: 'success',
 			});
@@ -232,7 +232,7 @@ export default async function handlePublishStructure({
 				Liferay.Language.get(
 					'x-was-published-successfully.-remember-to-review-the-customized-editor-if-needed'
 				),
-				localizedLabel
+				Liferay.Util.escapeHTML(localizedLabel)
 			),
 			toastProps: {
 				actions: (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handleSaveStructure.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handleSaveStructure.ts
@@ -118,7 +118,7 @@ export default async function handleSaveStructure({
 	openToast({
 		message: Liferay.Util.sub(
 			Liferay.Language.get('x-was-saved-successfully'),
-			localizedLabel
+			Liferay.Util.escapeHTML(localizedLabel)
 		),
 		type: 'success',
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
@@ -28,6 +28,8 @@ jest.mock(
 	})
 );
 
+const SPACE_NAME_WITH_MARKUP = '<img src=x onerror="alert(1)">';
+
 const SPACE: Partial<Space> = {
 	description: 'This is the description for Cool Space',
 	externalReferenceCode: 'space-external-reference-code',
@@ -156,6 +158,29 @@ describe('SpaceGeneralSettings', () => {
 				screen.getByText('My Space-was-saved-successfully')
 			).toBeInTheDocument();
 		});
+
+		await closeToast();
+	});
+
+	it('shows a name containing markup as text in the success toast', async () => {
+		renderComponent();
+
+		const nameField = screen.getByRole('textbox', {name: /space-name/});
+
+		await userEvent.clear(nameField);
+		await userEvent.type(nameField, SPACE_NAME_WITH_MARKUP);
+
+		await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					`${SPACE_NAME_WITH_MARKUP}-was-saved-successfully`
+				)
+			).toBeInTheDocument();
+		});
+
+		expect(document.querySelector('img[src="x"]')).toBeNull();
 
 		await closeToast();
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceLanguageSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceLanguageSettings.test.tsx
@@ -67,6 +67,16 @@ const mockPropsWithCustomLanguages = {
 	},
 };
 
+const SPACE_NAME_WITH_MARKUP = '<img src=x onerror="alert(1)">';
+
+const mockPropsWithMarkupInName = {
+	...mockProps,
+	space: {
+		...mockProps.space,
+		name: SPACE_NAME_WITH_MARKUP,
+	},
+};
+
 const closeToast = async () => {
 	await userEvent.click(screen.getByRole('button', {name: 'close'}));
 };
@@ -145,6 +155,24 @@ describe('SpaceLanguageSettings', () => {
 				screen.getByText('My Space-was-saved-successfully')
 			).toBeInTheDocument();
 		});
+
+		await closeToast();
+	});
+
+	it('shows a name containing markup as text in the success toast', async () => {
+		renderComponent(mockPropsWithMarkupInName);
+
+		await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					`${SPACE_NAME_WITH_MARKUP}-was-saved-successfully`
+				)
+			).toBeInTheDocument();
+		});
+
+		expect(document.querySelector('img[src="x"]')).toBeNull();
 
 		await closeToast();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101896

## What Is Being Fixed

Toast and modal messages in the CMS main view interpolate entity names into content that is rendered as HTML: `openToast` renders its `message` that way, and `openModal` does the same for `bodyHTML`. Both are deliberate, since callers embed markup such as `<strong>` and `<a>` in these messages, which makes preparing the interpolated value the caller's job.

A number of call sites were passing names straight through, so a name containing markup was parsed as markup instead of being shown as the text the user entered. Saving a space from Space Settings showed a broken element in the success message instead of the space name, and both tabs of that screen behaved this way.

The module already handled this correctly in most places, through `getFormattedLabel` or a direct call, so the gap also left neighbouring screens inconsistent with one another.

## How It Is Being Fixed

The sweep covers the message sinks in the module that receive a user-provided name: the two Space Settings tabs, the shared create and update toasts in `toastUtil`, tag merging, vocabularies, find and replace, folder editing and creation, the folder item selector, the delete-Space toast in `AllSpacesFDSPropsTransformer`, the delete confirmation in `HomeRecentAssetsFDSPropsTransformer`, and the structure and picklist builders. Each keeps whatever markup it already had, so the rendered output is unchanged apart from names that contain markup, which now read as the text the user entered.

Where a `<strong>` wrapper was already present, the existing `getFormattedLabel` helper is used rather than hand-rolling the same pair of calls.

Sites that cannot carry markup were left alone, including numeric counts and static messages, as were modal and toast `title` props, which React renders as text already.

One sink is deliberately **not** included. `additionalProps.objectEntryTitle` in `ViewVersionHistoryFDSPropsTransformer` arrives already escaped from `ViewVersionHistoryDisplayContext.java`, and props are serialized as JS source inside a script block, where the HTML parser does not decode entities. Preparing it again in JS would double-escape and show the entity in a delete confirmation, so that value is left as it arrives. This is the one place in the module where the value originates from a Java display context rather than a REST response.

One typing defect surfaced along the way: in `createFolderAction`, `folderName` and `spaceName` are destructured from `folderData || {}` and so are `string | undefined`. Both now fall back to an empty string. That branch only runs when `folderData` exists, so this is a compile-time correction.

The middle commit is test infrastructure rather than product behavior. The module's `jest-setup.config.ts` replaced the HTML helper on `Liferay.Util` with an identity function, so no test could tell prepared output from unprepared output and this whole family of call sites was invisible to the suite. It now uses the real implementation from `frontend-js-web`. Deleting the override outright is not enough, because the shared mock does not put that helper on `Util`, which is why the stand-in existed. With the real one in place the module's full suite passes unchanged.

## Test Execution

```bash
cd modules/apps/site/site-cms-site-initializer && yarn test
```

Both new cases were confirmed to fail when their source change is reverted.

## PR Check

**pr-check: PASS** — tested on `9ac79c74856a9a7b7fb9363b8289b880a9ff8e34`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Source Format ran with `-Dvalidate.commit.messages=true`.

Per-Module Compile ran at reduced scope: the module deploy only, without the `install-portal-snapshots` rebuild, since this branch changes no Java.

JavaScript Unit Tests: 170 suites and 949 tests pass.

<!-- pr-check {"result": "success", "sha": "9ac79c74856a9a7b7fb9363b8289b880a9ff8e34"} -->
