### PR TITLE
LPD-102030 Cover drag and drop upload in the CMS assets sections

### DIFF
--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
@@ -11,8 +11,6 @@ import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -49,12 +47,6 @@ public class ViewDesignLibraryAdminDisplayContext {
 	public String getAPIURL() {
 		return "/o/headless-asset-library/v1.0/asset-libraries?filter=type " +
 			"eq 'DesignLibrary'";
-	}
-
-	public Map<String, Object> getBreadcrumbProps() {
-		return HashMapBuilder.<String, Object>put(
-			"breadcrumbItems", _getBreadcrumbItemsJSONArray()
-		).build();
 	}
 
 	public Map<String, Object> getEmptyState() {
@@ -118,16 +110,6 @@ public class ViewDesignLibraryAdminDisplayContext {
 				"/design_library/view_resources_design_library"
 			).buildString()
 		).build();
-	}
-
-	private JSONArray _getBreadcrumbItemsJSONArray() {
-		return JSONUtil.putAll(
-			JSONUtil.put(
-				"active", true
-			).put(
-				"label",
-				LanguageUtil.get(_httpServletRequest, "design-libraries")
-			));
 	}
 
 	private String _getExportImportPortletURL(String portletId) {

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
@@ -29,6 +29,11 @@
 		background-color: $teal-l3;
 		color: $teal;
 	}
+
+	.fds .management-bar-wrapper {
+		border: 0;
+		margin-bottom: 0;
+	}
 }
 
 .design-library-fds-wrapper--resources {

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
@@ -25,6 +25,10 @@
 		}
 	}
 
+	.data-set-pagination-wrapper {
+		padding-inline: 0.75rem;
+	}
+
 	.design-library-fds-sticker-designlibrary {
 		background-color: $teal-l3;
 		color: $teal;

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
@@ -37,6 +37,10 @@
 	.fds .management-bar-wrapper {
 		border: 0;
 		margin-bottom: 0;
+
+		+ .inline-notification-bar {
+			margin-top: 0;
+		}
 	}
 }
 

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view.jsp
@@ -11,25 +11,16 @@
 ViewDesignLibraryAdminDisplayContext viewDesignLibraryAdminDisplayContext = new ViewDesignLibraryAdminDisplayContext(request, liferayPortletResponse);
 %>
 
-<div>
-	<div>
-		<react:component
-			module="{DesignLibraryBreadcrumb} from design-library-web"
-			props="<%= viewDesignLibraryAdminDisplayContext.getBreadcrumbProps() %>"
-		/>
-	</div>
-
-	<div class="design-library-fds-wrapper design-library-fds-wrapper--landing">
-		<frontend-data-set:headless-display
-			additionalProps="<%= viewDesignLibraryAdminDisplayContext.getFDSAdditionalProps() %>"
-			apiURL="<%= viewDesignLibraryAdminDisplayContext.getAPIURL() %>"
-			emptyState="<%= viewDesignLibraryAdminDisplayContext.getEmptyState() %>"
-			fdsActionDropdownItems="<%= viewDesignLibraryAdminDisplayContext.getFDSActionDropdownItems() %>"
-			formName="fm"
-			id="<%= DesignLibraryAdminFDSNames.DESIGN_LIBRARIES %>"
-			propsTransformer="{DesignLibraryAdminFDSPropsTransformer} from design-library-web"
-			selectedItemsKey="id"
-			selectionType="multiple"
-		/>
-	</div>
+<div class="design-library-fds-wrapper design-library-fds-wrapper--landing">
+	<frontend-data-set:headless-display
+		additionalProps="<%= viewDesignLibraryAdminDisplayContext.getFDSAdditionalProps() %>"
+		apiURL="<%= viewDesignLibraryAdminDisplayContext.getAPIURL() %>"
+		emptyState="<%= viewDesignLibraryAdminDisplayContext.getEmptyState() %>"
+		fdsActionDropdownItems="<%= viewDesignLibraryAdminDisplayContext.getFDSActionDropdownItems() %>"
+		formName="fm"
+		id="<%= DesignLibraryAdminFDSNames.DESIGN_LIBRARIES %>"
+		propsTransformer="{DesignLibraryAdminFDSPropsTransformer} from design-library-web"
+		selectedItemsKey="id"
+		selectionType="multiple"
+	/>
 </div>

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -32,7 +32,7 @@ ViewResourcesDesignLibraryDisplayContext viewResourcesDesignLibraryDisplayContex
 			Map<String, Object> membersFDSAdditionalProps = membersDesignLibraryDisplayContext.getFDSAdditionalProps();
 			%>
 
