### PR TITLE
LPD-102346 Wire the categories admin waits to the screen being ready

### DIFF
--- a/modules/test/playwright/tests/asset-categories-admin-web/main/pages/AssetCategoriesEditPage.ts
+++ b/modules/test/playwright/tests/asset-categories-admin-web/main/pages/AssetCategoriesEditPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {waitForAlert} from '../../../../utils/waitForAlert';
@@ -47,9 +47,13 @@ export class AssetCategoriesEditPage {
 		properties: {[key: string]: string},
 		{save = true} = {}
 	) {
-		await this.propertiesTab.click();
-
 		const keyInputs = this.page.getByLabel('key');
+
+		// Properties are also added with the tab already open
+
+		if (!(await keyInputs.first().isVisible())) {
+			await this.goToPropertiesTab();
+		}
 
 		for (const [key, value] of Object.entries(properties)) {
 			if (await keyInputs.last().inputValue()) {
@@ -79,8 +83,18 @@ export class AssetCategoriesEditPage {
 		await this.externalReferenceCodeInput.fill(externalReferenceCode);
 	}
 
-	async fillFriendlyURL(friendlyURL: string) {
-		await this.friendlyURLInput.fill(friendlyURL);
+	async fillFriendlyURL(friendlyURL: string, languageId = 'en_US') {
+
+		// The localized input copies the visible field into the hidden field of
+		// the language from a debounced handler bound to real typing, so filling
+		// the field leaves the hidden one behind
+
+		await this.friendlyURLInput.fill('');
+		await this.friendlyURLInput.pressSequentially(friendlyURL);
+
+		await expect(
+			this.page.locator(`[id$=urlTitleMapAsXML_${languageId}]`)
+		).toHaveValue(friendlyURL);
 	}
 
 	async fillName(name: string) {
@@ -94,12 +108,26 @@ export class AssetCategoriesEditPage {
 
 	async goToFriendlyURLTab(title: string) {
 		await this.goto(title);
+
+		// Leaving the details screen before it finishes wiring leaves the
+		// localized input of the next screen without its language dropdown
+
+		await this.descriptionField.waitFor();
 		await this.friendlyURLTab.click();
+		await this.friendlyURLInput.waitFor();
 	}
 
-	async goToPropertiesTab(title: string) {
-		await this.goto(title);
+	async goToPropertiesTab(title?: string) {
+		if (title) {
+			await this.goto(title);
+		}
+
+		// Leaving the details screen before it finishes wiring leaves the
+		// properties screen without its Add button
+
+		await this.descriptionField.waitFor();
 		await this.propertiesTab.click();
+		await this.page.getByLabel('key').first().waitFor();
 	}
 
 	async moveCategory({
@@ -129,9 +157,14 @@ export class AssetCategoriesEditPage {
 	}
 
 	async selectLanguage(languageId: string) {
+
+		// The default timeout also bounds the click that opens the dropdown,
+		// which a busy page does not always answer in time
+
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page.locator('.palette-item', {hasText: languageId}),
+			timeout: 5000,
 			trigger: this.page.locator('.input-localized-trigger'),
 		});
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102346

## What Is Being Fixed

Two tests in the categories admin spec failed intermittently, three times in fifteen consecutive executions of the file, from three races in the page object.

The first two share a cause. The tests switched screens as soon as the edit form appeared, and leaving the details screen while it is still wiring makes the deferred initialization of the next screen run against a document that has already changed. The traces show it: `createEditor` fails with a null node, and right after it the initializer in `input_localized.js` fails on a null placeholder. The localized input of the friendly URL screen is then dead and never opens its language dropdown, and the properties screen renders without its Add button. Both tests went on clicking an inert control until the test timeout expired, so retrying could not help.

The third is that the friendly URL was never really filled. The localized input copies the visible field into the hidden field of the language from a handler that is debounced and bound through AUI's synthetic input event, which a fill does not produce. Live previews still updated, because they listen to the native event, so the test looked correct while the value only reached the form as a side effect of the language change that followed.

## How It Is Being Fixed

Switching screens now waits for the details screen and then for the control the next screen owns, and adding properties reuses that navigation, skipping it when the tab is already open. Filling the friendly URL types the value and waits for the hidden field of the language to hold it, so nothing downstream depends on a later language change.

Twenty eight consecutive executions pass, against three failures in fifteen before, and the file runs in a fourth of the time because no execution burns a test timeout.

## PR Check

**pr-check: PASS** — tested on `464eee282e099ab17626d8c831aad96d8a996016`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "464eee282e099ab17626d8c831aad96d8a996016"} -->
