### PR TITLE
LPD-99445 Prevent managing another user's subscription

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SubscriptionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SubscriptionResourceImpl.java
@@ -7,6 +7,9 @@ package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Subscription;
 import com.liferay.headless.admin.user.resource.v1_0.SubscriptionResource;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -30,15 +33,15 @@ public class SubscriptionResourceImpl extends BaseSubscriptionResourceImpl {
 	public void deleteMyUserAccountSubscription(Long subscriptionId)
 		throws Exception {
 
-		_subscriptionLocalService.deleteSubscription(subscriptionId);
+		_subscriptionLocalService.deleteSubscription(
+			_getSubscription(subscriptionId));
 	}
 
 	@Override
 	public Subscription getMyUserAccountSubscription(Long subscriptionId)
 		throws Exception {
 
-		return _toSubscription(
-			_subscriptionLocalService.getSubscription(subscriptionId));
+		return _toSubscription(_getSubscription(subscriptionId));
 	}
 
 	@Override
@@ -76,6 +79,20 @@ public class SubscriptionResourceImpl extends BaseSubscriptionResourceImpl {
 		}
 
 		return contentType;
+	}
+
+	private com.liferay.subscription.model.Subscription _getSubscription(
+			Long subscriptionId)
+		throws Exception {
+
+		com.liferay.subscription.model.Subscription serviceBuilderSubscription =
+			_subscriptionLocalService.getSubscription(subscriptionId);
+
+		UserPermissionUtil.check(
+			PermissionThreadLocal.getPermissionChecker(),
+			serviceBuilderSubscription.getUserId(), ActionKeys.UPDATE);
+
+		return serviceBuilderSubscription;
 	}
 
 	private Subscription _toSubscription(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
@@ -35,5 +35,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:segments:segments-test-util")
 	testIntegrationImplementation project(":apps:sharing:sharing-api")
+	testIntegrationImplementation project(":apps:subscription:subscription-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SubscriptionResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SubscriptionResourceTest.java
@@ -6,14 +6,194 @@
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.user.client.dto.v1_0.Subscription;
+import com.liferay.headless.admin.user.client.resource.v1_0.SubscriptionResource;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.subscription.service.SubscriptionLocalService;
 
-import org.junit.Ignore;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Javier Gamarra
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class SubscriptionResourceTest extends BaseSubscriptionResourceTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_adminUser = UserTestUtil.getAdminUser(testCompany.getCompanyId());
+
+		String password = RandomTestUtil.randomString();
+
+		_user = UserTestUtil.addUser(testCompany, password);
+
+		_userSubscriptionResource = SubscriptionResource.builder(
+		).authentication(
+			_user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@Override
+	@Test
+	public void testDeleteMyUserAccountSubscription() throws Exception {
+		super.testDeleteMyUserAccountSubscription();
+
+		_testDeleteMyUserAccountSubscriptionWithAdminUser();
+		_testDeleteMyUserAccountSubscriptionWithOwnerUser();
+		_testDeleteMyUserAccountSubscriptionWithoutOwnerUser();
+	}
+
+	@Override
+	@Test
+	public void testGetMyUserAccountSubscription() throws Exception {
+		super.testGetMyUserAccountSubscription();
+
+		_testGetMyUserAccountSubscriptionWithAdminUser();
+		_testGetMyUserAccountSubscriptionWithOwnerUser();
+		_testGetMyUserAccountSubscriptionWithoutOwnerUser();
+	}
+
+	@Override
+	protected Subscription testDeleteMyUserAccountSubscription_addSubscription()
+		throws Exception {
+
+		return _addSubscription(_adminUser.getUserId());
+	}
+
+	@Override
+	protected Subscription testGetMyUserAccountSubscription_addSubscription()
+		throws Exception {
+
+		return _addSubscription(_adminUser.getUserId());
+	}
+
+	@Override
+	protected Subscription
+			testGetMyUserAccountSubscriptionsPage_addSubscription(
+				Subscription subscription)
+		throws Exception {
+
+		return _addSubscription(_adminUser.getUserId());
+	}
+
+	@Override
+	protected Subscription testGraphQLSubscription_addSubscription()
+		throws Exception {
+
+		return _addSubscription(_adminUser.getUserId());
+	}
+
+	private Subscription _addSubscription(long userId) throws Exception {
+		com.liferay.subscription.model.Subscription serviceBuilderSubscription =
+			_subscriptionLocalService.addSubscription(
+				userId, testGroup.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomLong());
+
+		return new Subscription() {
+			{
+				setContentId(serviceBuilderSubscription.getClassPK());
+				setContentType(serviceBuilderSubscription.getClassName());
+				setDateCreated(serviceBuilderSubscription.getCreateDate());
+				setDateModified(serviceBuilderSubscription.getModifiedDate());
+				setFrequency(serviceBuilderSubscription.getFrequency());
+				setId(serviceBuilderSubscription.getSubscriptionId());
+				setSiteId(serviceBuilderSubscription.getGroupId());
+			}
+		};
+	}
+
+	private void _testDeleteMyUserAccountSubscriptionWithAdminUser()
+		throws Exception {
+
+		Subscription subscription = _addSubscription(_user.getUserId());
+
+		assertHttpResponseStatusCode(
+			204,
+			subscriptionResource.deleteMyUserAccountSubscriptionHttpResponse(
+				subscription.getId()));
+	}
+
+	private void _testDeleteMyUserAccountSubscriptionWithoutOwnerUser()
+		throws Exception {
+
+		Subscription subscription = _addSubscription(_adminUser.getUserId());
+
+		assertHttpResponseStatusCode(
+			403,
+			_userSubscriptionResource.
+				deleteMyUserAccountSubscriptionHttpResponse(
+					subscription.getId()));
+	}
+
+	private void _testDeleteMyUserAccountSubscriptionWithOwnerUser()
+		throws Exception {
+
+		Subscription subscription = _addSubscription(_user.getUserId());
+
+		assertHttpResponseStatusCode(
+			204,
+			_userSubscriptionResource.
+				deleteMyUserAccountSubscriptionHttpResponse(
+					subscription.getId()));
+	}
+
+	private void _testGetMyUserAccountSubscriptionWithAdminUser()
+		throws Exception {
+
+		Subscription subscription = _addSubscription(_user.getUserId());
+
+		assertEquals(
+			subscription,
+			subscriptionResource.getMyUserAccountSubscription(
+				subscription.getId()));
+	}
+
+	private void _testGetMyUserAccountSubscriptionWithoutOwnerUser()
+		throws Exception {
+
+		Subscription subscription = _addSubscription(_adminUser.getUserId());
+
+		assertHttpResponseStatusCode(
+			404,
+			_userSubscriptionResource.getMyUserAccountSubscriptionHttpResponse(
+				subscription.getId()));
+	}
+
+	private void _testGetMyUserAccountSubscriptionWithOwnerUser()
+		throws Exception {
+
+		Subscription subscription = _addSubscription(_user.getUserId());
+
+		assertEquals(
+			subscription,
+			_userSubscriptionResource.getMyUserAccountSubscription(
+				subscription.getId()));
+	}
+
+	private User _adminUser;
+
+	@Inject
+	private SubscriptionLocalService _subscriptionLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	private SubscriptionResource _userSubscriptionResource;
+
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99445

## What Is Being Fixed

The "my-user-account" subscription endpoints in the Headless Admin User API resolved the subscription straight from the "subscriptionId" path parameter and handed it to SubscriptionLocalService, which enforces no ownership or permission constraint. Because the identifiers are sequential, any authenticated user could enumerate them and read or delete any subscription in the portal, including an administrator's, over plain HTTP — an Insecure Direct Object Reference (CWE-862).

## How It Is Being Fixed

SubscriptionResourceImpl now resolves the entry through a helper that runs UserPermissionUtil.check against the subscription owner, the same idiom TicketResourceImpl already uses in this module when acting on another user's data. That admits the owner, omniadmins, company administrators, and organization administrators with "Manage Users" rights over the target, and refuses everyone else. A non-owner gets 403 on DELETE and 404 on GET, since PrincipalExceptionMapper maps PrincipalException by request method.

Both endpoints check the UPDATE action key rather than VIEW on the GET. VIEW on the User resource is granted broadly enough that gating the read on it would have left the original hole open, and reading another user's subscriptions is a manage-the-user action rather than a profile view.

The test case was previously ignored in its entirety, so none of the generated coverage ran. The missing hooks are implemented to enable it, and the delete and get overrides each cover three callers: the owner acting on their own subscription, a non-owner who is refused, and an administrator acting on someone else's. The owner case earns its place because every other passing scenario runs as the company administrator, who satisfies the check through the administrator branch and never exercises the owner branch that ordinary users depend on.

## PR Check

**pr-check: PASS** — tested on `81de413f5567e86e949e223ef8811bc9764ef8cd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "81de413f5567e86e949e223ef8811bc9764ef8cd"} -->
