### PR TITLE
LPD-102025 Harden permission checks in the XML Sitemap providers

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -387,7 +387,9 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		}
 
 		if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
-				journalArticleLayout)) {
+				journalArticleLayout) ||
+			!_layoutModelResourcePermission.contains(
+				permissionChecker, journalArticleLayout, ActionKeys.VIEW)) {
 
 			return;
 		}
@@ -481,6 +483,11 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Layout)"
+	)
+	private ModelResourcePermission<Layout> _layoutModelResourcePermission;
 
 	@Reference
 	private LayoutPageTemplateEntryLocalService

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -363,7 +363,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		if ((permissionChecker != null) &&
+		if ((permissionChecker == null) ||
 			!_journalArticleModelResourcePermission.contains(
 				permissionChecker, journalArticle, ActionKeys.VIEW)) {
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/site/provider/test/JournalArticleSitemapURLProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/site/provider/test/JournalArticleSitemapURLProviderTest.java
@@ -26,10 +26,14 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -41,6 +45,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -343,6 +348,64 @@ public class JournalArticleSitemapURLProviderTest {
 	}
 
 	@Test
+	@TestInfo("LPD-102047")
+	public void testJournalArticleSitemapURLProviderDefaultLayoutWhenGuestUserCannotViewLayout()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		_addArticleWithLayoutUuid(layout);
+
+		RoleTestUtil.removeResourcePermission(
+			RoleConstants.GUEST, Layout.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(layout.getPlid()), ActionKeys.VIEW);
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(
+				_userLocalService.getGuestUser(_group.getCompanyId()));
+
+		Assert.assertFalse(
+			_layoutModelResourcePermission.contains(
+				permissionChecker, layout, ActionKeys.VIEW));
+
+		Element rootElement = _getRootElement();
+
+		_visitLayoutSet(permissionChecker, rootElement);
+
+		Assert.assertFalse(rootElement.hasContent());
+	}
+
+	@Test
+	@TestInfo("LPD-102047")
+	public void testJournalArticleSitemapURLProviderDefaultLayoutWhenGuestUserCanViewLayout()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		JournalArticle article = _addArticleWithLayoutUuid(layout);
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(
+				_userLocalService.getGuestUser(_group.getCompanyId()));
+
+		Assert.assertTrue(
+			_journalArticleModelResourcePermission.contains(
+				permissionChecker, article, ActionKeys.VIEW));
+		Assert.assertTrue(
+			_layoutModelResourcePermission.contains(
+				permissionChecker, layout, ActionKeys.VIEW));
+
+		Element rootElement = _getRootElement();
+
+		_visitLayoutSet(permissionChecker, rootElement);
+
+		Assert.assertTrue(rootElement.hasContent());
+	}
+
+	@Test
 	@TestInfo("LPD-102025")
 	public void testJournalArticleSitemapURLProviderDefaultLayoutWithoutPermissionChecker()
 		throws Exception {
@@ -613,6 +676,12 @@ public class JournalArticleSitemapURLProviderTest {
 	private JournalArticleLocalService _journalArticleLocalService;
 
 	@Inject(
+		filter = "model.class.name=com.liferay.journal.model.JournalArticle"
+	)
+	private ModelResourcePermission<JournalArticle>
+		_journalArticleModelResourcePermission;
+
+	@Inject(
 		filter = "component.name=com.liferay.journal.internal.site.provider.JournalArticleSitemapURLProvider",
 		type = SitemapURLProvider.class
 	)
@@ -623,6 +692,9 @@ public class JournalArticleSitemapURLProviderTest {
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject(filter = "model.class.name=com.liferay.portal.kernel.model.Layout")
+	private ModelResourcePermission<Layout> _layoutModelResourcePermission;
 
 	@Inject
 	private LayoutSEOEntryLocalService _layoutSEOEntryLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/site/provider/test/JournalArticleSitemapURLProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/site/provider/test/JournalArticleSitemapURLProviderTest.java
@@ -11,6 +11,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
@@ -26,12 +27,16 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -338,6 +343,30 @@ public class JournalArticleSitemapURLProviderTest {
 	}
 
 	@Test
+	@TestInfo("LPD-102025")
+	public void testJournalArticleSitemapURLProviderDefaultLayoutWithoutPermissionChecker()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		_addArticleWithLayoutUuid(layout);
+
+		Element rootElement = _getRootElement();
+
+		_visitLayoutSet(null, rootElement);
+
+		Assert.assertFalse(rootElement.hasContent());
+
+		_visitLayoutSet(
+			PermissionCheckerFactoryUtil.create(
+				_userLocalService.getGuestUser(_group.getCompanyId())),
+			rootElement);
+
+		Assert.assertTrue(rootElement.hasContent());
+	}
+
+	@Test
 	public void testJournalArticleSitemapWithADisabledLanguageId()
 		throws Exception {
 
@@ -373,6 +402,20 @@ public class JournalArticleSitemapURLProviderTest {
 			_layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid()),
 			rootElement,
 			FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE);
+	}
+
+	private JournalArticle _addArticleWithLayoutUuid(Layout layout)
+		throws Exception {
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		return _journalArticleLocalService.updateArticle(
+			article.getUserId(), article.getGroupId(), article.getFolderId(),
+			article.getArticleId(), article.getVersion(), article.getTitleMap(),
+			article.getDescriptionMap(), article.getContent(), layout.getUuid(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
 	private void _assertRootElement(
@@ -532,6 +575,25 @@ public class JournalArticleSitemapURLProviderTest {
 		_themeDisplay.setUser(TestPropsValues.getUser());
 	}
 
+	private void _visitLayoutSet(
+			PermissionChecker permissionChecker, Element rootElement)
+		throws Exception {
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+
+			_journalArticleSitemapURLProvider.visitLayoutSet(
+				rootElement, _layoutSet, _themeDisplay);
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+	}
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
@@ -577,5 +639,8 @@ public class JournalArticleSitemapURLProviderTest {
 	private SAXReader _saxReader;
 
 	private ThemeDisplay _themeDisplay;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
@@ -212,7 +212,7 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		if ((permissionChecker != null) &&
+		if ((permissionChecker == null) ||
 			!_layoutModelResourcePermission.contains(
 				permissionChecker, layout, ActionKeys.VIEW)) {
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/site/provider/test/LayoutSitemapURLProviderTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/site/provider/test/LayoutSitemapURLProviderTest.java
@@ -13,7 +13,9 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -313,6 +315,26 @@ public class LayoutSitemapURLProviderTest {
 			).build());
 	}
 
+	@Test
+	@TestInfo("LPD-102025")
+	public void testLayoutSitemapURLProviderWithoutPermissionChecker()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false);
+
+		Element rootElement = _getRootElement();
+
+		_visitLayoutWithoutPermissionChecker(layout.getUuid(), rootElement);
+
+		Assert.assertFalse(rootElement.hasContent());
+
+		_layoutSitemapURLProvider.visitLayout(
+			rootElement, layout.getUuid(), _layoutSet, _themeDisplay);
+
+		Assert.assertTrue(rootElement.hasContent());
+	}
+
 	private void _assertVisitLayout(Map<Locale, String> robotsMap)
 		throws Exception {
 
@@ -372,6 +394,25 @@ public class LayoutSitemapURLProviderTest {
 		_themeDisplay.setSignedIn(true);
 		_themeDisplay.setSiteGroupId(_group.getGroupId());
 		_themeDisplay.setUser(TestPropsValues.getUser());
+	}
+
+	private void _visitLayoutWithoutPermissionChecker(
+			String layoutUuid, Element rootElement)
+		throws Exception {
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(null);
+
+			_layoutSitemapURLProvider.visitLayout(
+				rootElement, layoutUuid, _layoutSet, _themeDisplay);
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102025
https://liferay.atlassian.net/browse/LPD-102047

## What Is Being Fixed

A web content article whose display page is a page the Guest role cannot view was still published in the XML sitemap. `JournalArticleSitemapURLProvider` checked `VIEW` on the article but never on the display page it resolves, so an article reachable only through a restricted page was advertised to anonymous crawlers together with its title-derived URL and last modification date, and the advertised URL led to a page those visitors cannot open. The sibling `LayoutSitemapURLProvider` already performed the equivalent check for its own entries, so in asset-type index mode a restricted page was correctly omitted while an article rendered on it was not.

Separately, both providers skipped their permission check whenever no permission checker was bound to the thread. That fails open: a caller running without a checker received an unfiltered sitemap rather than an empty one.

## How It Is Being Fixed

The first commit inverts the guard in both providers so an absent permission checker returns instead of bypassing the check. Publishing nothing is the safe outcome when there is no identity to evaluate. In production this is not expected to change behavior, since the asset-type generation path binds a Guest permission checker before visiting and the request-driven path inherits the requesting user's, but a programmatic caller with no checker now gets an empty sitemap instead of an unfiltered one.

With that in place, the display page check needs no null handling of its own. The second commit resolves the display page as before and then checks `VIEW` on it through `ModelResourcePermission<Layout>`, reusing the same `contains` overload as `LayoutSitemapURLProvider` so both providers evaluate a layout the same way — that overload resolves to `LayoutPermissionImpl.containsWithoutViewableGroup`, which consults the layout's own resource permission rather than the permissive group-level fallback. The check is folded into the existing sitemap-exclusion guard, which already returns for a null layout, so an article without a resolvable display page still returns before the permission call.

The affected path is `visitLayoutSet`, which enumerates articles through the local service with no permission filtering and therefore relies entirely on these checks. The display page template routes are unaffected: those layouts are created in the public layout set and always grant the Guest role `VIEW`, and the Display Page Templates admin manages permissions on the `LayoutPageTemplateEntry` rather than on the layout.

The third commit covers the fix with a regression test asserting the article is omitted once the Guest role loses `VIEW` on its display page, plus a control test asserting it is still emitted while the page remains viewable. The control matters because both tests run under a Guest permission checker, and without it an empty sitemap would satisfy the regression test for the wrong reason.

## PR Check

**pr-check: PASS** — tested on `68d5e021a8f19fdd5750de10bdaac8f4ca2fb6e7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "68d5e021a8f19fdd5750de10bdaac8f4ca2fb6e7"} -->
