### PR TITLE
LPD-102359 Repoint Poshi configuration navigation at the new route

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -1349,9 +1349,7 @@ definition {
 			locator1 = "TextInput#ANY",
 			value1 = ${copyLimit});
 
-		Button.clickSave();
-
-		Alert.viewSuccessMessage();
+		SystemSettings.saveConfiguration();
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMNavigator.macro
@@ -467,18 +467,16 @@ definition {
 			var baseURL = JSONCompany.getPortalURL();
 		}
 
-		if (${portlet} == "Documents and Media Size Limits") {
-			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_configurationScreenKey=dl-size-limit-configuration-company");
-		}
-		else if (${portlet} == "File Order") {
+		if (${portlet} == "File Order") {
 			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_factoryPid=com.liferay.document.library.internal.configuration.DLFileOrderConfiguration&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_pid=com.liferay.document.library.internal.configuration.DLFileOrderConfiguration");
-		}
-		else if (${portlet} == "File Preview Limits") {
-			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_configurationScreenKey=dl-file-entry-configuration-company");
 		}
 		else {
 			if (${portlet} == "Cache Control") {
 				var portletId = "com.liferay.document.library.web.internal.configuration.CacheControlConfiguration";
+			}
+
+			if (${portlet} == "Documents and Media Size Limits") {
+				var portletId = "com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration";
 			}
 
 			if (${portlet} == "Google Drive") {
@@ -496,7 +494,7 @@ definition {
 		var baseURL = JSONCompany.getPortalURL();
 
 		if (${portlet} == "Documents and Media Size Limits") {
-			Open(value1 = "${baseURL}/group/${siteURLKey}/~/control_panel/manage/-/site/settings?_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_configurationScreenKey=dl-size-limit-configuration-group");
+			Open(value1 = "${baseURL}/group/${siteURLKey}/~/control_panel/manage/-/site/settings?_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_factoryPid=com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration&_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration");
 		}
 
 		if (${portlet} == "Documents and Media") {
@@ -507,10 +505,6 @@ definition {
 
 		if (${portlet} == "File Order") {
 			Open(value1 = "${baseURL}/group/${siteURLKey}/~/control_panel/manage/-/site/settings?_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_factoryPid=com.liferay.document.library.internal.configuration.DLFileOrderConfiguration&_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration&_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_pid=com.liferay.document.library.internal.configuration.DLFileOrderConfiguration");
-		}
-
-		if (${portlet} == "PDF Preview") {
-			Open(value1 = "${baseURL}/group/${siteURLKey}/~/control_panel/manage/-/site/settings?_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_configurationScreenKey=dl-file-entry-configuration-group");
 		}
 
 		WaitForPageLoad();
@@ -524,14 +518,8 @@ definition {
 			var baseURL = JSONCompany.getPortalURL();
 		}
 
-		if (${portlet} == "Documents and Media Size Limits") {
-			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_configurationScreenKey=dl-size-limit-configuration-system");
-		}
-		else if (${portlet} == "File Order") {
+		if (${portlet} == "File Order") {
 			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=com.liferay.document.library.internal.configuration.DLFileOrderConfiguration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_pid=com.liferay.document.library.internal.configuration.DLFileOrderConfiguration");
-		}
-		else if (${portlet} == "File Preview Limits") {
-			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_configurationScreenKey=dl-file-entry-configuration-system");
 		}
 		else {
 			if (${portlet} == "AWS Translator") {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -1407,7 +1407,7 @@ definition {
 
 	@summary = "Default summary"
 	macro updateCheckInterval(fieldValue = null) {
-		Navigator.openWithAppendToBaseURL(urlAppend = "group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_configurationScreenKey=knowledge-base-service");
+		KBNavigator.openToConfigInSystemSettings(portlet = "System Service");
 
 		Type(
 			key_text = "Check Interval",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBNavigator.macro
@@ -9,7 +9,7 @@ definition {
 		}
 
 		if (${portlet} == "System Service") {
-			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_configurationScreenKey=knowledge-base-service");
+			Open(value1 = "${baseURL}/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=com.liferay.knowledge.base.internal.configuration.KBServiceConfiguration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration");
 		}
 
 		WaitForPageLoad();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
@@ -99,11 +99,6 @@ definition {
 		task ("Given the Notification Date is changed to 2 weeks") {
 			KBNavigator.openToConfigInSystemSettings(portlet = "System Service");
 
-			AssertTextEquals(
-				key_sectionTitle = "Article Expiration Date Notification",
-				locator1 = "PagesAdmin#SECTION_SUBTITLE",
-				value1 = "Define the timeline (in weeks) in which the user will receive a notification informing of an article expiration date. Articles within the specified expiration date will display the label \"Expiring Soon\" in the knowledge base management screen.");
-
 			Type(
 				key_text = "Notification Date (Weeks)",
 				locator1 = "TextInput#ANY",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
@@ -109,7 +109,7 @@ definition {
 				locator1 = "TextInput#ANY",
 				value1 = 2);
 
-			Button.clickSave();
+			SystemSettings.saveConfiguration();
 		}
 
 		task ("When a Knowledge Base article is created that has expired and another that has not") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100954
https://liferay.atlassian.net/browse/LPD-102359

## What Is Being Fixed

LPD-92881, LPD-93201, and LPD-93202 replaced the `ConfigurationScreen` components of `KBServiceConfiguration`, `DLSizeLimitConfiguration`, and `DLFileEntryConfiguration` with `ConfigurationFormRenderer` implementations. The screen keys those components published are gone, but Poshi still navigates through `/configuration_admin/view_configuration_screen` with the deleted keys `dl-size-limit-configuration-company`, `-group`, `-system`, `dl-file-entry-configuration-company`, `-group`, `-system`, and `knowledge-base-service`. An unresolvable key renders no form, so roughly fifteen tests fail before they exercise any size limit or check interval behavior.

No product behavior is broken. Release test failures: LPD-100737, LPD-100738, LPD-100740.

## How It Is Being Fixed

Each configuration now renders through `/configuration_admin/edit_configuration` keyed by its PID. `EditConfigurationMVCRenderCommand` reads `pid` with `factoryPid` as its default, and neither configuration is a factory, so `factoryPid` alone is sufficient. The scope comes from the hosting portlet rather than the URL: `DLSizeLimitConfigurationFormRenderer` maps `InstanceSettingsPortlet` to `COMPANY`, `SiteSettingsPortlet` to `GROUP`, and `SystemSettingsPortlet` to `SYSTEM`, then renders through `DLSizeLimitConfigurationProvider`, so the narrower scopes still show inherited values and the existing `existingLimit` assertions keep working.

In instance and system settings the size limits branches fall through to the trailing `else`, which already builds the `edit_configuration` URL and already carried the `DLSizeLimitConfiguration` PID behind the dead branch that shadowed it. Site settings gets an explicit `edit_configuration` URL. `KBArticle.updateCheckInterval` inlined a second copy of the Knowledge Base URL and now calls `KBNavigator.openToConfigInSystemSettings`, so the route lives in one place.

`DMDocument.configureMaxCopySize` saves through `SystemSettings.saveConfiguration` rather than `Button.clickSave`, because the form renders Update instead of Save once a configuration exists in the current scope. `KBAdmin#CanEnableArticleExpirationLabel` needed the same change, and its assertion on the notification-date description was dropped: the locator requires a `.sheet-section` ancestor that the conversion replaced with `div.form-group`, it asserts localized help copy inside a test whose subject is the Expiring Soon label, and the form is now covered by `knowledgeBaseServiceConfiguration.spec.ts`.

The `dl-file-entry-configuration` branches are removed, since no Poshi test navigates to File Preview Limits or PDF Preview.

## Test Execution

```bash
HOSTNAME=localhost ant -buildfile build-test.xml run-selenium-test -Dtest.class=DMFileSizeLimits
HOSTNAME=localhost ant -buildfile build-test.xml run-selenium-test -Dtest.class=DMCopyLimits
HOSTNAME=localhost ant -buildfile build-test.xml run-selenium-test -Dtest.class=KBArticle
HOSTNAME=localhost ant -buildfile build-test.xml run-selenium-test -Dtest.class=KBWorkflow
HOSTNAME=localhost ant -buildfile build-test.xml run-selenium-test -Dtest.class=DMAdmin#StagingFileSizeIsNotAffectedByDLRestrictions
HOSTNAME=localhost ant -buildfile build-test.xml run-selenium-test -Dtest.class=KBAdmin#CanEnableArticleExpirationLabel
```

`DMCopyLimits#CannotCopyFileThatExceedsMaxSizeSetInTargetSite` passes against a clean bundle, exercising instance-scope navigation, site-scope navigation, the rendered form, the inherited-value assertion, and the Update path. **The full six-class run has not been completed**, so acceptance criterion 5 is not yet demonstrated.

These suites also need a teardown that resets the size limits, which this PR does not add. `DMFileSizeLimits` writes size limits at system scope and its teardown (`DMDocument.tearDownCP`) only clears documents and the recycle bin. While the navigation was dead those writes silently did nothing; now they land and leak into later tests, so `CanLimitSizeOnlyInCurrentSite` sets the site limit to 20480 and reads back a system-scope 2 KB left by an earlier test. The Playwright side got this treatment in LPD-93201 (`60198fcdc5fb7`); the Poshi equivalent is `SystemSettings.resetConfiguration`.

## Why Are There No Tests?

This PR changes only Poshi test code and adds no product behavior. It repairs navigation in existing suites rather than adding coverage; the equivalent behavior coverage was migrated to Playwright by the three conversion tickets.

## PR Check

**pr-check: PASS** — tested on `d92c6c05863f8b7f255fe8cbe6ea2de5ca73b4d0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

Full Portal Build matched by path regex (the diff touches `portal-web/`) but was not run: every changed file is Poshi DSL under `portal-web/test/functional`, which `ant all` does not compile, so the build produces no signal for this diff.

<!-- pr-check {"result": "success", "sha": "d92c6c05863f8b7f255fe8cbe6ea2de5ca73b4d0"} -->
