### PR TITLE
LPD-102334 Preview the category ID when the site URL exceeds the maximum length

### DIFF
--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/constants/CPAssetCategoriesWebKeys.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/constants/CPAssetCategoriesWebKeys.java
@@ -24,6 +24,8 @@ public class CPAssetCategoriesWebKeys {
 	public static final String SITE_FRIENDLY_URL_SEPARATOR =
 		"SITE_FRIENDLY_URL_SEPARATOR";
 
+	public static final String SITE_URL_TITLE = "SITE_URL_TITLE";
+
 	public static final String TITLE_MAP_AS_XML = "TITLE_MAP_AS_XML";
 
 	public static final String URL_TITLE = "URL_TITLE";

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/frontend/taglib/servlet/taglib/CategoryCPFriendlyURLScreenNavigationEntry.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/frontend/taglib/servlet/taglib/CategoryCPFriendlyURLScreenNavigationEntry.java
@@ -80,6 +80,7 @@ public class CategoryCPFriendlyURLScreenNavigationEntry
 		String commerceFriendlyURLSeparator = StringPool.BLANK;
 		String siteFriendlyURLBase = StringPool.BLANK;
 		String siteFriendlyURLSeparator = StringPool.BLANK;
+		String siteURLTitle = StringPool.BLANK;
 		String titleMapAsXML = StringPool.BLANK;
 		String urlTitle = StringPool.BLANK;
 
@@ -116,11 +117,19 @@ public class CategoryCPFriendlyURLScreenNavigationEntry
 							themeDisplay.getCompanyId(),
 							AssetCategory.class.getName());
 
-				siteFriendlyURLBase = _getSiteFriendlyURLBase(
-					assetCategory, groupFriendlyURL, layoutDisplayPageProvider,
-					siteDefaultLocale);
 				siteFriendlyURLSeparator =
 					layoutDisplayPageProvider.getURLSeparator();
+
+				String siteURLPath = _getSiteURLPath(
+					assetCategory, layoutDisplayPageProvider,
+					siteDefaultLocale);
+
+				int index = siteURLPath.lastIndexOf(CharPool.SLASH) + 1;
+
+				siteFriendlyURLBase =
+					groupFriendlyURL + siteFriendlyURLSeparator +
+						siteURLPath.substring(0, index);
+				siteURLTitle = siteURLPath.substring(index);
 			}
 		}
 		catch (Exception exception) {
@@ -142,6 +151,8 @@ public class CategoryCPFriendlyURLScreenNavigationEntry
 			CPAssetCategoriesWebKeys.SITE_FRIENDLY_URL_SEPARATOR,
 			siteFriendlyURLSeparator);
 		httpServletRequest.setAttribute(
+			CPAssetCategoriesWebKeys.SITE_URL_TITLE, siteURLTitle);
+		httpServletRequest.setAttribute(
 			CPAssetCategoriesWebKeys.TITLE_MAP_AS_XML, titleMapAsXML);
 		httpServletRequest.setAttribute(
 			CPAssetCategoriesWebKeys.URL_TITLE, urlTitle);
@@ -161,8 +172,8 @@ public class CategoryCPFriendlyURLScreenNavigationEntry
 			group.getPublicLayoutSet(), themeDisplay, false, false);
 	}
 
-	private String _getSiteFriendlyURLBase(
-		AssetCategory assetCategory, String groupFriendlyURL,
+	private String _getSiteURLPath(
+		AssetCategory assetCategory,
 		LayoutDisplayPageProvider<?> layoutDisplayPageProvider,
 		Locale siteDefaultLocale) {
 
@@ -172,11 +183,7 @@ public class CategoryCPFriendlyURLScreenNavigationEntry
 					AssetCategory.class.getName(),
 					assetCategory.getCategoryId()));
 
