### PR TITLE
LPD-97869 Index the contents a CMS content points at

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
@@ -1,0 +1,332 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.field.builder.RichTextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.relationship.util.ObjectRelationshipUtil;
+import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class CMSContentOutboundLinksModelDocumentContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_contentStructuresObjectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				TestPropsValues.getCompanyId());
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_group = _depotEntry.getGroup();
+
+		_objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+					_group.getGroupId(), TestPropsValues.getCompanyId());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for (ObjectRelationship objectRelationship : _objectRelationships) {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship.getObjectRelationshipId());
+		}
+
+		_objectRelationships.clear();
+
+		for (ObjectDefinition objectDefinition : _objectDefinitions) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition.getObjectDefinitionId());
+		}
+
+		_objectDefinitions.clear();
+
+		_depotEntryLocalService.deleteDepotEntry(_depotEntry.getDepotEntryId());
+	}
+
+	@Test
+	public void testContributeNoOutboundLinks() throws Exception {
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>No references at all</p>"
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertNull(document.getField("outboundLinks"));
+	}
+
+	@Test
+	public void testContributeRelationshipReference() throws Exception {
+		ObjectDefinition parentObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition childObjectDefinition = _addCMSObjectDefinition();
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, parentObjectDefinition,
+				childObjectDefinition);
+
+		_objectRelationships.add(objectRelationship);
+
+		ObjectEntry parentObjectEntry = _addObjectEntry(
+			parentObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>Target</p>"
+			).build());
+
+		ObjectEntry childObjectEntry = _addObjectEntry(
+			childObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					parentObjectDefinition, objectRelationship.getName()),
+				parentObjectEntry.getObjectEntryId()
+			).put(
+				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>Source</p>"
+			).build());
+
+		Document document = _getDocument(
+			childObjectDefinition, childObjectEntry);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				"objectEntryId_" + parentObjectEntry.getObjectEntryId()
+			},
+			document.getValues("outboundLinks"));
+	}
+
+	@Test
+	public void testContributeRichTextReferences() throws Exception {
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String otherExternalReferenceCode = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME,
+				StringBundler.concat(
+					_getImageHTML(externalReferenceCode),
+					_getVideoHTML(otherExternalReferenceCode),
+					"<a href=\"https://www.liferay.com\">External</a>")
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				"objectEntryERC_" + externalReferenceCode,
+				"objectEntryERC_" + otherExternalReferenceCode
+			},
+			document.getValues("outboundLinks"));
+	}
+
+	@Test
+	public void testContributeWhenObjectDefinitionIsNotCMS() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				false, false, false, ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(_buildRichTextObjectField()), 0,
+				ObjectDefinitionConstants.SCOPE_SITE,
+				TestPropsValues.getUserId());
+
+		_objectDefinitions.add(objectDefinition);
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME,
+				_getImageHTML(RandomTestUtil.randomString())
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertNull(document.getField("outboundLinks"));
+	}
+
+	private ObjectDefinition _addCMSObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				false, false, false, ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(_buildRichTextObjectField()),
+				_contentStructuresObjectFolder.getObjectFolderId(),
+				ObjectDefinitionConstants.SCOPE_DEPOT,
+				TestPropsValues.getUserId());
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS, "true");
+
+		_objectDefinitions.add(objectDefinition);
+
+		return objectDefinition;
+	}
+
+	private ObjectEntry _addObjectEntry(
+			ObjectDefinition objectDefinition, Map<String, Serializable> values)
+		throws Exception {
+
+		return ObjectEntryTestUtil.addObjectEntry(
+			_group.getGroupId(), objectDefinition,
+			_objectEntryFolder.getObjectEntryFolderId(), values);
+	}
+
+	private ObjectField _buildRichTextObjectField() throws Exception {
+		return new RichTextObjectFieldBuilder(
+		).indexed(
+			true
+		).labelMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+		).name(
+			_RICH_TEXT_OBJECT_FIELD_NAME
+		).userId(
+			TestPropsValues.getUserId()
+		).build();
+	}
+
+	private Document _getDocument(
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+		throws Exception {
+
+		Indexer<ObjectEntry> indexer = IndexerRegistryUtil.getIndexer(
+			objectDefinition.getClassName());
+
+		return indexer.getDocument(objectEntry);
+	}
+
+	private String _getImageHTML(String externalReferenceCode) {
+		return StringBundler.concat(
+			"<img src=\"/documents/20125/0/image.jpg/", StringUtil.randomId(),
+			"?download=true&amp;objectDefinitionExternalReferenceCode=",
+			"L_CMS_BASIC_DOCUMENT&amp;objectEntryExternalReferenceCode=",
+			externalReferenceCode,
+			"&amp;objectFieldExternalReferenceCode=FILE\">");
+	}
+
+	private String _getVideoHTML(String externalReferenceCode) {
+		String url = StringBundler.concat(
+			"/documents/20125/0/video.mp4/", StringUtil.randomId(),
+			"?download=true&amp;objectDefinitionExternalReferenceCode=",
+			"L_CMS_BASIC_DOCUMENT&amp;objectEntryExternalReferenceCode=",
+			externalReferenceCode,
+			"&amp;objectFieldExternalReferenceCode=FILE");
+
+		return StringBundler.concat(
+			"<div data-oembed-url=\"", url, "\"><video src=\"", url,
+			"\"></video></div>");
+	}
+
+	private static final String _RICH_TEXT_OBJECT_FIELD_NAME = "content";
+
+	private ObjectFolder _contentStructuresObjectFolder;
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private final List<ObjectDefinition> _objectDefinitions = new ArrayList<>();
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+
+	private ObjectEntryFolder _objectEntryFolder;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private final List<ObjectRelationship> _objectRelationships =
+		new ArrayList<>();
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
@@ -42,6 +42,8 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -64,6 +66,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Jürgen Kappler
  */
+@FeatureFlags(featureFlags = @FeatureFlag("LPD-82226"))
 @RunWith(Arquillian.class)
 public class CMSContentOutboundLinksModelDocumentContributorTest {
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
@@ -124,106 +124,11 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 	}
 
 	@Test
-	public void testContributeNoOutboundLinks() throws Exception {
-		ObjectDefinition objectDefinition = _addCMSObjectDefinition();
-
-		ObjectEntry objectEntry = _addObjectEntry(
-			objectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>No references at all</p>"
-			).build());
-
-		Document document = _getDocument(objectDefinition, objectEntry);
-
-		Assert.assertNull(document.getField("outboundLinks"));
-	}
-
-	@Test
-	public void testContributeRelationshipReference() throws Exception {
-		ObjectDefinition parentObjectDefinition = _addCMSObjectDefinition();
-		ObjectDefinition childObjectDefinition = _addCMSObjectDefinition();
-
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, parentObjectDefinition,
-				childObjectDefinition);
-
-		_objectRelationships.add(objectRelationship);
-
-		ObjectEntry parentObjectEntry = _addObjectEntry(
-			parentObjectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>Target</p>"
-			).build());
-
-		ObjectEntry childObjectEntry = _addObjectEntry(
-			childObjectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				ObjectRelationshipUtil.getObjectRelationshipFieldName(
-					parentObjectDefinition, objectRelationship.getName()),
-				parentObjectEntry.getObjectEntryId()
-			).put(
-				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>Source</p>"
-			).build());
-
-		Document document = _getDocument(
-			childObjectDefinition, childObjectEntry);
-
-		Assert.assertArrayEquals(
-			new String[] {
-				"objectEntryId_" + parentObjectEntry.getObjectEntryId()
-			},
-			document.getValues("outboundLinks"));
-	}
-
-	@Test
-	public void testContributeRichTextReferences() throws Exception {
-		ObjectDefinition objectDefinition = _addCMSObjectDefinition();
-
-		String externalReferenceCode = RandomTestUtil.randomString();
-		String otherExternalReferenceCode = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = _addObjectEntry(
-			objectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				_RICH_TEXT_OBJECT_FIELD_NAME,
-				StringBundler.concat(
-					_getImageHTML(externalReferenceCode),
-					_getVideoHTML(otherExternalReferenceCode),
-					"<a href=\"https://www.liferay.com\">External</a>")
-			).build());
-
-		Document document = _getDocument(objectDefinition, objectEntry);
-
-		Assert.assertArrayEquals(
-			new String[] {
-				"objectEntryERC_" + externalReferenceCode,
-				"objectEntryERC_" + otherExternalReferenceCode
-			},
-			document.getValues("outboundLinks"));
-	}
-
-	@Test
-	public void testContributeWhenObjectDefinitionIsNotCMS() throws Exception {
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				false, false, false, ObjectDefinitionTestUtil.getRandomName(),
-				Collections.singletonList(_buildRichTextObjectField()), 0,
-				ObjectDefinitionConstants.SCOPE_SITE,
-				TestPropsValues.getUserId());
-
-		_objectDefinitions.add(objectDefinition);
-
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			TestPropsValues.getGroupId(), objectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				_RICH_TEXT_OBJECT_FIELD_NAME,
-				_getImageHTML(RandomTestUtil.randomString())
-			).build());
-
-		Document document = _getDocument(objectDefinition, objectEntry);
-
-		Assert.assertNull(document.getField("outboundLinks"));
+	public void testContribute() throws Exception {
+		_testContributeWhenObjectDefinitionIsNotCMS();
+		_testContributeWithRelationshipReference();
+		_testContributeWithRichTextReferences();
+		_testContributeWithoutReferences();
 	}
 
 	private ObjectDefinition _addCMSObjectDefinition() throws Exception {
@@ -297,6 +202,107 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 		return StringBundler.concat(
 			"<div data-oembed-url=\"", url, "\"><video src=\"", url,
 			"\"></video></div>");
+	}
+
+	private void _testContributeWhenObjectDefinitionIsNotCMS()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				false, false, false, ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(_buildRichTextObjectField()), 0,
+				ObjectDefinitionConstants.SCOPE_SITE,
+				TestPropsValues.getUserId());
+
+		_objectDefinitions.add(objectDefinition);
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME,
+				_getImageHTML(RandomTestUtil.randomString())
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertNull(document.getField("outboundLinks"));
+	}
+
+	private void _testContributeWithoutReferences() throws Exception {
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>No references at all</p>"
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertNull(document.getField("outboundLinks"));
+	}
+
+	private void _testContributeWithRelationshipReference() throws Exception {
+		ObjectDefinition parentObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition childObjectDefinition = _addCMSObjectDefinition();
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, parentObjectDefinition,
+				childObjectDefinition);
+
+		_objectRelationships.add(objectRelationship);
+
+		ObjectEntry parentObjectEntry = _addObjectEntry(
+			parentObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>Target</p>"
+			).build());
+
+		ObjectEntry childObjectEntry = _addObjectEntry(
+			childObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					parentObjectDefinition, objectRelationship.getName()),
+				parentObjectEntry.getObjectEntryId()
+			).put(
+				_RICH_TEXT_OBJECT_FIELD_NAME, "<p>Source</p>"
+			).build());
+
+		Document document = _getDocument(
+			childObjectDefinition, childObjectEntry);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				"objectEntryId_" + parentObjectEntry.getObjectEntryId()
+			},
+			document.getValues("outboundLinks"));
+	}
+
+	private void _testContributeWithRichTextReferences() throws Exception {
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String otherExternalReferenceCode = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_RICH_TEXT_OBJECT_FIELD_NAME,
+				StringBundler.concat(
+					_getImageHTML(externalReferenceCode),
+					_getVideoHTML(otherExternalReferenceCode),
+					"<a href=\"https://www.liferay.com\">External</a>")
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				"objectEntryERC_" + externalReferenceCode,
+				"objectEntryERC_" + otherExternalReferenceCode
+			},
+			document.getValues("outboundLinks"));
 	}
 
 	private static final String _RICH_TEXT_OBJECT_FIELD_NAME = "content";

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-rest-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/links/OutboundLinksUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/links/OutboundLinksUtil.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.links;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class OutboundLinksUtil {
+
+	public static Set<String> getObjectEntryExternalReferenceCodes(
+		String content) {
+
+		if (Validator.isNull(content)) {
+			return Collections.emptySet();
+		}
+
+		Matcher matcher = _pattern.matcher(
+			StringUtil.replace(
+				content, StringPool.AMPERSAND_ENCODED, StringPool.AMPERSAND));
+
+		Set<String> objectEntryExternalReferenceCodes = new LinkedHashSet<>();
+
+		while (matcher.find()) {
+			String objectEntryExternalReferenceCode = _decodeURL(
+				matcher.group(1));
+
+			if (Validator.isNotNull(objectEntryExternalReferenceCode)) {
+				objectEntryExternalReferenceCodes.add(
+					objectEntryExternalReferenceCode);
+			}
+		}
+
+		return objectEntryExternalReferenceCodes;
+	}
+
+	private static String _decodeURL(String value) {
+		if (!value.contains(StringPool.PERCENT)) {
+			return value;
+		}
+
+		try {
+			return URLCodec.decodeURL(value);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return value;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OutboundLinksUtil.class);
+
+	private static final Pattern _pattern = Pattern.compile(
+		"objectEntryExternalReferenceCode=([^&\"'\\s>]+)");
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSOutboundLinksCompanyIndexConfigurationContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSOutboundLinksCompanyIndexConfigurationContributor.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.CompanyIndexConfigurationContributor;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.SettingsHelper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = CompanyIndexConfigurationContributor.class)
+public class CMSOutboundLinksCompanyIndexConfigurationContributor
+	implements CompanyIndexConfigurationContributor {
+
+	@Override
+	public void contributeMappings(
+		long companyId, MappingsHelper mappingsHelper) {
+
+		mappingsHelper.putMappings(
+			StringUtil.read(
+				getClass(), "dependencies/outbound-links-type-mappings.json"));
+	}
+
+	@Override
+	public void contributeSettings(
+		long companyId, SettingsHelper settingsHelper) {
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -10,6 +10,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -23,7 +24,7 @@ import com.liferay.site.cms.site.initializer.internal.search.links.OutboundLinks
 
 import java.io.Serializable;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 					if (objectEntryId != 0) {
 						outboundLinks.add(
 							_getToken(
-								_TOKEN_PREFIX_OBJECT_ENTRY_ID,
+								"objectEntryId",
 								String.valueOf(objectEntryId)));
 					}
 				}
@@ -101,8 +102,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 
 							outboundLinks.add(
 								_getToken(
-									_TOKEN_PREFIX_OBJECT_ENTRY_ERC,
-									externalReferenceCode));
+									"objectEntryERC", externalReferenceCode));
 						}
 					}
 				}
