### PR TITLE
LPD-100952 Fix global menu permissions test for CMS always-visible behavior

### DIFF
--- a/modules/test/playwright/tests/product-navigation-applications-menu/main/globalMenuPermissions.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-applications-menu/main/globalMenuPermissions.spec.ts
@@ -102,12 +102,22 @@ test(
 
 		const categories = globalMenuPage.categoriesList.getByRole('menuitem');
 
-		await expect(categories).toHaveCount(1);
-
 		const firstCategory = categories.first();
 
 		await expect(firstCategory).toHaveAccessibleName('Control Panel');
 		await expect(firstCategory).toHaveCSS('border-top-width', '0px');
+
+		await expect(
+			globalMenuPage.categoriesList.getByRole('menuitem', {
+				name: 'Applications',
+			})
+		).not.toBeAttached();
+
+		await expect(
+			globalMenuPage.categoriesList.getByRole('menuitem', {
+				name: 'Commerce',
+			})
+		).not.toBeAttached();
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100952

## What Is Being Fixed

The Playwright test "It shows categories according to user permissions" was asserting that a restricted user (with only `VIEW_CONTROL_PANEL` and `ACCESS_IN_CONTROL_PANEL` for UsersAdminPortlet) sees exactly one category in the global menu. The test was failing because the CMS category always appears unconditionally — `normalizeCategoryItems` in `GlobalMenu.tsx` splices CMS into the category list at position 2 regardless of user permissions.

## How It Is Being Fixed

The count assertion is removed and replaced with targeted assertions that verify the permission-gated categories (Applications and Commerce) are not attached to the DOM for this restricted user. CMS is intentionally excluded from that check since it is always visible. The first-category assertions (Control Panel is first, with no top border) are preserved.

## PR Check

**pr-check: PASS** — tested on `ecc8f678414f87c9b0694897cd3e3747d2bf05cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "ecc8f678414f87c9b0694897cd3e3747d2bf05cf"} -->