-		String urlTitle = layoutDisplayPageObjectProvider.getURLTitle(
-			siteDefaultLocale);
-
-		return groupFriendlyURL + layoutDisplayPageProvider.getURLSeparator() +
-			urlTitle.substring(0, urlTitle.lastIndexOf(CharPool.SLASH) + 1);
+		return layoutDisplayPageObjectProvider.getURLTitle(siteDefaultLocale);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/friendly_url.jsp
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/friendly_url.jsp
@@ -13,6 +13,7 @@ String commerceFriendlyURLBase = (String)request.getAttribute(CPAssetCategoriesW
 String commerceFriendlyURLSeparator = (String)request.getAttribute(CPAssetCategoriesWebKeys.COMMERCE_FRIENDLY_URL_SEPARATOR);
 String siteFriendlyURLBase = (String)request.getAttribute(CPAssetCategoriesWebKeys.SITE_FRIENDLY_URL_BASE);
 String siteFriendlyURLSeparator = (String)request.getAttribute(CPAssetCategoriesWebKeys.SITE_FRIENDLY_URL_SEPARATOR);
+String siteURLTitle = (String)request.getAttribute(CPAssetCategoriesWebKeys.SITE_URL_TITLE);
 String titleMapAsXML = (String)request.getAttribute(CPAssetCategoriesWebKeys.TITLE_MAP_AS_XML);
 String urlTitle = (String)request.getAttribute(CPAssetCategoriesWebKeys.URL_TITLE);
 long vocabularyId = ParamUtil.getLong(request, "vocabularyId");
@@ -59,7 +60,15 @@ renderResponse.setTitle(category.getTitle(locale));
 			<label for="<portlet:namespace />urlTitleMapAsXML"><liferay-ui:message key="friendly-url" /><span aria-label="<%= friendlyURLHelpMessage %>" class="c-ml-1 lfr-portal-tooltip" tabindex="0" title="<%= friendlyURLHelpMessage %>"><clay:icon symbol="question-circle-full" /></span></label>
 
 			<div class="c-mb-2 text-3 text-secondary">
-				<div><%= HtmlUtil.escape(siteFriendlyURLBase) %><strong class="text-dark" id="<portlet:namespace />siteURLTitle"><%= HtmlUtil.escape(urlTitle) %></strong></div>
+				<c:choose>
+					<c:when test="<%= siteURLTitle.equals(urlTitle) %>">
+						<div><%= HtmlUtil.escape(siteFriendlyURLBase) %><strong class="text-dark" id="<portlet:namespace />siteURLTitle"><%= HtmlUtil.escape(urlTitle) %></strong></div>
+					</c:when>
+					<c:otherwise>
+						<div><%= HtmlUtil.escape(siteFriendlyURLBase) %><strong class="text-dark"><%= HtmlUtil.escape(siteURLTitle) %></strong></div>
+					</c:otherwise>
+				</c:choose>
+
 				<div><%= HtmlUtil.escape(commerceFriendlyURLBase) %><strong class="text-dark" id="<portlet:namespace />commerceURLTitle"><%= HtmlUtil.escape(urlTitle) %></strong></div>
 			</div>
 

--- a/modules/test/playwright/tests/asset-categories-admin-web/main/categories.spec.ts
+++ b/modules/test/playwright/tests/asset-categories-admin-web/main/categories.spec.ts
@@ -324,3 +324,78 @@ test(
 		);
 	}
 );