@@ -130,8 +130,6 @@ public class CMSContentOutboundLinksModelDocumentContributor
 	private List<String> _getContents(
 		ObjectField objectField, Map<String, Serializable> values) {
 
-		List<String> contents = new ArrayList<>();
-
 		if (objectField.isLocalized()) {
 			Object localizedValues = values.get(
 				objectField.getI18nObjectFieldName());
@@ -139,33 +137,30 @@ public class CMSContentOutboundLinksModelDocumentContributor
 			if (localizedValues instanceof Map) {
 				Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
 
-				for (Object value : localizedValuesMap.values()) {
-					if (value != null) {
-						contents.add(String.valueOf(value));
-					}
-				}
+				return TransformUtil.transform(
+					localizedValuesMap.values(),
+					localizedValue -> {
+						if (localizedValue == null) {
+							return null;
+						}
 
-				return contents;
+						return String.valueOf(localizedValue);
+					});
 			}
 		}
 
-		Object value = values.get(objectField.getName());
+		Object content = values.get(objectField.getName());
 
-		if (value != null) {
-			contents.add(String.valueOf(value));
+		if (content == null) {
+			return Collections.emptyList();
 		}
 
-		return contents;
+		return Collections.singletonList(String.valueOf(content));
 	}
 
 	private String _getToken(String prefix, String value) {
 		return StringBundler.concat(prefix, StringPool.UNDERLINE, value);
 	}
-
-	private static final String _TOKEN_PREFIX_OBJECT_ENTRY_ERC =
-		"objectEntryERC";
-
-	private static final String _TOKEN_PREFIX_OBJECT_ENTRY_ID = "objectEntryId";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CMSContentOutboundLinksModelDocumentContributor.class);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -12,6 +12,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -49,6 +50,12 @@ public class CMSContentOutboundLinksModelDocumentContributor
 		ObjectEntry objectEntry = (ObjectEntry)baseModel;
 
 		try {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					objectEntry.getCompanyId(), "LPD-82226")) {
+
+				return;
+			}
+
 			ObjectDefinition objectDefinition =
 				objectEntry.getObjectDefinition();
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentContributor;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.site.cms.site.initializer.internal.search.links.OutboundLinksUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = DocumentContributor.class)
+public class CMSContentOutboundLinksModelDocumentContributor
+	implements DocumentContributor<ObjectEntry> {
+
+	@Override
+	public void contribute(
+		Document document, BaseModel<ObjectEntry> baseModel) {
+
+		if (!(baseModel instanceof ObjectEntry)) {
+			return;
+		}
+
+		ObjectEntry objectEntry = (ObjectEntry)baseModel;
+
+		try {
+			ObjectDefinition objectDefinition =
+				objectEntry.getObjectDefinition();
+
+			if (!objectDefinition.isCMS()) {
+				return;
+			}
+
+			Set<String> outboundLinks = new LinkedHashSet<>();
+
+			Map<String, Serializable> values = objectEntry.getValues();
+
+			ObjectFieldBag objectFieldBag =
+				objectDefinition.getObjectFieldBag();
+
+			for (ObjectField objectField :
+					objectFieldBag.getIndexedObjectFields()) {
+
+				String businessType = objectField.getBusinessType();
+
+				if (Objects.equals(
+						businessType,
+						ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
+
+					long objectEntryId = GetterUtil.getLong(
+						values.get(objectField.getName()));
+
+					if (objectEntryId != 0) {
+						outboundLinks.add(
+							_getToken(
+								_TOKEN_PREFIX_OBJECT_ENTRY_ID,
+								String.valueOf(objectEntryId)));
+					}
+				}
+				else if (Objects.equals(
+							businessType,
+							ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+					for (String content : _getContents(objectField, values)) {
+						for (String externalReferenceCode :
+								OutboundLinksUtil.
+									getObjectEntryExternalReferenceCodes(
+										content)) {
+
+							outboundLinks.add(
+								_getToken(
+									_TOKEN_PREFIX_OBJECT_ENTRY_ERC,
+									externalReferenceCode));
+						}
+					}
+				}
+			}
+
+			if (!outboundLinks.isEmpty()) {
+				document.addKeyword(
+					"outboundLinks", outboundLinks.toArray(new String[0]));
+			}
+		}
+		catch (Exception exception) {
+
+			// Never break indexing of the object entry because of the outbound
+			// links
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to contribute outbound links for object entry " +
+						objectEntry.getObjectEntryId(),
+					exception);
+			}
+		}
+	}
+
+	private List<String> _getContents(
+		ObjectField objectField, Map<String, Serializable> values) {
+
+		List<String> contents = new ArrayList<>();
+
+		if (objectField.isLocalized()) {
+			Object localizedValues = values.get(
+				objectField.getI18nObjectFieldName());
+
+			if (localizedValues instanceof Map) {
+				Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+				for (Object value : localizedValuesMap.values()) {
+					if (value != null) {
+						contents.add(String.valueOf(value));
+					}
+				}
+
+				return contents;
+			}
+		}
+
+		Object value = values.get(objectField.getName());
+
+		if (value != null) {
+			contents.add(String.valueOf(value));
+		}
+
+		return contents;
+	}
+
+	private String _getToken(String prefix, String value) {
+		return StringBundler.concat(prefix, StringPool.UNDERLINE, value);
+	}
+
+	private static final String _TOKEN_PREFIX_OBJECT_ENTRY_ERC =
+		"objectEntryERC";
+
+	private static final String _TOKEN_PREFIX_OBJECT_ENTRY_ID = "objectEntryId";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CMSContentOutboundLinksModelDocumentContributor.class);
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -66,7 +66,8 @@ public class CMSContentOutboundLinksModelDocumentContributor
 
 			Set<String> outboundLinks = new LinkedHashSet<>();
 
