### PR TITLE
LPD-102517 Wait for the Permissions submenu before opening the modal

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -3297,14 +3297,7 @@ test(
 					.getByRole('button', {name: `${contentName} Actions`})
 					.click();
 
-				await page
-					.getByRole('menuitem', {exact: true, name: 'Permissions'})
-					.click();
-
-				await page
-					.getByRole('menuitem', {exact: true, name: 'Permissions'})
-					.last()
-					.click();
+				await permissionsPage.openFromActionsMenu();
 
 				await permissionsPage.checkPermissionsAndSave(
 					overriddenPermissions
@@ -3342,14 +3335,7 @@ test(
 					.getByRole('button', {name: `${contentName} Actions`})
 					.click();
 
-				await page
-					.getByRole('menuitem', {exact: true, name: 'Permissions'})
-					.click();
-
-				await page
-					.getByRole('menuitem', {exact: true, name: 'Permissions'})
-					.last()
-					.click();
+				await permissionsPage.openFromActionsMenu();
 
 				await permissionsPage.verifyPermissions([
 					{
@@ -3446,14 +3432,7 @@ test(
 					.getByRole('button', {name: `${contentName} Actions`})
 					.click();
 
-				await page
-					.getByRole('menuitem', {exact: true, name: 'Permissions'})
-					.click();
-
-				await page
-					.getByRole('menuitem', {exact: true, name: 'Permissions'})
-					.last()
-					.click();
+				await permissionsPage.openFromActionsMenu();
 
 				await permissionsPage.verifyPermissions(expected);
 			}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts
@@ -11,6 +11,7 @@ import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import getRandomString from '../../../../utils/getRandomString';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {waitForAlert} from '../../../../utils/waitForAlert';
+import {PermissionsPage} from '../../permissions/pages/PermissionsPage';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 import {addRoleMemberAndSwitch} from './helpers/roleMembership';
 
@@ -165,14 +166,9 @@ test(
 				.getByRole('button', {name: 'Actions'})
 				.click();
 
-			await page
-				.getByRole('menuitem', {exact: true, name: 'Permissions'})
-				.click();
+			const permissionsPage = new PermissionsPage(page);
 
-			await page
-				.getByRole('menuitem', {exact: true, name: 'Permissions'})
-				.last()
-				.click();
+			await permissionsPage.openFromActionsMenu();
 
 			await expect(
 				page

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
@@ -10,6 +10,7 @@ import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {waitForAlert} from '../../../../utils/waitForAlert';
+import {PermissionsPage} from '../../permissions/pages/PermissionsPage';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
@@ -151,14 +152,9 @@ test(
 
 		await spaceRow.getByRole('button', {name: 'Actions'}).click();
 
-		await page
-			.getByRole('menuitem', {exact: true, name: 'Permissions'})
-			.click();
+		const permissionsPage = new PermissionsPage(page);
 
-		await page
-			.getByRole('menuitem', {exact: true, name: 'Permissions'})
-			.last()
-			.click();
+		await permissionsPage.openFromActionsMenu();
 
 		await expect(
 			page.getByRole('dialog').getByRole('heading', {name: 'Permissions'})

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/pages/PermissionsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/pages/PermissionsPage.ts
@@ -54,6 +54,17 @@ export class PermissionsPage {
 		await this.permissionsModalCloseButton.click();
 	}
 
+	async openFromActionsMenu() {
+		const permissionsMenuItems = this.page.getByRole('menuitem', {
+			exact: true,
+			name: 'Permissions',
+		});
+
+		await permissionsMenuItems.first().click();
+
+		await permissionsMenuItems.nth(1).click();
+	}
+
 	async verifyPermissions(
 		permissions: Array<{action: string; checked: boolean; role: string}>
 	) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102517

## What Is Being Fixed

Four Playwright tests fail because the Permissions modal is never opened:

- `bulkActions.spec.ts` — `Permissions can be reset to defaults in bulk from the All section` (LPD-85553)
- `bulkActions.spec.ts` — `Permissions can be edited by role in bulk from the All section` (LPD-85553)
- `spaces/roleBasedActions.spec.ts` — `A Space Admin can manage space content and settings` (LPD-85681)
- `spaces/spaceManagement.spec.ts` — `The Permissions modal can be opened from the All Spaces row actions` (LPD-85670)

`Permissions` is a submenu whose child entry, also named `Permissions`, is the one that opens the modal. Each test clicked the parent and then clicked the last match of `menuitem[name="Permissions"]`. A `last()` locator resolves as soon as one element matches and does not wait for a second, so at that moment the only match is the parent and the test clicks it again. The submenu is left open, the modal is never requested, and the assertion times out. Traces contain no request to `PortletConfigurationPortlet`, which confirms the modal was never fetched.

The tests were not flaky in the ordinary sense: all four reproduce locally. They passed on older runs only because the ordering happened to be favorable.

## How It Is Being Fixed

`PermissionsPage` gains `openFromActionsMenu`, which clicks the first match to open the submenu and then clicks `nth(1)`. Unlike `last()`, `nth(1)` names a position that does not exist yet, so Playwright waits for the submenu to render before clicking the child.

The parent is first and the child second in DOM order, verified against the rendered accessibility tree, so `nth(1)` is the child rather than a guess.

The same eight-line block appeared at four call sites across three specs. All four now delegate to the page object, which removes the duplication along with the defect.

## Test Execution

```bash
cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/bulkActions.spec.ts tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts --grep "Permissions can be edited by role in bulk from the All section|Permissions can be reset to defaults in bulk from the All section|A Space Admin can manage space content and settings|The Permissions modal can be opened from the All Spaces row actions"
```

All four pass, with the project setup and teardown specs, in 1.3 minutes.

## Why Are There No Tests?

The change repairs existing coverage rather than adding behavior. The four tests already cover the Permissions modal; they were failing because the navigation never reached it.

## PR Check

**pr-check: PASS** — tested on `f57c6e047b35e7a902de74cffd09552edf8f0a58`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile matched the diff but is not applicable: `modules/test/playwright` has a node-only `build.gradle` with no `deploy` task, no `bnd.bnd`, and the diff contains no Java. JavaScript Unit Tests is the module's TypeScript project check, since the module has no jest suite and its `test` script is `playwright test`.

<!-- pr-check {"result": "success", "sha": "f57c6e047b35e7a902de74cffd09552edf8f0a58"} -->
