### PR TITLE
LPD-101968 Capture the expected denial log in the permissions test

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/GetObjectEntriesValuesStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/GetObjectEntriesValuesStrutsActionTest.java
@@ -44,6 +44,8 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -427,8 +429,14 @@ public class GetObjectEntriesValuesStrutsActionTest {
 			MockHttpServletResponse mockHttpServletResponse =
 				new MockHttpServletResponse();
 
-			_getObjectEntriesValuesStrutsAction.execute(
-				mockHttpServletRequest, mockHttpServletResponse);
+			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+					"com.liferay.site.cms.site.initializer.internal.struts." +
+						"GetObjectEntriesValuesStrutsAction",
+					LoggerTestUtil.OFF)) {
+
+				_getObjectEntriesValuesStrutsAction.execute(
+					mockHttpServletRequest, mockHttpServletResponse);
+			}
 
 			JSONArray resultJSONArray = _jsonFactory.createJSONArray(
 				mockHttpServletResponse.getContentAsString());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101968

## What Is Being Fixed

`PortalLogAssertorTest#testScanXMLLog` fails in the CMS run with a `PrincipalException$MustHavePermission` stack trace logged by `GetObjectEntriesValuesStrutsAction`. The trace comes from `GetObjectEntriesValuesStrutsActionTest#testExecuteWithPermissions`, which requests two object entries while the acting user may view only the first one.

That test is correct as written and already passes. `_getObjectEntry` treats a denial as ordinary control flow, returning `null` so the caller skips the entry, but it calls `_log.error(exception)` on the way out. `PortalLogAssertorTest` scans the portal log for unexpected exceptions and fails the build on the trace, even though the denial is exactly what the test provokes.

## How It Is Being Fixed

The provoking `execute` call is wrapped in a `LogCapture` configured at `LoggerTestUtil.OFF` for the action's logger, so the expected denial no longer reaches the portal log. Only that call sits inside the capture; the assertions still read `mockHttpServletResponse` outside it, and the existing `assertEquals(1, resultJSONArray.length())` continues to prove the entry the user cannot view was filtered out.

Runtime logging is deliberately left alone. Downgrading the production `_log.error` to a guarded `debug` for `PrincipalException` would reduce genuine log noise, but no runtime behaviour should change to satisfy a test, so it is tracked separately on LPD-101966.

## Test Execution

```bash
gradlew -p modules/apps/site/site-cms-site-initializer-test \
	testIntegration --tests GetObjectEntriesValuesStrutsActionTest
```

Verified against the deployed bundle. On an untouched tree the run wrote `ERROR [...][GetObjectEntriesValuesStrutsAction:120] User ... must have VIEW permission for com.liferay.object.model.ObjectDefinition#...` to the bundle log. After the change the same run passes with all three tests executing and no `GetObjectEntriesValuesStrutsAction` line and no `ERROR` line in the log window.

## PR Check

**pr-check: PASS** — tested on `29976291fde97`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "29976291fde97b1cbc8f06c005098b9263223a92"} -->