+
+test(
+	'User sees the category ID in the site URL when the friendly URL is too long',
+	{tag: '@LPD-102334'},
+	async ({apiHelpers, assetCategoriesEditPage, page, site}) => {
+
+		// A friendly URL holds up to 255 characters, so only a deep chain of
+		// categories takes the site URL over its maximum length
+
+		const namePadding = 'x'.repeat(240);
+		const vocabularyName = 'vocabulary-1';
+
+		const {id: vocabularyId} =
+			await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
+				name: vocabularyName,
+				siteId: site.id,
+			});
+
+		let categoryName = `1-${namePadding}`;
+
+		const {id: rootCategoryId} =
+			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+				{
+					name: categoryName,
+					vocabularyId,
+				}
+			);
+
+		let categoryId = rootCategoryId;
+
+		for (let i = 2; i <= 9; i++) {
+			categoryName = `${i}-${namePadding}`;
+
+			const {id} =
+				await apiHelpers.headlessAdminTaxonomy.postTaxonomyCategoryTaxonomyCategory(
+					{
+						name: categoryName,
+						parentTaxonomyCategoryId: categoryId,
+					}
+				);
+
+			categoryId = id;
+		}
+
+		await assetCategoriesEditPage.gotoEditCategory({
+			categoryId,
+			siteUrl: site.friendlyUrlPath,
+			vocabularyId,
+		});
+
+		// Leaving the details screen before it finishes wiring leaves the
+		// localized input of the next screen without its language dropdown
+
+		await assetCategoriesEditPage.descriptionField.waitFor();
+		await assetCategoriesEditPage.friendlyURLTab.click();
+		await assetCategoriesEditPage.friendlyURLInput.waitFor();
+
+		// The site URL falls back to the category ID, the Commerce one keeps the
+		// friendly URL
+
+		await expect(page.getByText(`/v/${categoryId}`)).toBeVisible();
+		await expect(page.locator('[id$=siteURLTitle]')).toHaveCount(0);
+		await expect(page.locator('[id$=commerceURLTitle]')).toHaveText(
+			categoryName
+		);
+
+		// The site URL no longer holds the friendly URL, so it does not follow
+		// the field
+
+		await assetCategoriesEditPage.fillFriendlyURL('Winter Sports');
+
+		await expect(page.getByText(`/v/${categoryId}`)).toBeVisible();
+		await expect(page.getByText('/g/winter-sports')).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/asset-categories-admin-web/main/pages/AssetCategoriesEditPage.ts
+++ b/modules/test/playwright/tests/asset-categories-admin-web/main/pages/AssetCategoriesEditPage.ts
@@ -92,6 +92,20 @@ export class AssetCategoriesEditPage {
 		await this.assetCategoriesAdminPage.gotoAction('Edit', title);
 	}
 
+	async gotoEditCategory({
+		categoryId,
+		siteUrl,
+		vocabularyId,
+	}: {
+		categoryId: number | string;
+		siteUrl?: Site['friendlyUrlPath'];
+		vocabularyId: number | string;
+	}) {
+		await this.page.goto(
+			`/group${siteUrl || '/guest'}/~/control_panel/manage/-/categories_admin/vocabulary/${vocabularyId}/category/${categoryId}/edit`
+		);
+	}
+
 	async goToFriendlyURLTab(title: string) {
 		await this.goto(title);
 		await this.friendlyURLTab.click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102334

## What Is Being Fixed

The friendly URL screen of a category previewed a URL that does not resolve. It built the preview by taking the display page path from the layout display page object provider and cutting it at the last slash, so the JSP could append the category friendly URL and keep the preview in sync with the input. That shape only holds while the path fits. Over the maximum length the provider falls back to the plain category ID, which holds no slash, so the prefix collapsed to an empty string and the preview showed the site friendly URL followed by the leaf friendly URL alone, with the vocabulary and every ancestor missing.

Opening that URL returns a 404, since resolution walks the vocabulary and each ancestor in turn. The URL the portal actually serves for such a category is the ID one, which resolves with no redirect. Only the preview was wrong; URL generation and resolution behave correctly, and the Commerce line of the preview is unaffected because it is flat.

## How It Is Being Fixed

The path is now split into a base and a last segment whatever its shape, so the case with no slash yields the site friendly URL as the base and the category ID as the last segment. The screen exposes that segment separately from the category friendly URL, and the JSP gives it the id the JavaScript hooks only when the two match. In the fallback the site line therefore shows the ID URL and stops following the field, which is correct because the URL no longer depends on the friendly URL. The JavaScript is untouched: it already skips an absent element.

The test builds a chain deep enough to pass the limit, since a friendly URL holds up to 255 characters, and asserts that the site line shows the category ID, that the element the JavaScript syncs is absent, and that the Commerce line still holds the friendly URL and still follows the field.

## PR Check

**pr-check: PASS** — tested on `6e012ba70434a47fa3497b28e9d06c7c93d3cdc2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6e012ba70434a47fa3497b28e9d06c7c93d3cdc2"} -->