-			<div class="p-4">
+			<div class="pb-4 px-4">
 				<div class="row">
 					<div class="col-12 col-lg-8">
 						<div class="card">

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/GetObjectEntriesValuesStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/GetObjectEntriesValuesStrutsActionTest.java
@@ -44,6 +44,8 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -427,8 +429,14 @@ public class GetObjectEntriesValuesStrutsActionTest {
 			MockHttpServletResponse mockHttpServletResponse =
 				new MockHttpServletResponse();
 
-			_getObjectEntriesValuesStrutsAction.execute(
-				mockHttpServletRequest, mockHttpServletResponse);
+			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+					"com.liferay.site.cms.site.initializer.internal.struts." +
+						"GetObjectEntriesValuesStrutsAction",
+					LoggerTestUtil.OFF)) {
+
+				_getObjectEntriesValuesStrutsAction.execute(
+					mockHttpServletRequest, mockHttpServletResponse);
+			}
 
 			JSONArray resultJSONArray = _jsonFactory.createJSONArray(
 				mockHttpServletResponse.getContentAsString());

--- a/modules/test/playwright/tests/layout-page-template-admin-web/main/pageTemplatesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/main/pageTemplatesAdmin.spec.ts
@@ -476,6 +476,10 @@ test.describe('General', () => {
 			template: pageTemplateName,
 		});
 
+		// Publish the page so it can be reached through its live friendly URL
+
+		await pageEditorPage.publishPage();
+
 		// Assert new content page in view mode
 
 		await page.goto(`/web${site.friendlyUrlPath}/${layoutTitle}`);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditorPreview.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditorPreview.spec.ts
@@ -151,6 +151,11 @@ const createStructureWithAllFields = async ({
 				picklist: picklist.name,
 			});
 		}