-			Map<String, Serializable> values = objectEntry.getValues();
+			Map<String, Serializable> indexedValues =
+				objectEntry.getIndexedValues();
 
 			ObjectFieldBag objectFieldBag =
 				objectDefinition.getObjectFieldBag();
@@ -81,7 +82,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 						ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
 
 					long objectEntryId = GetterUtil.getLong(
-						values.get(objectField.getName()));
+						indexedValues.get(objectField.getName()));
 
 					if (objectEntryId != 0) {
 						outboundLinks.add(
@@ -94,7 +95,9 @@ public class CMSContentOutboundLinksModelDocumentContributor
 							businessType,
 							ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
 
-					for (String content : _getContents(objectField, values)) {
+					for (String content :
+							_getContents(objectField, indexedValues)) {
+
 						for (String externalReferenceCode :
 								OutboundLinksUtil.
 									getObjectEntryExternalReferenceCodes(
@@ -128,10 +131,10 @@ public class CMSContentOutboundLinksModelDocumentContributor
 	}
 
 	private List<String> _getContents(
-		ObjectField objectField, Map<String, Serializable> values) {
+		ObjectField objectField, Map<String, Serializable> indexedValues) {
 
 		if (objectField.isLocalized()) {
-			Object localizedValues = values.get(
+			Object localizedValues = indexedValues.get(
 				objectField.getI18nObjectFieldName());
 
 			if (localizedValues instanceof Map) {
@@ -149,7 +152,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 			}
 		}
 
-		Object content = values.get(objectField.getName());
+		Object content = indexedValues.get(objectField.getName());
 
 		if (content == null) {
 			return Collections.emptyList();

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/outbound-links-type-mappings.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/outbound-links-type-mappings.json
@@ -1,0 +1,7 @@
+{
+	"properties": {
+		"outboundLinks": {
+			"type": "keyword"
+		}
+	}
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/links/OutboundLinksUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/links/OutboundLinksUtilTest.java
@@ -1,0 +1,145 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.links;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class OutboundLinksUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetObjectEntryExternalReferenceCodes() {
+		_testGetObjectEntryExternalReferenceCodesWithBlankContent();
+		_testGetObjectEntryExternalReferenceCodesWithEmbeddedDocument();
+		_testGetObjectEntryExternalReferenceCodesWithEmbeddedVideo();
+		_testGetObjectEntryExternalReferenceCodesWithEncodedValue();
+		_testGetObjectEntryExternalReferenceCodesWithMalformedValue();
+		_testGetObjectEntryExternalReferenceCodesWithMultipleReferences();
+		_testGetObjectEntryExternalReferenceCodesWithUnescapedQueryString();
+		_testGetObjectEntryExternalReferenceCodesWithoutReferences();
+	}
+
+	private String _getDocumentURL(String objectEntryExternalReferenceCode) {
+		return StringBundler.concat(
+			"/documents/1/2/document.jpg/3?version=1.0&amp;",
+			"download=true&amp;groupExternalReferenceCode=4&amp;",
+			"objectDefinitionExternalReferenceCode=L_CMS_BASIC_DOCUMENT&amp;",
+			"objectEntryExternalReferenceCode=",
+			objectEntryExternalReferenceCode,
+			"&amp;objectFieldExternalReferenceCode=FILE");
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithBlankContent() {
+		Assert.assertEquals(
+			Collections.emptySet(),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(null));
+		Assert.assertEquals(
+			Collections.emptySet(),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(""));
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithEmbeddedDocument() {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			Collections.singleton(externalReferenceCode),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(
+				StringBundler.concat(
+					"<p><img src=\"", _getDocumentURL(externalReferenceCode),
+					"\"></p>")));
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithEmbeddedVideo() {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			Collections.singleton(externalReferenceCode),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(
+				StringBundler.concat(
+					"<figure class=\"media\"><div data-oembed-url=\"https://",
+					_getDocumentURL(externalReferenceCode),
+					"\"><video controls=\"\" src=\"",
+					_getDocumentURL(externalReferenceCode),
+					"\"></video></div></figure>")));
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithEncodedValue() {
+		Assert.assertEquals(
+			Collections.singleton("a b"),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(
+				"<img src=\"" + _getDocumentURL("a%20b") + "\">"));
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithMalformedValue() {
+		Assert.assertEquals(
+			Collections.singleton("a%"),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(
+				"<img src=\"" + _getDocumentURL("a%") + "\">"));
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithMultipleReferences() {
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String otherExternalReferenceCode = RandomTestUtil.randomString();
+
+		Set<String> objectEntryExternalReferenceCodes =
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(
+				StringBundler.concat(
+					"<img src=\"", _getDocumentURL(externalReferenceCode),
+					"\"><img src=\"",
+					_getDocumentURL(otherExternalReferenceCode), "\">"));
+
+		Assert.assertEquals(
+			objectEntryExternalReferenceCodes.toString(), 2,
+			objectEntryExternalReferenceCodes.size());
+		Assert.assertTrue(
+			objectEntryExternalReferenceCodes.toString(),
+			objectEntryExternalReferenceCodes.contains(externalReferenceCode));
+		Assert.assertTrue(
+			objectEntryExternalReferenceCodes.toString(),
+			objectEntryExternalReferenceCodes.contains(
+				otherExternalReferenceCode));
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithoutReferences() {
+		Assert.assertEquals(
+			Collections.emptySet(),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(
+				StringBundler.concat(
+					"<p>Some rich text</p><p><a href=\"www.claude.com\">",
+					"www.claude.com</a></p><p>",
+					"<a href=\"/web/guest/home\">A page</a></p>")));
+	}
+
+	private void _testGetObjectEntryExternalReferenceCodesWithUnescapedQueryString() {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			Collections.singleton(externalReferenceCode),
+			OutboundLinksUtil.getObjectEntryExternalReferenceCodes(
+				StringBundler.concat(
+					"/documents/1/2?objectEntryExternalReferenceCode=",
+					externalReferenceCode,
+					"&objectFieldExternalReferenceCode=FILE")));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97869

## What Is Being Fixed

The Content Governance Dashboard's Broken Links and Similar Links widgets both need to know which contents a CMS content points at, and nothing records that today. There is no outbound-reference index anywhere in the portal, and the search document for a CMS content keeps no trace of its links: attachment targets are discarded after a file-name lookup, and rich-text markup is reduced to visible text by `HtmlParserUtil.extractText` before indexing, so every `href` and `src` is gone by the time the document is written. Both widgets are blocked on a net-new extraction and indexing pass.

## How It Is Being Fixed

This is the first phase of the pipeline, extraction and indexing only. There is no endpoint and no UI yet; the read path, the Broken Links endpoint and the LINKS similarity dimension are the next phase, and they are why the field exists.

`OutboundLinksUtil` extracts the contents a rich-text value references. The CMS editor writes the target's identity into the URL it generates, so this is a query-parameter parse rather than an HTML crawl: no friendly-URL resolution and no canonicalization, because the editor already resolved the target. It decodes percent-encoded values, leaves malformed ones alone rather than dropping them, and deduplicates, which matters because a single embedded video yields the same target twice, once on `data-oembed-url` and once on `video src`.

`CMSContentOutboundLinksModelDocumentContributor` adds the `outboundLinks` field, taking relationship targets by id and rich-text targets by external reference code. It registers as a plain `DocumentContributor` with no `indexer.class.name`, which is deliberate rather than an omission. CMS contents are indexed by a per-object-definition indexer, so a contributor bound to `ObjectEntry` answers only on a full reindex and never when an author saves. The one global contributor list is handed to every indexer, so a single component covers both the write path and the full reindex with no `ServiceTracker` registrar and no per-definition registration to pay for at boot. `ExternalReferenceCodeModelDocumentContributor` is the template.

`CMSOutboundLinksCompanyIndexConfigurationContributor` declares the field as `keyword`. Without it the dynamic template maps it as `text` and the terms queries the read path is built on cannot run.

The last commit puts the write behind `LPD-82226`, so nothing reaches a customer index while the dashboard is still being built. The mapping is deliberately left ungated. Feature flags toggle at runtime, so gating it would let the contributor start writing into an index that has no mapping for the field; Elasticsearch would dynamic-map it as `text`, and the next `putMappings` would hit a mapper conflict and be rejected, leaving the field `text` until someone recreates the index and reindexes. Keeping the mapping always on guarantees mapping-before-data and costs one field declaration.

## Test Execution

```bash
cd modules/apps/site/site-cms-site-initializer && gradlew test --tests OutboundLinksUtilTest

cd modules/apps/site/site-cms-site-initializer-test && gradlew testIntegration --tests CMSContentOutboundLinksModelDocumentContributorTest
```

With the flag off by default, the integration test is what exercises this path in CI; it carries `@FeatureFlags(featureFlags = @FeatureFlag("LPD-82226"))`.

## PR Check

**pr-check: PASS** — tested on `a44afcc754f047a00348ce2bd6531087af0b60ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Source Format ran with `-Dvalidate.commit.messages=true`.

Cross-Module Compile ran with an empty consumer set: `OutboundLinksUtil` is new and lives in an `internal` package, so no deprecated module and no `testIntegration` source outside this bundle references it.

Structural Smoke ran `ModulesStructureTest` only, selected by the `build.gradle` change; 8 tests pass.

<!-- pr-check {"result": "success", "sha": "a44afcc754f047a00348ce2bd6531087af0b60ed"} -->
