### PR TITLE
LPD-102076 Count contents that reference an expired asset

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
+++ b/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless CMS API
 Bundle-SymbolicName: com.liferay.headless.cms.api
-Bundle-Version: 3.0.1
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.headless.cms.dto.v1_0,\
 	com.liferay.headless.cms.resource.v1_0

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/AssetStatistics.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/AssetStatistics.java
@@ -88,6 +88,47 @@ public class AssetStatistics implements Serializable {
 	private Supplier<Long> _approvedCountSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getBrokenLinksCount() {
+		if (_brokenLinksCountSupplier != null) {
+			brokenLinksCount = _brokenLinksCountSupplier.get();
+
+			_brokenLinksCountSupplier = null;
+		}
+
+		return brokenLinksCount;
+	}
+
+	public void setBrokenLinksCount(Long brokenLinksCount) {
+		this.brokenLinksCount = brokenLinksCount;
+
+		_brokenLinksCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setBrokenLinksCount(
+		UnsafeSupplier<Long, Exception> brokenLinksCountUnsafeSupplier) {
+
+		_brokenLinksCountSupplier = () -> {
+			try {
+				return brokenLinksCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long brokenLinksCount;
+
+	@JsonIgnore
+	private Supplier<Long> _brokenLinksCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public Long getExpiredCount() {
 		if (_expiredCountSupplier != null) {
 			expiredCount = _expiredCountSupplier.get();
@@ -454,6 +495,18 @@ public class AssetStatistics implements Serializable {
 			sb.append(approvedCount);
 		}
 
+		Long brokenLinksCount = getBrokenLinksCount();
+
+		if (brokenLinksCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"brokenLinksCount\": ");
+
+			sb.append(brokenLinksCount);
+		}
+
 		Long expiredCount = getExpiredCount();
 
 		if (expiredCount != null) {
@@ -651,4 +704,4 @@ public class AssetStatistics implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1350526058
+// LIFERAY-REST-BUILDER-HASH:-178751699

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/AssetStatistics.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/AssetStatistics.java
@@ -46,6 +46,27 @@ public class AssetStatistics implements Cloneable, Serializable {
 
 	protected Long approvedCount;
 
+	public Long getBrokenLinksCount() {
+		return brokenLinksCount;
+	}
+
+	public void setBrokenLinksCount(Long brokenLinksCount) {
+		this.brokenLinksCount = brokenLinksCount;
+	}
+
+	public void setBrokenLinksCount(
+		UnsafeSupplier<Long, Exception> brokenLinksCountUnsafeSupplier) {
+
+		try {
+			brokenLinksCount = brokenLinksCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long brokenLinksCount;
+
 	public Long getExpiredCount() {
 		return expiredCount;
 	}
@@ -246,4 +267,4 @@ public class AssetStatistics implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-195853936
+// LIFERAY-REST-BUILDER-HASH:-614999884

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/AssetStatisticsSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/AssetStatisticsSerDes.java
@@ -56,6 +56,16 @@ public class AssetStatisticsSerDes {
 			sb.append(assetStatistics.getApprovedCount());
 		}
 
+		if (assetStatistics.getBrokenLinksCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"brokenLinksCount\": ");
+
+			sb.append(assetStatistics.getBrokenLinksCount());
+		}
+
 		if (assetStatistics.getExpiredCount() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -164,6 +174,15 @@ public class AssetStatisticsSerDes {
 				String.valueOf(assetStatistics.getApprovedCount()));
 		}
 
+		if (assetStatistics.getBrokenLinksCount() == null) {
+			map.put("brokenLinksCount", null);
+		}
+		else {
+			map.put(
+				"brokenLinksCount",
+				String.valueOf(assetStatistics.getBrokenLinksCount()));
+		}
+
 		if (assetStatistics.getExpiredCount() == null) {
 			map.put("expiredCount", null);
 		}
@@ -256,6 +275,9 @@ public class AssetStatisticsSerDes {
 			if (Objects.equals(jsonParserFieldName, "approvedCount")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "brokenLinksCount")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "expiredCount")) {
 				return false;
 			}
@@ -296,6 +318,12 @@ public class AssetStatisticsSerDes {
 			if (Objects.equals(jsonParserFieldName, "approvedCount")) {
 				if (jsonParserFieldValue != null) {
 					assetStatistics.setApprovedCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "brokenLinksCount")) {
+				if (jsonParserFieldValue != null) {
+					assetStatistics.setBrokenLinksCount(
 						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
@@ -432,4 +460,4 @@ public class AssetStatisticsSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-650741636
+// LIFERAY-REST-BUILDER-HASH:1512915642

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -21,6 +21,10 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
+                brokenLinksCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
                 expiredCount:
                     format: int64
                     readOnly: true

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -61,7 +61,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetStatistics(assetLibraryId: ___){approvedCount, expiredCount, expiringSoonCount, inDraftCount, pendingCount, reviewDateOverdueCount, scheduledCount, totalCount, upcomingReviewCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetStatistics(assetLibraryId: ___){approvedCount, brokenLinksCount, expiredCount, expiringSoonCount, inDraftCount, pendingCount, reviewDateOverdueCount, scheduledCount, totalCount, upcomingReviewCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public AssetStatistics assetStatistics(
@@ -243,4 +243,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1260038530
+// LIFERAY-REST-BUILDER-HASH:-1836156125

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -163,8 +163,7 @@ public class AssetStatisticsResourceImpl
 
 			booleanQuery.addShouldQueryClauses(
 				_createTermsQuery(
-					CMSOutboundLinksUtil.FIELD_NAME,
-					values.toArray(new String[0])));
+					"outboundLinks", values.toArray(new String[0])));
 		}
 
 		booleanQuery.setMinimumShouldMatch(1);

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -15,16 +15,28 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
+import com.liferay.site.cms.site.initializer.util.CMSOutboundLinksUtil;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -75,6 +87,8 @@ public class AssetStatisticsResourceImpl
 						groupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_APPROVED)));
+				setBrokenLinksCount(
+					() -> _getBrokenLinksCount(groupIds, objectDefinitionIds));
 				setExpiredCount(
 					() -> _getCount(
 						groupIds, objectDefinitionIds,
@@ -138,6 +152,87 @@ public class AssetStatisticsResourceImpl
 		};
 	}
 
+	private BooleanQuery _createOutboundLinksBooleanQuery(
+		List<String> outboundLinkTokens) {
+
+		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+		for (int i = 0; i < outboundLinkTokens.size(); i += _MAX_TERMS_COUNT) {
+			List<String> values = outboundLinkTokens.subList(
+				i, Math.min(i + _MAX_TERMS_COUNT, outboundLinkTokens.size()));
+
+			booleanQuery.addShouldQueryClauses(
+				_createTermsQuery(
+					CMSOutboundLinksUtil.FIELD_NAME,
+					values.toArray(new String[0])));
+		}
+
+		booleanQuery.setMinimumShouldMatch(1);
+
+		return booleanQuery;
+	}
+
+	private TermsQuery _createTermsQuery(String fieldName, String... values) {
+		TermsQuery termsQuery = QueriesUtil.terms(fieldName);
+
+		termsQuery.addValues(values);
+
+		return termsQuery;
+	}
+
+	private long _getBrokenLinksCount(
+		Long[] groupIds, Long[] objectDefinitionIds) {
+
+		try {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					contextCompany.getCompanyId(), "LPD-82226")) {
+
+				return 0;
+			}
+
+			List<String> expiredAssetTokens = _getExpiredAssetTokens(
+				objectDefinitionIds);
+
+			if (expiredAssetTokens.isEmpty()) {
+				return 0;
+			}
+
+			BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+			booleanQuery.addFilterQueryClauses(
+				_createOutboundLinksBooleanQuery(expiredAssetTokens),
+				_createTermsQuery("cms_section", "contents", "files"),
+				_createTermsQuery(
+					Field.STATUS,
+					ArrayUtil.toStringArray(CMSWorkflowConstants.STATUSES)),
+				QueriesUtil.term("rootDescendantNode", false));
+
+			SearchResponse searchResponse = _searcher.search(
+				_searchRequestBuilderFactory.builder(
+				).companyId(
+					contextCompany.getCompanyId()
+				).emptySearchEnabled(
+					true
+				).groupIds(
+					ArrayUtil.toArray(groupIds)
+				).query(
+					booleanQuery
+				).withSearchContext(
+					searchContext -> searchContext.setAttribute(
+						Field.STATUS, WorkflowConstants.STATUS_ANY)
+				).build());
+
+			return searchResponse.getCount();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return 0;
+		}
+	}
+
 	private long _getCount(
 		Long[] groupIds, Long[] objectDefinitionIds, Predicate predicate) {
 
@@ -153,6 +248,39 @@ public class AssetStatisticsResourceImpl
 
 			return 0;
 		}
+	}
+
+	private List<String> _getExpiredAssetTokens(Long[] objectDefinitionIds) {
+		List<String> expiredAssetTokens = new ArrayList<>();
+
+		List<Object[]> results = _objectEntryLocalService.dslQuery(
+			DSLQueryFactoryUtil.select(
+				ObjectEntryTable.INSTANCE.externalReferenceCode,
+				ObjectEntryTable.INSTANCE.objectEntryId
+			).from(
+				ObjectEntryTable.INSTANCE
+			).where(
+				ObjectEntryTable.INSTANCE.companyId.eq(
+					contextCompany.getCompanyId()
+				).and(
+					ObjectEntryTable.INSTANCE.objectDefinitionId.in(
+						objectDefinitionIds)
+				).and(
+					ObjectEntryTable.INSTANCE.status.eq(
+						WorkflowConstants.STATUS_EXPIRED)
+				)
+			));
+
+		for (Object[] objects : results) {
+			expiredAssetTokens.add(
+				CMSOutboundLinksUtil.getObjectEntryExternalReferenceCodeToken(
+					GetterUtil.getString(objects[0])));
+			expiredAssetTokens.add(
+				CMSOutboundLinksUtil.getObjectEntryIdToken(
+					GetterUtil.getLong(objects[1])));
+		}
+
+		return expiredAssetTokens;
 	}
 
 	private Long[] _getGroupIds(Long assetLibraryId) {
@@ -180,6 +308,7 @@ public class AssetStatisticsResourceImpl
 		return new AssetStatistics() {
 			{
 				setApprovedCount(() -> 0L);
+				setBrokenLinksCount(() -> 0L);
 				setExpiredCount(() -> 0L);
 				setExpiringSoonCount(() -> 0L);
 				setInDraftCount(() -> 0L);
@@ -193,6 +322,8 @@ public class AssetStatisticsResourceImpl
 	}
 
 	private static final int _EXPIRING_SOON_DAYS = 7;
+
+	private static final int _MAX_TERMS_COUNT = 65536;
 
 	private static final int _UPCOMING_REVIEW_DAYS = 7;
 
@@ -210,5 +341,11 @@ public class AssetStatisticsResourceImpl
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 }

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -182,13 +182,13 @@ public class AssetStatisticsResourceImpl
 	private long _getBrokenLinksCount(
 		Long[] groupIds, Long[] objectDefinitionIds) {
 
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-82226")) {
+
+			return 0;
+		}
+
 		try {
-			if (!FeatureFlagManagerUtil.isEnabled(
-					contextCompany.getCompanyId(), "LPD-82226")) {
-
-				return 0;
-			}
-
 			List<String> expiredAssetTokens = _getExpiredAssetTokens(
 				objectDefinitionIds);
 
@@ -224,8 +224,8 @@ public class AssetStatisticsResourceImpl
 			return searchResponse.getCount();
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to get the broken links count", exception);
 			}
 
 			return 0;

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -21,6 +21,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -31,6 +32,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -42,6 +44,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -70,7 +73,8 @@ public class AssetStatisticsResourceTest
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	@Override
@@ -88,6 +92,7 @@ public class AssetStatisticsResourceTest
 		};
 	}
 
+	@FeatureFlag("LPD-82226")
 	@Override
 	@Test
 	public void testGetAssetStatistics() throws Exception {
@@ -227,6 +232,7 @@ public class AssetStatisticsResourceTest
 
 		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
 
+		_testGetAssetStatisticsBrokenLinksCount();
 		_testGetAssetStatisticsByAssetLibrary();
 	}
 
@@ -237,6 +243,15 @@ public class AssetStatisticsResourceTest
 
 	private ObjectEntry _addObjectEntry(
 			DepotEntry depotEntry, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		return _addObjectEntry(
+			RandomTestUtil.randomString(), depotEntry, objectDefinition);
+	}
+
+	private ObjectEntry _addObjectEntry(
+			String content, DepotEntry depotEntry,
+			ObjectDefinition objectDefinition)
 		throws Exception {
 
 		ObjectEntryFolder objectEntryFolder =
@@ -252,7 +267,7 @@ public class AssetStatisticsResourceTest
 			HashMapBuilder.<String, Serializable>put(
 				"content_i18n",
 				HashMapBuilder.put(
-					"en_US", RandomTestUtil.randomString()
+					"en_US", content
 				).build()
 			).put(
 				"title_i18n",
@@ -333,6 +348,22 @@ public class AssetStatisticsResourceTest
 		}
 	}
 
+	private void _assertBrokenLinksCount(
+			Long assetLibraryId, long expectedBrokenLinksCount)
+		throws Exception {
+
+		for (AssetStatisticsResource assetStatisticsResource :
+				_assetStatisticsResources) {
+
+			AssetStatistics assetStatistics =
+				assetStatisticsResource.getAssetStatistics(assetLibraryId);
+
+			Assert.assertEquals(
+				expectedBrokenLinksCount,
+				GetterUtil.getLong(assetStatistics.getBrokenLinksCount()));
+		}
+	}
+
 	private AssetStatisticsResource _buildAssetStatisticsResource(User user) {
 		return AssetStatisticsResource.builder(
 		).authentication(
@@ -354,6 +385,47 @@ public class AssetStatisticsResourceTest
 		return _objectDefinitionLocalService.
 			getObjectDefinitionByExternalReferenceCode(
 				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+	}
+
+	private String _getImageHTML(String externalReferenceCode) {
+		return StringBundler.concat(
+			"<img src=\"/documents/20125/0/image.jpg/", StringUtil.randomId(),
+			"?download=true&amp;objectDefinitionExternalReferenceCode=",
+			"L_CMS_BASIC_DOCUMENT&amp;objectEntryExternalReferenceCode=",
+			externalReferenceCode,
+			"&amp;objectFieldExternalReferenceCode=FILE\">");
+	}
+
+	private void _testGetAssetStatisticsBrokenLinksCount() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+
+		try {
+			ObjectDefinition objectDefinition =
+				_getBasicWebContentObjectDefinition();
+
+			ObjectEntry targetObjectEntry = _addObjectEntry(
+				depotEntry, objectDefinition);
+
+			_addObjectEntry(
+				_getImageHTML(targetObjectEntry.getExternalReferenceCode()),
+				depotEntry, objectDefinition);
+
+			_assertBrokenLinksCount(depotEntry.getGroupId(), 0);
+
+			_objectEntryLocalService.updateStatus(
+				TestPropsValues.getUserId(),
+				targetObjectEntry.getObjectEntryId(),
+				WorkflowConstants.STATUS_EXPIRED, serviceContext);
+
+			_assertBrokenLinksCount(depotEntry.getGroupId(), 1);
+		}
+		finally {
+			_depotEntryLocalService.deleteDepotEntry(
+				depotEntry.getDepotEntryId());
+		}
 	}
 
 	private void _testGetAssetStatisticsByAssetLibrary() throws Exception {

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -421,6 +421,30 @@ public class AssetStatisticsResourceTest
 				WorkflowConstants.STATUS_EXPIRED, serviceContext);
 
 			_assertBrokenLinksCount(depotEntry.getGroupId(), 1);
+
+			_addObjectEntry(
+				_getImageHTML(targetObjectEntry.getExternalReferenceCode()),
+				depotEntry, objectDefinition);
+
+			_assertBrokenLinksCount(depotEntry.getGroupId(), 2);
+
+			ObjectEntry otherTargetObjectEntry = _addObjectEntry(
+				depotEntry, objectDefinition);
+
+			_objectEntryLocalService.updateStatus(
+				TestPropsValues.getUserId(),
+				otherTargetObjectEntry.getObjectEntryId(),
+				WorkflowConstants.STATUS_EXPIRED, serviceContext);
+
+			String imageHTML = _getImageHTML(
+				targetObjectEntry.getExternalReferenceCode());
+			String otherImageHTML = _getImageHTML(
+				otherTargetObjectEntry.getExternalReferenceCode());
+
+			_addObjectEntry(
+				imageHTML + otherImageHTML, depotEntry, objectDefinition);
+
+			_assertBrokenLinksCount(depotEntry.getGroupId(), 3);
 		}
 		finally {
 			_depotEntryLocalService.deleteDepotEntry(

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetStatisticsResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetStatisticsResourceTestCase.java
@@ -282,6 +282,14 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("brokenLinksCount", additionalAssertFieldName)) {
+				if (assetStatistics.getBrokenLinksCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("expiredCount", additionalAssertFieldName)) {
 				if (assetStatistics.getExpiredCount() == null) {
 					valid = false;
@@ -475,6 +483,17 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				if (!Objects.deepEquals(
 						assetStatistics1.getApprovedCount(),
 						assetStatistics2.getApprovedCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("brokenLinksCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetStatistics1.getBrokenLinksCount(),
+						assetStatistics2.getBrokenLinksCount())) {
 
 					return false;
 				}
@@ -689,6 +708,11 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("brokenLinksCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("expiredCount")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -777,6 +801,7 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 		return new AssetStatistics() {
 			{
 				approvedCount = RandomTestUtil.randomLong();
+				brokenLinksCount = RandomTestUtil.randomLong();
 				expiredCount = RandomTestUtil.randomLong();
 				expiringSoonCount = RandomTestUtil.randomLong();
 				inDraftCount = RandomTestUtil.randomLong();
@@ -1012,4 +1037,4 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 		_assetStatisticsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:501613399
+// LIFERAY-REST-BUILDER-HASH:-583460990

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSOutboundLinksUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSOutboundLinksUtil.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class CMSOutboundLinksUtil {
+
+	public static final String FIELD_NAME = "outboundLinks";
+
+	public static String getObjectEntryExternalReferenceCodeToken(
+		String externalReferenceCode) {
+
+		return _getToken("objectEntryERC", externalReferenceCode);
+	}
+
+	public static String getObjectEntryIdToken(long objectEntryId) {
+		return _getToken("objectEntryId", String.valueOf(objectEntryId));
+	}
+
+	private static String _getToken(String prefix, String value) {
+		return StringBundler.concat(prefix, StringPool.UNDERLINE, value);
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSOutboundLinksUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSOutboundLinksUtil.java
@@ -13,8 +13,6 @@ import com.liferay.petra.string.StringPool;
  */
 public class CMSOutboundLinksUtil {
 
-	public static final String FIELD_NAME = "outboundLinks";
-
 	public static String getObjectEntryExternalReferenceCodeToken(
 		String externalReferenceCode) {
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -112,8 +112,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 
 			if (!outboundLinks.isEmpty()) {
 				document.addKeyword(
-					CMSOutboundLinksUtil.FIELD_NAME,
-					outboundLinks.toArray(new String[0]));
+					"outboundLinks", outboundLinks.toArray(new String[0]));
 			}
 		}
 		catch (Exception exception) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -11,8 +11,6 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -21,6 +19,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.site.cms.site.initializer.internal.search.links.OutboundLinksUtil;
+import com.liferay.site.cms.site.initializer.util.CMSOutboundLinksUtil;
 
 import java.io.Serializable;
 
@@ -86,9 +85,8 @@ public class CMSContentOutboundLinksModelDocumentContributor
 
 					if (objectEntryId != 0) {
 						outboundLinks.add(
-							_getToken(
-								"objectEntryId",
-								String.valueOf(objectEntryId)));
+							CMSOutboundLinksUtil.getObjectEntryIdToken(
+								objectEntryId));
 					}
 				}
 				else if (Objects.equals(
@@ -104,8 +102,9 @@ public class CMSContentOutboundLinksModelDocumentContributor
 										content)) {
 
 							outboundLinks.add(
-								_getToken(
-									"objectEntryERC", externalReferenceCode));
+								CMSOutboundLinksUtil.
+									getObjectEntryExternalReferenceCodeToken(
+										externalReferenceCode));
 						}
 					}
 				}
@@ -113,7 +112,8 @@ public class CMSContentOutboundLinksModelDocumentContributor
 
 			if (!outboundLinks.isEmpty()) {
 				document.addKeyword(
-					"outboundLinks", outboundLinks.toArray(new String[0]));
+					CMSOutboundLinksUtil.FIELD_NAME,
+					outboundLinks.toArray(new String[0]));
 			}
 		}
 		catch (Exception exception) {
@@ -155,10 +155,6 @@ public class CMSContentOutboundLinksModelDocumentContributor
 		}
 
 		return Collections.singletonList(String.valueOf(content));
-	}
-
-	private String _getToken(String prefix, String value) {
-		return StringBundler.concat(prefix, StringPool.UNDERLINE, value);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/GovernanceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/GovernanceService.ts
@@ -7,6 +7,7 @@ import ApiHelper from '../../../common/services/ApiHelper';
 
 export type AssetStatistics = {
 	approvedCount: number;
+	brokenLinksCount: number;
 	expiredCount: number;
 	expiringSoonCount: number;
 	inDraftCount: number;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/AttentionRequired.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/AttentionRequired.tsx
@@ -25,7 +25,7 @@ type AttentionCard = {
 	description: string;
 	hoverContent: React.ReactNode;
 	icon: string;
-	statKey?: keyof AssetStatistics;
+	statKey: keyof AssetStatistics;
 	title: string;
 };
 
@@ -37,6 +37,7 @@ const ATTENTION_CARDS: AttentionCard[] = [
 		),
 		hoverContent: reviewText(Liferay.Language.get('review-broken-links')),
 		icon: 'link',
+		statKey: 'brokenLinksCount',
 		title: Liferay.Language.get('broken-links'),
 	},
 	{
@@ -123,7 +124,7 @@ export function AttentionRequired() {
 						statKey,
 						title,
 					}) => {
-						const sectionPath = statKey && SECTION_PATHS[statKey];
+						const sectionPath = SECTION_PATHS[statKey];
 
 						return (
 							<ClayLayout.Col
@@ -145,9 +146,7 @@ export function AttentionRequired() {
 									}
 									title={title}
 									trend={placeholderTrend}
-									value={
-										(statKey && statistics?.[statKey]) || 0
-									}
+									value={statistics?.[statKey] || 0}
 								/>
 							</ClayLayout.Col>
 						);

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSOutboundLinksCompanyIndexConfigurationContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSOutboundLinksCompanyIndexConfigurationContributorTest.java
@@ -6,12 +6,10 @@
 package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
 
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-import com.liferay.site.cms.site.initializer.util.CMSOutboundLinksUtil;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -52,12 +50,10 @@ public class CMSOutboundLinksCompanyIndexConfigurationContributorTest {
 		);
 
 		Assert.assertEquals(
-			StringBundler.concat(
-				"{\"properties\":{\"", CMSOutboundLinksUtil.FIELD_NAME,
-				"\":{\"type\":\"keyword\"}}}"),
+			"{\"properties\": {\"outboundLinks\": {\"type\": \"keyword\"}}}",
 			StringUtil.removeChars(
 				argumentCaptor.getValue(), CharPool.NEW_LINE, CharPool.RETURN,
-				CharPool.SPACE, CharPool.TAB));
+				CharPool.TAB));
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSOutboundLinksCompanyIndexConfigurationContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSOutboundLinksCompanyIndexConfigurationContributorTest.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.site.cms.site.initializer.util.CMSOutboundLinksUtil;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class CMSOutboundLinksCompanyIndexConfigurationContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContributeMappings() {
+		CMSOutboundLinksCompanyIndexConfigurationContributor
+			cmsOutboundLinksCompanyIndexConfigurationContributor =
+				new CMSOutboundLinksCompanyIndexConfigurationContributor();
+
+		MappingsHelper mappingsHelper = Mockito.mock(MappingsHelper.class);
+
+		cmsOutboundLinksCompanyIndexConfigurationContributor.contributeMappings(
+			RandomTestUtil.randomLong(), mappingsHelper);
+
+		ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			mappingsHelper
+		).putMappings(
+			argumentCaptor.capture()
+		);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"{\"properties\":{\"", CMSOutboundLinksUtil.FIELD_NAME,
+				"\":{\"type\":\"keyword\"}}}"),
+			StringUtil.removeChars(
+				argumentCaptor.getValue(), CharPool.NEW_LINE, CharPool.RETURN,
+				CharPool.SPACE, CharPool.TAB));
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/util/CMSOutboundLinksUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/util/CMSOutboundLinksUtilTest.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.util;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class CMSOutboundLinksUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetObjectEntryExternalReferenceCodeToken() {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			"objectEntryERC_" + externalReferenceCode,
+			CMSOutboundLinksUtil.getObjectEntryExternalReferenceCodeToken(
+				externalReferenceCode));
+	}
+
+	@Test
+	public void testGetObjectEntryIdToken() {
+		long objectEntryId = RandomTestUtil.randomLong();
+
+		Assert.assertEquals(
+			"objectEntryId_" + objectEntryId,
+			CMSOutboundLinksUtil.getObjectEntryIdToken(objectEntryId));
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceDashboard.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceDashboard.test.tsx
@@ -29,6 +29,7 @@ const mockedSpaceService = SpaceService as jest.Mocked<typeof SpaceService>;
 
 const STATISTICS = {
 	approvedCount: 0,
+	brokenLinksCount: 7,
 	expiredCount: 6,
 	expiringSoonCount: 0,
 	inDraftCount: 0,
@@ -54,7 +55,7 @@ describe('[CMS Dashboard] GovernanceDashboard', () => {
 		} as any);
 	});
 
-	it("shows each card's count, from the statistics for the real ones and the placeholder for Broken Links", async () => {
+	it("shows each card's count from the statistics", async () => {
 		render(<GovernanceDashboard />);
 
 		expect(
@@ -78,7 +79,7 @@ describe('[CMS Dashboard] GovernanceDashboard', () => {
 		expect(
 			within(
 				screen.getByRole('button', {name: /broken-links/})
-			).getByText('0')
+			).getByText('7')
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102076

## What Is Being Fixed

The Attention Required card on the governance dashboard had no way to report broken links. The asset statistics endpoint returned only the expired and expiring figures, so the card had nothing to read for the Broken Links section and the section could not be rendered at all.

A content has a broken link when it references an asset that is no longer available to the reader. The index already records those references: `CMSContentOutboundLinksModelDocumentContributor` writes one token per referenced asset into the `outboundLinks` keyword field. Nothing consumed them yet.

## How It Is Being Fixed

`AssetStatistics` gains a `brokenLinksCount` field, and `AssetStatisticsResourceImpl` computes it by resolving the expired assets of the requested scope, turning each one into the same tokens the document contributor writes, and counting the contents whose `outboundLinks` field matches any of them. The count is therefore the number of referring contents rather than the number of dead references, which is what the card reports.

The token format was the coupling problem. It lived as private string concatenation inside the contributor, in `site-cms-site-initializer`, while the reader now lives in `headless-cms-impl`. Two modules formatting the same index tokens independently would drift on the first change, so the format moved into `CMSOutboundLinksUtil` in `site-cms-site-initializer-api`, alongside the field name itself. Both sides now build tokens through the same two methods, and a unit test pins the wire format so a rename cannot silently break the match.

There are two token forms because there are two kinds of reference. Rich text references an asset by external reference code, while a relationship field references it by ID, and the count has to match either.

The dashboard card wires the new statistic into the existing Broken Links section, and `statKey` became a required prop, since every section now has a statistic backing it.

A second unit test guards the index mapping. The `outboundLinks` field has to stay a `keyword` for the terms match to work, and a change to `text` would keep compiling while quietly returning wrong counts.

## Test Execution

```bash
gradlew -p modules/apps/site/site-cms-site-initializer test
gradlew -p modules/apps/headless/headless-cms/headless-cms-test testIntegration --tests AssetStatisticsResourceTest
```

```bash
cd modules/apps/site/site-cms-site-initializer && yarn test test/js/main_view/dashboard/GovernanceDashboard.test.tsx
```

## PR Check

**pr-check: PASS** — tested on `2b9d30c5cf1f0977214c75c04c28920154918f33`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Transaction Usage | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

`JavaScript Unit Tests`: the full-suite run reported 955 of 956 passing. The one failure, `test/js/content_editor/components/panels/SchedulePanel.test.tsx`, overran the default 5s timeout under concurrent build load; the file is not in this diff and the suite passes on its own.

`Per-Module Compile`: the `ant compile install-portal-snapshots` setup step was skipped, as this branch touches no portal core.

<!-- pr-check {"result": "success", "sha": "2b9d30c5cf1f0977214c75c04c28920154918f33"} -->