+		else if (type === 'Select Related Content') {
+			await structureBuilderPage.changeFieldSettings({
+				relatedContent: 'Basic Document',
+			});
+		}
 		else if (type === 'Upload') {
 			await structureBuilderPage.changeFieldSettings({
 				requestFile: 'computer',
@@ -642,7 +647,9 @@ test(
 				},
 				{
 					action: async () => {
-						const trigger = form.getByLabel('Open Options Menu');
+						const trigger = form
+							.getByLabel('Open Options Menu')
+							.nth(1);
 
 						await trigger.scrollIntoViewIfNeeded();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditorPreview.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditorPreview.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import {Locator, Page, expect, mergeTests} from '@playwright/test';
+import {readFileSync} from 'fs';
 import path from 'path';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
@@ -554,6 +555,7 @@ test(
 		structureBuilderPage,
 	}) => {
 		const displayPageTemplateName = getRandomString();
+		const fileTitle = `File ${getRandomString()}`;
 		const spaceName = `Space ${getRandomString()}`;
 		const title = getRandomString();
 		const unsavedChangesAlert = page.getByText(
@@ -589,6 +591,26 @@ test(
 					spaceName,
 					spaceSummaryPage,
 				});
+			});
+
+			await test.step('Create a basic document to relate content to', async () => {
+				await apiHelpers.objectEntry.postObjectEntry(
+					{
+						file: {
+							fileBase64: readFileSync(
+								path.join(
+									__dirname,
+									'/dependencies/file_upload_image_1.jpg'
+								)
+							).toString('base64'),
+							name: `${fileTitle}.jpg`,
+						},
+						objectEntryFolderExternalReferenceCode: 'L_FILES',
+						title: fileTitle,
+					},
+					'cms/basic-documents',
+					spaceName
+				);
 			});
 
 			await test.step('Create a content from the new structure', async () => {
@@ -726,6 +748,24 @@ test(
 					action: () =>
 						fill(form.locator('input[type="tel"]'), '2125551234'),
 					label: 'Phone Number',
+				},
+				{
+					action: async () => {
+						const trigger = form.getByRole('combobox', {
+							name: 'Select Related Content',
+						});
+
+						await trigger.scrollIntoViewIfNeeded();
+
+						await clickAndExpectToBeVisible({
+							autoClick: true,
+							target: page.getByRole('option', {
+								name: fileTitle,
+							}),
+							trigger,
+						});
+					},
+					label: 'Select Related Content',
 				},
 			];
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/dragAndDropUpload.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/dragAndDropUpload.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import getRandomString from '../../../utils/getRandomString';
+import {waitForAlert} from '../../../utils/waitForAlert';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+import {AssetsPage} from './pages/AssetsPage';
+
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+async function createSpace(apiHelpers: DataApiHelpers) {
+	const {name} = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name: getRandomString(),
+		type: 'Space',
+	});
+
+	return name;
+}
+
+async function dropFiles({
+	fileNames,
+	page,
+	target,
+}: {
+	fileNames: string[];
+	page: Page;
+	target: Locator;
+}) {
+	const dataTransfer = await page.evaluateHandle((fileNames) => {
+		const dataTransfer = new DataTransfer();
+
+		for (const fileName of fileNames) {
+			dataTransfer.items.add(
+				new File([`Content of ${fileName}.`], fileName, {
+					type: 'text/plain',
+				})
+			);
+		}
+
+		return dataTransfer;
+	}, fileNames);
+
+	await target.dispatchEvent('dragenter', {dataTransfer});
+	await target.dispatchEvent('dragover', {dataTransfer});
+	await target.dispatchEvent('drop', {dataTransfer});
+}
+
+async function getDocuments({
+	apiHelpers,
+	spaceName,
+	titles,
+}: {
+	apiHelpers: DataApiHelpers;
+	spaceName: string;
+	titles: string[];
+}) {
+	const {items} =
+		await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+			APPLICATION_NAME,
+			spaceName,
+			new URLSearchParams({pageSize: '100'})
+		);
+
+	const documents = (items || []).filter((item: {title: string}) =>
+		titles.includes(item.title)
+	);
+
+	for (const document of documents) {
+		apiHelpers.data.push({
+			applicationName: APPLICATION_NAME,
+			id: String(document.id),
+			type: 'objectEntry',
+		});
+	}
+
+	return documents;
+}
+
+async function submitUpload({assetsPage}: {assetsPage: AssetsPage}) {
+	await assetsPage.modal.footer
+		.getByRole('button', {name: /^Upload/})
+		.click();
+}
+
+test(
+	'Uploads the files dropped into the Files section',
+	{tag: '@LPD-102030'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const spaceName = await createSpace(apiHelpers);
+
+		const titles = [`${getRandomString()}.txt`, `${getRandomString()}.txt`];
+
+		await assetsPage.gotoFiles();
+
+		await dropFiles({
+			fileNames: titles,
+			page,
+			target: page.locator('div.data-set-wrapper').first(),
+		});
+
+		// The dropped files arrive already queued in the uploader
+
+		await expect(assetsPage.modal.title).toHaveText(
+			'Upload Multiple Files'
+		);
+
+		for (const title of titles) {
+			await expect(assetsPage.modal.body).toContainText(title);
+		}
+
+		await assetsPage.modal.container.getByLabel(/^Space/).click();
+
+		await page.getByRole('option', {name: spaceName}).click();
+
+		await submitUpload({assetsPage});
+
+		await waitForAlert(
+			page,
+			`2 files were successfully uploaded to ${spaceName} space.`
+		);
+
+		await expect(assetsPage.modal.container).toBeHidden();
+
+		expect(
+			await getDocuments({apiHelpers, spaceName, titles})
+		).toHaveLength(2);
+	}
+);
+
+test(
+	'Uploads a drop into a Space Files section without asking for a Space',
+	{tag: '@LPD-102030'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const spaceName = await createSpace(apiHelpers);
+
+		const title = `${getRandomString()}.txt`;
+
+		const rootFolder =
+			await apiHelpers.objectFolder.getObjectEntryFolderByExternalReferenceCode(
+				{externalReferenceCode: 'L_FILES', scopeKey: spaceName}
+			);
+
+		await assetsPage.gotoFolder(rootFolder.id, rootFolder.title);
+
+		await dropFiles({
+			fileNames: [title],
+			page,
+			target: page.locator('div.data-set-wrapper').first(),
+		});
+
+		await expect(assetsPage.modal.title).toHaveText(
+			'Upload Multiple Files'
+		);
+
+		await expect(
+			assetsPage.modal.container.getByLabel(/^Space/)
+		).toBeHidden();
+
+		await submitUpload({assetsPage});
+
+		await waitForAlert(
+			page,
+			`1 file was successfully uploaded to ${spaceName} space.`
+		);
+
+		await expect(assetsPage.modal.container).toBeHidden();
+
+		expect(
+			await getDocuments({apiHelpers, spaceName, titles: [title]})
+		).toHaveLength(1);
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
@@ -10,6 +10,7 @@ import path from 'path';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
 import getRandomString from '../../../utils/getRandomString';
 import performLogin, {
 	performLoginViaApi,
@@ -17,6 +18,7 @@ import performLogin, {
 	performUserSwitch,
 	userData,
 } from '../../../utils/performLogin';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const validImageFileBase64 =
@@ -27,6 +29,25 @@ const validPdfFileBase64 = readFileSync(
 ).toString('base64');
 
 const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+
+async function getBasicDocuments({
+	apiHelpers,
+	titles,
+}: {
+	apiHelpers: DataApiHelpers;
+	titles: string[];
+}) {
+	const {items} =
+		await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+			'cms/basic-documents',
+			'Default',
+			new URLSearchParams({pageSize: '100'})
+		);
+
+	return (items || []).filter((item: {title: string}) =>
+		titles.includes(item.title)
+	);
+}
 
 test(
 	'Renders video preview for External Video entries',
@@ -876,7 +897,7 @@ test(
 
 test(
 	'Uploads a file dropped onto a folder into that folder in Gallery View',
-	{tag: '@LPD-87681'},
+	{tag: ['@LPD-87681', '@LPD-102030']},
 	async ({apiHelpers, assetsPage, page}) => {
 		const fileName = 'file_upload_image_1.jpeg';
 		const parentFolderTitle = getRandomString();
@@ -956,8 +977,38 @@ test(
 
 				await expect(assetsPage.modal.body).toContainText(fileName);
 			});
+
+			await test.step('The uploaded file lands in the target folder', async () => {
+				await assetsPage.modal.footer
+					.getByRole('button', {name: /^Upload/})
+					.click();
+
+				await waitForAlert(
+					page,
+					'1 file was successfully uploaded to Default space.'
+				);
+
+				const [document] = await getBasicDocuments({
+					apiHelpers,
+					titles: [fileName],
+				});
+
+				expect(document.objectEntryFolderExternalReferenceCode).toBe(
+					targetFolder.externalReferenceCode
+				);
+			});
 		}
 		finally {
+			for (const document of await getBasicDocuments({
+				apiHelpers,
+				titles: [fileName],
+			})) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					'cms/basic-documents',
+					String(document.id)
+				);
+			}
+
 			await apiHelpers.objectFolder.deleteObjectEntryFolder(
 				targetFolder.id
 			);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102030

## What Is Being Fixed

No test anywhere completed a drag-and-drop upload. The two tests in `all.spec.ts` stop at the modal opening with files queued, and `files.spec.ts` "Uploads a file dropped onto a folder into that folder in Gallery View" does not upload at all despite its name: it asserts the drop-target highlight and the queued file, then deletes the folders. Nothing verified that a dropped file reaches storage, let alone the right Space or folder.

## How It Is Being Fixed

`fileDropAction` hands the dropped files to the same modal as the creation menu through its `filesToUpload` prop, so the four sections named in the story reduce to two real code paths: the assets data set at section level, and a folder as the drop target. The tests follow that split.

Two new tests in `dragAndDropUpload.spec.ts`. The first drops two files on the Files data set, asserts both arrive queued, selects the Space, uploads, and checks the toast and both documents landing in that space. The second drops into a pre-scoped Space Files view and asserts no Space field renders, since the candidate list holds a single Space, then verifies the file lands there.

The existing gallery folder-drop test is extended rather than duplicated, so it now finishes the upload and asserts the document's folder external reference code matches the target folder. That makes its name true and avoids a second test covering the same `isDropTarget` logic. Its cleanup deletes the uploaded document before the folders, so an assertion failure cannot be masked by a folder deletion failing on non-empty contents.

Note that `gotoSpaceFiles` is unusable for a freshly created Space: it ends in `changeVisualizationMode('Table')` and the section hides its management bar in the empty state, so no view selector appears. The test navigates to the space's `L_FILES` root folder directly instead.

## Out Of Scope

`fileDropSettings.enabled` is `!isCreationMenuEmpty` and `onFileDrop` guards on the same condition, so a user without create permission cannot drop. Covering that needs a role and user and belongs in the `site-cms-site-initializer/permissions` project, so it is left for its own sub-task.

The story's "File Integration" bullet, that a file uploaded to a content becomes a document in the Space, is already covered by `contents.spec.ts` "Upload fields marked to show in the CMS library create visible files".

## PR Check

**pr-check: PASS** — tested on `b4b64b69489b406df221fcabea04a2cbc8900a45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b4b64b69489b406df221fcabea04a2cbc8900a45"} -->
