### PR TITLE
LPD-101967 Show site names with HTML characters as typed

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
+++ b/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
@@ -5,6 +5,8 @@
 
 // @ts-nocheck
 
+import {escapeHTML} from 'frontend-js-web';
+
 jest.mock('@ckeditor/ckeditor5-bookmark/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-clipboard/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-editor-decoupled/dist/index', () => ({}));
@@ -84,7 +86,7 @@ class MockBroadcastChannel {
 	},
 	Util: {
 		...(globalThis.Liferay.Util || {}),
-		escapeHTML: (str: string) => str,
+		escapeHTML,
 		formatStorage: (size: number) => `${size / 1024} KB`,
 	},
 	authToken: 'mocked-auth-token',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/DeleteStructureModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/DeleteStructureModalContent.tsx
@@ -40,10 +40,7 @@ export default function DeleteStructureModalContent({
 			<ClayModal.Header
 				closeButtonAriaLabel={Liferay.Language.get('close')}
 			>
-				{sub(
-					Liferay.Language.get('delete-x'),
-					Liferay.Util.escapeHTML(name)
-				)}
+				{sub(Liferay.Language.get('delete-x'), name)}
 			</ClayModal.Header>
 
 			<ClayModal.Body>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
@@ -319,9 +319,7 @@ const ConnectableSelector = ({
 								<ItemSelector.Item
 									className="align-items-center d-flex"
 									key={item.id}
-									textValue={Liferay.Util.escapeHTML(
-										item.descriptiveName
-									)}
+									textValue={item.descriptiveName}
 								>
 									<ClaySticker
 										className="c-mr-2"
@@ -335,9 +333,7 @@ const ConnectableSelector = ({
 										/>
 									</ClaySticker>
 
-									{Liferay.Util.escapeHTML(
-										item.descriptiveName
-									)}
+									{item.descriptiveName}
 								</ItemSelector.Item>
 							)}
 						</ItemSelector>
@@ -371,9 +367,7 @@ const ConnectableSelector = ({
 								<ItemSelector.Item
 									className="align-items-center d-flex"
 									key={item.id}
-									textValue={Liferay.Util.escapeHTML(
-										item.name
-									)}
+									textValue={item.name}
 								>
 									<ClaySticker
 										className="c-mr-2"
@@ -387,7 +381,7 @@ const ConnectableSelector = ({
 										/>
 									</ClaySticker>
 
-									{Liferay.Util.escapeHTML(item.name)}
+									{item.name}
 								</ItemSelector.Item>
 							)}
 						</ItemSelector>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/DeleteStructureModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/DeleteStructureModalContent.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import mockSub from '../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/sub';
+import DeleteStructureModalContent from '../../../../src/main/resources/META-INF/resources/js/main_view/modal/DeleteStructureModalContent';
+
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual<typeof import('frontend-js-web')>('frontend-js-web'),
+	sub: mockSub,
+}));
+
+const STRUCTURE_NAME = 'Marketing & Sales/EMEA';
+
+const DEFAULT_PROPS = {
+	closeModal: jest.fn(),
+	name: STRUCTURE_NAME,
+	onDelete: jest.fn(),
+	usesCount: 2,
+};
+
+describe('DeleteStructureModalContent', () => {
+	const languageGet = Liferay.Language.get;
+
+	beforeEach(() => {
+		Liferay.Language.get = jest.fn((key: string) =>
+			key === 'delete-x' ? 'Delete {0}' : key
+		);
+	});
+
+	afterEach(() => {
+		Liferay.Language.get = languageGet;
+	});
+
+	it('renders a structure name containing HTML characters as typed', () => {
+		render(<DeleteStructureModalContent {...DEFAULT_PROPS} />);
+
+		expect(
+			screen.getByText(`Delete ${STRUCTURE_NAME}`)
+		).toBeInTheDocument();
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
@@ -87,12 +87,41 @@ const mockUnconnectedSiteTemplate: SiteTemplate = {
 	siteExternalReferenceCode: '102-erc',
 };
 
+const mockAutocompleteFetch = ({
+	siteTemplates = [],
+	sites = [],
+}: {
+	siteTemplates?: SiteTemplate[];
+	sites?: Site[];
+} = {}) => {
+	const itemsByPathname: Record<string, Site[] | SiteTemplate[]> = {
+		'/o/headless-admin-site/v1.0/site-templates': siteTemplates,
+		'/o/headless-admin-site/v1.0/sites': sites,
+	};
+
+	mockFetch.mockImplementation(async (...args: unknown[]) => {
+		const url = String(args[0]);
+		const items = itemsByPathname[new URL(url).pathname];
+
+		if (!items) {
+			throw new Error(`Unexpected autocomplete request: ${url}`);
+		}
+
+		return {
+			headers: new Headers([['Content-Type', 'application/json']]),
+			json: async () => ({items}),
+		} as Response;
+	});
+};
+
 const DEFAULT_PROPS = {
 	externalReferenceCode: 'ERC',
 	hasConnectSitesPermission: true,
 };
 
 const errorMessage = 'Connection failed';
+
+const SPECIAL_CHARS_NAME = 'Marketing & Sales/EMEA';
 
 const renderComponent = (props = DEFAULT_PROPS) => {
 	return render(<SpaceConnectedSitesModal {...props} />);
@@ -139,6 +168,8 @@ describe('SpaceConnectedSitesModal', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+
+		mockAutocompleteFetch();
 
 		mockGetConnectedSitesFromSpace.mockResolvedValue({
 			data: {items: mockConnectedSites},
@@ -240,15 +271,8 @@ describe('SpaceConnectedSitesModal', () => {
 
 	describe('when hasConnectSitesPermission is true', () => {
 		it('allows connecting a new site', async () => {
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({
-						items: [...mockConnectedSites, mockUnconnectedSite],
-					}),
-				} as Response;
+			mockAutocompleteFetch({
+				sites: [...mockConnectedSites, mockUnconnectedSite],
 			});
 
 			renderComponent();
@@ -291,14 +315,7 @@ describe('SpaceConnectedSitesModal', () => {
 		});
 
 		it('renders the site logo in the autocomplete options', async () => {
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({items: [mockUnconnectedSite]}),
-				} as Response;
-			});
+			mockAutocompleteFetch({sites: [mockUnconnectedSite]});
 
 			renderComponent();
 			await waitForComponentRendering();
@@ -315,16 +332,54 @@ describe('SpaceConnectedSitesModal', () => {
 			);
 		});
 
+		it('renders a site name containing HTML characters as typed', async () => {
+			mockAutocompleteFetch({
+				sites: [
+					{
+						...mockUnconnectedSite,
+						descriptiveName: SPECIAL_CHARS_NAME,
+					},
+				],
+			});
+
+			renderComponent();
+			await waitForComponentRendering();
+
+			await userEvent.click(screen.getByPlaceholderText('select-a-site'));
+
+			expect(
+				await screen.findByRole('option', {name: SPECIAL_CHARS_NAME})
+			).toBeInTheDocument();
+		});
+
+		it('renders a site template name containing HTML characters as typed', async () => {
+			mockAutocompleteFetch({
+				siteTemplates: [
+					{...mockUnconnectedSiteTemplate, name: SPECIAL_CHARS_NAME},
+				],
+			});
+
+			renderComponent();
+			await waitForComponentRendering();
+
+			await userEvent.click(screen.getByLabelText('sites'));
+
+			await userEvent.click(
+				screen.getByRole('option', {name: 'site-templates'})
+			);
+
+			await userEvent.click(
+				screen.getByPlaceholderText('select-a-site-template')
+			);
+
+			expect(
+				await screen.findByRole('option', {name: SPECIAL_CHARS_NAME})
+			).toBeInTheDocument();
+		});
+
 		it('shows an error toast if connecting a site fails', async () => {
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({
-						items: [...mockConnectedSites, mockUnconnectedSite],
-					}),
-				} as Response;
+			mockAutocompleteFetch({
+				sites: [...mockConnectedSites, mockUnconnectedSite],
 			});
 
 			mockConnectSiteToSpace.mockResolvedValue({
@@ -478,16 +533,7 @@ describe('SpaceConnectedSitesModal', () => {
 		});
 
 		it('disable connect to site button when site already selected', async () => {
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({
-						items: [...mockConnectedSites],
-					}),
-				} as Response;
-			});
+			mockAutocompleteFetch({sites: [...mockConnectedSites]});
 
 			renderComponent();
 			await waitForComponentRendering();
@@ -514,14 +560,7 @@ describe('SpaceConnectedSitesModal', () => {
 		});
 
 		it('excludes already-connected sites from the autocomplete request', async () => {
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({items: []}),
-				} as Response;
-			});
+			mockAutocompleteFetch();
 
 			renderComponent();
 			await waitForComponentRendering();
@@ -549,14 +588,7 @@ describe('SpaceConnectedSitesModal', () => {
 				error: null,
 			});
 
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({items: []}),
-				} as Response;
-			});
+			mockAutocompleteFetch();
 
 			renderComponent();
 
@@ -612,15 +644,8 @@ describe('SpaceConnectedSitesModal', () => {
 		});
 
 		it('allows connecting a new site template', async () => {
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({
-						items: [mockUnconnectedSiteTemplate],
-					}),
-				} as Response;
+			mockAutocompleteFetch({
+				siteTemplates: [mockUnconnectedSiteTemplate],
 			});
 
 			mockConnectSiteToSpace.mockResolvedValue({
@@ -688,15 +713,8 @@ describe('SpaceConnectedSitesModal', () => {
 		});
 
 		it('shows an error toast if connecting a site template fails', async () => {
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({
-						items: [mockUnconnectedSiteTemplate],
-					}),
-				} as Response;
+			mockAutocompleteFetch({
+				siteTemplates: [mockUnconnectedSiteTemplate],
 			});
 
 			mockConnectSiteToSpace.mockResolvedValue({
@@ -751,15 +769,8 @@ describe('SpaceConnectedSitesModal', () => {
 					mockConnectedSiteTemplate.externalReferenceCode,
 			};
 
-			mockFetch.mockImplementation(async () => {
-				return {
-					headers: new Headers([
-						['Content-Type', 'application/json'],
-					]),
-					json: async () => ({
-						items: [alreadyConnectedTemplate],
-					}),
-				} as Response;
+			mockAutocompleteFetch({
+				siteTemplates: [alreadyConnectedTemplate],
 			});
 
 			renderComponent();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101967

## What Is Being Fixed

The connected sites selector in a Space passed every site and site template name through `Liferay.Util.escapeHTML` before handing it to JSX. React already encodes text nodes, so the value was encoded twice and a site named `Marketing & Sales/EMEA` reached the dropdown as `Marketing &amp; Sales&#047;EMEA`. The connected sites list a few lines below renders the same name correctly through `getConnectionLabel`, so one string looked different in two places of the same dialog. The delete structure modal had the same defect in its header.

The symptom reported in the ticket was different: a nondeterministic `TypeError: Cannot read properties of undefined (reading 'replace')` while rendering, attributed to the transition between **Site** and **Site Template**. That attribution does not hold. Each `ItemSelector` carries a distinct `key={apiURL}`, so React unmounts one branch and mounts the other with nothing carried across, and eight rapid switches in a browser produce no error and two cleanly separated requests. The throw only ever happened in the Jest suite, where the fetch mock returned the same payload for every URL, mock implementations survive `jest.clearAllMocks()` (that is `resetAllMocks`), and the selector fetches on mount with a 500 ms delay — so under load one test's site template payload resolved into the next test's sites renderer.

## How It Is Being Fixed

The four calls in the item renderers are removed, both for the rendered text and for `textValue`, and so is the one in the delete modal header. The helper stays where it genuinely assembles HTML strings: the three toast messages built with `sub` and `<strong>`, and the two `dangerouslySetInnerHTML` paragraphs of the delete modal. This also makes the crash unreachable without adding a fallback at the renderer, which the ticket explicitly asked to avoid.

The `textValue` removal is for consistency, not observable behavior. Clay destructures it out of the item props so it never reaches the DOM, and only uses it for a fuzzy match that is discarded here because the highlight branch requires `typeof children === 'string'` while the children are a `ClaySticker` followed by the name. The accessible name comes from the rendered child, which is where a screen reader announced the encoded entity and where the removal fixes it.

On the test side, the fetch mock now routes by exact pathname and raises on any other URL, and is installed in `beforeEach` so no implementation leaks between tests. `jest-setup.config.ts` replaces the identity `escapeHTML` stub with the real implementation: the stub returned `undefined` instead of throwing, which is why a crash reachable in the browser was never reported by any test. That hunk is byte-identical to the one in #8766 and is not a contribution of this PR; if that one lands first, a rebase drops it.

The first commit adds two regression tests for the selector, asserting the option by accessible name; the second adds one for the delete modal header. All three were validated in both directions. The delete modal test needs two local overrides to observe the name at all — the real `sub`, and a `Liferay.Language.get` returning the `Delete {0}` template that `Language.properties` ships — because the default mocks return the template unchanged and the bare key respectively. The same technique would cover the three retained toast calls; left out to keep this scoped.

The module suite was run repeatedly to confirm the nondeterminism is gone, and the rendering was checked in a browser with sites named `Marketing & Sales` and `Support <Tier 1>/EMEA` connected to a Space.
