### PR TITLE
LPD-100267 Fix WAVE accessibility errors in the web content creation form

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -348,9 +348,7 @@ journalEditArticleDisplayContext.setViewAttributes();
 					>
 						<div class="c-gap-4 d-flex flex-column panel-body">
 							<div id="<portlet:namespace />titleMapAsXMLWrapper">
-								<label for="<portlet:namespace />titleMapAsXML" id="<portlet:namespace />Aria"><liferay-ui:message key="title" /></label>
-
-								<aui:input cssClass="form-control-inline form-control-sm" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label='<%= LanguageUtil.get(request, "title") %>' labelCssClass="sr-only" languagesDropdownDirection="down" languagesDropdownVisible="<%= false %>" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
+								<aui:input cssClass="form-control-inline form-control-sm" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label='<%= LanguageUtil.get(request, "title") %>' languagesDropdownDirection="down" languagesDropdownVisible="<%= false %>" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
 							</div>
 
 							<div id="<portlet:namespace />descriptionMapAsXMLWrapper">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPagePreview.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPagePreview.js
@@ -29,6 +29,8 @@ export default function AssetDisplayPagePreview({
 	const [assetDisplayPageSelected, setAssetDisplayPageSelected] = useState();
 
 	const siteInputId = `${namespace}siteInput`;
+	const siteLabelId = `${namespace}siteLabel`;
+	const siteValueId = `${namespace}siteValue`;
 
 	const items = useMemo(() => {
 		return [
@@ -49,20 +51,25 @@ export default function AssetDisplayPagePreview({
 
 	return (
 		<>
-			<label className="control-label" htmlFor={siteInputId}>
+			<label
+				className="control-label"
+				htmlFor={siteInputId}
+				id={siteLabelId}
+			>
 				{Liferay.Language.get('site')}
 			</label>
 			<ClayDropDown
 				active={active}
-				aria-labelledby={siteInputId}
 				onActiveChange={setActive}
 				trigger={
 					<ClayButton
+						aria-labelledby={`${siteLabelId} ${siteValueId}`}
 						className="bg-light form-control-select text-left w-100"
 						displayType="secondary"
+						id={siteInputId}
 						type="button"
 					>
-						<span>
+						<span id={siteValueId}>
 							{selectedSite?.name ||
 								`- ${Liferay.Language.get('not-selected')} -`}
 						</span>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPageSelector.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPageSelector.js
@@ -19,7 +19,7 @@ export default function AssetDisplayPageSelector({
 	selectedSite,
 	setAssetDisplayPageSelected,
 }) {
-	const assetDisplayPageId = `${namespace}assetDisplayPageId`;
+	const assetDisplayPageNameInputId = `${namespace}assetDisplayPageName`;
 
 	const openAssetDisplayPageSelector = () => {
 		const url = new URL(selectAssetDisplayPageURL);
@@ -71,7 +71,10 @@ export default function AssetDisplayPageSelector({
 	return (
 		<div className="mb-2 mt-2">
 			<ClayForm.Group className="mb-2">
-				<label className="sr-only" htmlFor={assetDisplayPageId}>
+				<label
+					className="sr-only"
+					htmlFor={assetDisplayPageNameInputId}
+				>
 					{Liferay.Language.get('display-page')}
 				</label>
 
@@ -79,6 +82,7 @@ export default function AssetDisplayPageSelector({
 					<ClayInput.GroupItem>
 						<ClayInput
 							disabled={disabled}
+							id={assetDisplayPageNameInputId}
 							placeholder={sub(
 								Liferay.Language.get('no-x-selected'),
 								Liferay.Language.get('display-page')

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage.js
@@ -102,20 +102,20 @@ export default function SelectAssetDisplayPage({
 			</ClayForm.Group>
 
 			<ClayInput
-				hidden
 				name={`${namespace}layoutUuid`}
+				type="hidden"
 				value={assetDisplayPageSelected?.layoutUuid ?? ''}
 			/>
 
 			<ClayInput
-				hidden
 				name={`${namespace}assetDisplayPageId`}
+				type="hidden"
 				value={assetDisplayPageSelected?.assetDisplayPageId ?? ''}
 			/>
 
 			<ClayInput
-				hidden
 				name={`${namespace}displayPageType`}
+				type="hidden"
 				value={selectedDisplayPageType ?? ''}
 			/>
 

--- a/modules/apps/journal/journal-web/test/js/article/AssetDisplayPagePreview.test.js
+++ b/modules/apps/journal/journal-web/test/js/article/AssetDisplayPagePreview.test.js
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// eslint-disable-next-line @liferay/portal/no-cross-module-deep-import
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import AssetDisplayPagePreview from '../../../src/main/resources/META-INF/resources/js/article/AssetDisplayPagePreview';
+
+const DEFAULT_PROPS = {
+	newArticle: true,
+	portletNamespace: 'namespace',
+	previewURL: 'http://localhost/preview',
+	saveAsDraftURL: 'http://localhost/save-as-draft',
+	selectAssetDisplayPageEventName: 'selectAssetDisplayPage',
+	selectAssetDisplayPageURL: 'http://localhost/select-asset-display-page',
+	selectSiteEventName: 'selectSite',
+	siteItemSelectorURL: 'http://localhost/select-site',
+	sites: [{groupId: 1, name: 'Site 1'}],
+	sitesCount: 1,
+};
+
+const renderComponent = () =>
+	render(<AssetDisplayPagePreview {...DEFAULT_PROPS} />);
+
+describe('AssetDisplayPagePreview', () => {
+	beforeEach(() => {
+		const articleIdInput = document.createElement('input');
+
+		articleIdInput.id = `${DEFAULT_PROPS.portletNamespace}articleId`;
+
+		document.body.appendChild(articleIdInput);
+
+		Liferay.componentReady = jest.fn(() => Promise.resolve({}));
+	});
+
+	afterEach(() => {
+		document
+			.getElementById(`${DEFAULT_PROPS.portletNamespace}articleId`)
+			?.remove();
+
+		delete Liferay.componentReady;
+	});
+
+	it('names the site selector after its label when no site is selected', () => {
+		renderComponent();
+
+		expect(
+			screen.getByRole('button', {name: 'site - not-selected -'})
+		).toBeInTheDocument();
+	});
+
+	it('includes the selected site in the site selector accessible name', async () => {
+		renderComponent();
+
+		await userEvent.click(screen.getByRole('button', {name: /site/}));
+		await userEvent.click(screen.getByRole('menuitem', {name: 'Site 1'}));
+
+		expect(
+			screen.getByRole('button', {name: 'site Site 1'})
+		).toBeInTheDocument();
+	});
+
+	it('has no accessibility violations', async () => {
+		const {container} = renderComponent();
+
+		await checkAccessibility({bestPractices: true, context: container});
+	});
+});

--- a/modules/apps/journal/journal-web/test/js/article/AssetDisplayPageSelector.test.js
+++ b/modules/apps/journal/journal-web/test/js/article/AssetDisplayPageSelector.test.js
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// eslint-disable-next-line @liferay/portal/no-cross-module-deep-import
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import AssetDisplayPageSelector from '../../../src/main/resources/META-INF/resources/js/article/AssetDisplayPageSelector';
+
+const DEFAULT_PROPS = {
+	assetDisplayPageSelected: null,
+	disabled: false,
+	namespace: 'namespace',
+	selectAssetDisplayPageEventName: 'selectAssetDisplayPage',
+	selectAssetDisplayPageURL: 'http://localhost/select-asset-display-page',
+	selectedSite: null,
+	setAssetDisplayPageSelected: jest.fn(),
+};
+
+const renderComponent = () =>
+	render(<AssetDisplayPageSelector {...DEFAULT_PROPS} />);
+
+describe('AssetDisplayPageSelector', () => {
+	it('gives the display page field an accessible name from its label', () => {
+		renderComponent();
+
+		expect(
+			screen.getByRole('textbox', {name: 'display-page'})
+		).toBeInTheDocument();
+	});
+
+	it('has no accessibility violations', async () => {
+		const {container} = renderComponent();
+
+		await checkAccessibility({bestPractices: true, context: container});
+	});
+});

--- a/modules/apps/journal/journal-web/test/js/article/SelectAssetDisplayPage.test.js
+++ b/modules/apps/journal/journal-web/test/js/article/SelectAssetDisplayPage.test.js
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// eslint-disable-next-line @liferay/portal/no-cross-module-deep-import
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import SelectAssetDisplayPage from '../../../src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage';
+
+const DISPLAY_PAGE_TYPE_NONE = 0;
+
+const DEFAULT_PROPS = {
+	assetDisplayPageId: '',
+	assetDisplayPageType: DISPLAY_PAGE_TYPE_NONE,
+	defaultDisplayPageName: '',
+	layoutUuid: '',
+	newArticle: true,
+	portletNamespace: 'namespace',
+	saveAsDraftURL: 'http://localhost/save-as-draft',
+	selectAssetDisplayPageEventName: 'selectAssetDisplayPage',
+	selectAssetDisplayPageURL: 'http://localhost/select-asset-display-page',
+	specificAssetDisplayPageName: '',
+};
+
+const renderComponent = () =>
+	render(<SelectAssetDisplayPage {...DEFAULT_PROPS} />);
+
+describe('SelectAssetDisplayPage', () => {
+	it('submits the display page fields as native hidden inputs', () => {
+		const {container} = renderComponent();
+
+		['assetDisplayPageId', 'displayPageType', 'layoutUuid'].forEach(
+			(name) => {
+				expect(
+					container.querySelector(
+						`input[name="${DEFAULT_PROPS.portletNamespace}${name}"]`
+					)
+				).toHaveAttribute('type', 'hidden');
+			}
+		);
+	});
+
+	it('has no accessibility violations', async () => {
+		const {container} = renderComponent();
+
+		await checkAccessibility({bestPractices: true, context: container});
+	});
+});


### PR DESCRIPTION
# What is this trying to solve?

[LPD-100267](https://liferay.atlassian.net/browse/LPD-100267) | [LPP-65018](https://liferay.atlassian.net/browse/LPP-65018)

The classic web content creation form (New → Basic Web Content) reports several accessibility errors under the WAVE evaluation tool, reported by a customer through LPP-65018:

- **Multiple form labels** — the Title field has two `<label>` elements bound to it: a hand-written one, plus the one `<aui:input>` emits automatically and hides with `labelCssClass="sr-only"`. Both labels also carry an identical `id`, which `ckeditor.jsp` points the Description editor's `aria-labelledby` at. Because the id is duplicated, that reference resolves to the Title label instead of the Description one.
- **Missing form label (3)** — the `layoutUuid`, `assetDisplayPageId`, and `displayPageType` inputs use the boolean `hidden` prop instead of `type="hidden"`. Bootstrap's `.form-control` rule sets `display: block`, overriding the user-agent `[hidden]` rule, so all three can render as visible, empty, unlabeled text inputs.
- **Broken ARIA reference plus orphaned form label** — the site selector button builds an element id and references it from both the label's `htmlFor` and the dropdown's `aria-labelledby`, but never assigns it to any element.
- **Missing form label** — the Display Page field's sr-only label references an id that no element carries, leaving the read-only input unnamed. This one was not part of the original WAVE report but was found on the same form and confirmed live with WAVE while fixing the errors above.

# How am I fixing it?

Four files under `journal-web` changed:

1. `edit_article.jsp` — removes the hand-written Title label and its `sr-only` override, letting `<aui:input>` own the one visible label. The shared id stays only on the Description label, so `ckeditor.jsp`'s reference resolves correctly.
2. `SelectAssetDisplayPage.js` — switches the three hidden inputs from the boolean `hidden` prop to `type="hidden"`, which hides them natively regardless of any conflicting CSS rule.
3. `AssetDisplayPagePreview.js` — assigns the site selector's id to the trigger button so both the label's `htmlFor` and the dropdown's naming resolve. The accessible name is driven by `aria-labelledby` placed directly on the button (not on the dropdown's wrapper element), referencing both the label and the currently selected site, so the selection isn't lost from the announced name. Verified live with WAVE — no Orphaned form label or Broken ARIA reference errors.
4. `AssetDisplayPageSelector.js` — assigns the Display Page field's id to its input so the sr-only label resolves. The id is distinct from the sibling hidden input's submitted field name to avoid a DOM id/name collision.

Three new Jest suites cover the accessible-name and hidden-field behavior for the changed components.

# How can you verify that it works?

1. Sign in as an administrator.
2. Go to **Site Menu → Content & Data → Web Content**.
3. Click **New → Basic Web Content**.
4. Run WAVE and open the Details panel.
5. Confirm there are no Multiple form labels, Missing form label, or Broken ARIA reference errors originating from `journal-web`.
6. For the Site selector (visible on Depot/Global-scope articles, under the "Display Page Preview" panel): select a site and confirm the button announces the selected site name (not just "Site") to assistive technology.
7. For the Display Page field: select a specific display page and confirm it has an accessible name in WAVE/dev tools.

   
   
<img width="1910" height="1027" alt="2026-08-11_13-04" src="https://github.com/user-attachments/assets/51aba7c6-1a8f-443a-93ed-332338fb0275" />

