### PR TITLE
LPD-102504 Reach the Knowledge Base service configuration by factory PID

### DIFF
--- a/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
+++ b/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
@@ -27,6 +27,14 @@ export class SystemSettingsPage {
 		await this.globalMenuPage.goToControlPanel('System Settings');
 	}
 
+	async goToConfiguration(factoryPid: string) {
+		await this.page.goto(
+			`/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=${factoryPid}&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration`
+		);
+
+		await waitForPageToBeLoaded(this.page);
+	}
+
 	async goToSystemSetting(
 		categoryKey: string,
 		configurationName: string,

--- a/modules/test/playwright/pages/knowledge-base-web/KBServiceConfigurationPage.ts
+++ b/modules/test/playwright/pages/knowledge-base-web/KBServiceConfigurationPage.ts
@@ -32,9 +32,8 @@ export class KBServiceConfigurationPage {
 	}
 
 	async goTo() {
-		await this.systemSettingsPage.goToSystemSetting(
-			'Knowledge Base',
-			'Service'
+		await this.systemSettingsPage.goToConfiguration(
+			'com.liferay.knowledge.base.internal.configuration.KBServiceConfiguration'
 		);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102504

## What Is Being Fixed

Both tests in `knowledgeBaseServiceConfiguration.spec.ts` fail with `Test timeout of 90000ms exceeded while running "beforeEach" hook`.

Two Knowledge Base configurations render under the same display name in System Settings: `knowledge-base-group-service-configuration-name` and `knowledge-base-service-configuration-name` both resolve to `Service`. `SystemSettingsPage.goToSystemSetting` picks the entry by that label and calls `first()`, so the page object lands on `KBGroupServiceConfiguration`, which renders the email template fields. The `checkInterval` and `expirationDateNotificationDateWeeks` inputs the fixture reads belong to `KBServiceConfiguration`, so they never appear and `inputValue()` waits out the full timeout, failing the hook for every test in the file.

## How It Is Being Fixed

The page object now asks for the configuration by factory PID instead of by display name. `SystemSettingsPage` gains a `goToConfiguration` method that navigates straight to the `edit_configuration` URL for a given factory PID and waits for the page to load, following the shape already used by `QuestionsConfigurationPage` and `StagingConfigurationPage`. `KBServiceConfigurationPage.goTo` passes `com.liferay.knowledge.base.internal.configuration.KBServiceConfiguration`, the same PID `KBNavigator.openToConfigInSystemSettings` uses on the Poshi side.

`goToSystemSetting` is left untouched, so no other page object changes behavior.

## Test Execution

```bash
cd modules/test/playwright && yarn test tests/knowledge-base-web/main/knowledgeBaseServiceConfiguration.spec.ts
```

Both tests pass in 4.7s and 3.8s, against 90s timeouts before the change.

## Why Are There No Tests?

The change fixes existing coverage rather than adding new behavior. The two tests in `knowledgeBaseServiceConfiguration.spec.ts` already cover persisting and resetting the configuration; they were failing because the page object navigated to the wrong screen, and they pass now.

## PR Check

**pr-check: PASS** — tested on `00d8d8eddae844248b91c185a93a6c407d86f40f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile matched the diff but is not applicable: `modules/test/playwright` has a node-only `build.gradle` with no `deploy` task, no `bnd.bnd`, and the diff contains no Java. JavaScript Unit Tests is the module's TypeScript project check, since the module has no jest suite and its `test` script is `playwright test`.

<!-- pr-check {"result": "success", "sha": "00d8d8eddae844248b91c185a93a6c407d86f40f"} -->
