### PR TITLE
LPD-102522 Set the principal before running the CMP site initializer

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer-test-util/src/main/java/com/liferay/site/cmp/site/initializer/test/util/CMPTestUtil.java
+++ b/modules/apps/site/site-cmp-site-initializer-test-util/src/main/java/com/liferay/site/cmp/site/initializer/test/util/CMPTestUtil.java
@@ -24,6 +24,10 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -248,7 +252,17 @@ public class CMPTestUtil {
 			boolean processBatchEngine, Class<?> clazz, Group group)
 		throws Exception {
 
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		String originalName = PrincipalThreadLocal.getName();
+
 		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+			PrincipalThreadLocal.setName(TestPropsValues.getUserId());
+
 			ServiceContextThreadLocal.pushServiceContext(
 				ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
@@ -282,6 +296,11 @@ public class CMPTestUtil {
 			}
 		}
 		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+
+			PrincipalThreadLocal.setName(originalName);
+
 			ServiceContextThreadLocal.popServiceContext();
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102522
https://liferay.atlassian.net/browse/LPD-102521

## What Is Being Fixed

`CMPTestUtil._initialize` pushed a `ServiceContext` and set `CompanyThreadLocal`, but never set `PrincipalThreadLocal`. `BundleSiteInitializer._initialize` resolves the acting user from that thread local:

```java
User user = _userLocalService.getUser(PrincipalThreadLocal.getUserId());
```

With nothing set, `getUserId()` returned 0 and the lookup threw `NoSuchUserException: No User exists with the primary key 0`.

`BundleSiteInitializer.initialize` both logs that exception and rethrows it as an `InitializationException`, so one failure surfaced as two reported failures: `DepotEntryUserNotificationTest#testGetLink` failed on the exception, and `PortalLogAssertorTest#testScanXMLLog` failed on the logged ERROR while scanning the portal log. The log assertor had no independent defect.

The failure is deterministic, not flaky. It occurs whenever `CMPTestUtil.getOrAddGroup` takes the branch where the `L_CMP_PROJECT` object definition is null, and passes only when an earlier test in the same database already created that definition, short-circuiting the branch. Test ordering therefore decided the outcome in CI, which made it look intermittent.

## How It Is Being Fixed

`CMPTestUtil._initialize` now sets both the principal and a permission checker for the test user before invoking the site initializer, and restores the original values in the existing `finally` block. This mirrors the sibling helper `DSRTestUtil.getOrAddGroup` in `site-dsr-site-initializer-test-util`, which already handled this correctly, so the two helpers are now consistent. The permission checker is set alongside the principal because the initializer goes on to create permissioned content, where a null checker would be a latent second failure.

No `LogCapture` was added. Suppressing the logged ERROR would have masked the underlying setup defect and would not have fixed `testGetLink`.

One note for reviewers reproducing this locally: the CMP runtime is excluded from the portal bundle, and it spans two modules that both need deploying — `site-initializer/site-initializer-cmp` (the initializer) and `site/site-cmp-site-initializer` (which registers `CMPProjectObjectEntryScopeProvider`). With only the first deployed, the batch unit fails with `The value true of setting "autogeneratedGroupId" is invalid for object definition "CMPProject"`, because `ObjectDefinitionLocalServiceImpl` accepts that setting only when a scope provider is registered for the definition's external reference code. That error is an environment artifact, not a defect in this change.

## Test Execution

```bash
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests DepotEntryUserNotificationTest
```

Verified locally: fails on `testGetLink` before the change, passes 5/5 after, across two consecutive runs each starting from a database with no `L_CMP_*` object definitions.

## Why Are There No Tests?

This commit fixes a test utility, not product code. The covering test already exists: `DepotEntryUserNotificationTest#testGetLink` fails without this change with `NoSuchUserException: No User exists with the primary key 0` and passes with it, verified locally across two consecutive 5/5 runs. A new test would be redundant, since the change exists precisely to make existing coverage executable.

## PR Check

**pr-check: PASS** — tested on `6cd928c2d665f6a99a7239e89cf8524fa0bd1ea6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

Per-Module Compile ran the module deploy without the `ant compile install-portal-snapshots` setup step, as this branch changes no `portal-kernel` or `portal-impl` source and the existing snapshot already matched the branch tree.

<!-- pr-check {"result": "success", "sha": "6cd928c2d665f6a99a7239e89cf8524fa0bd1ea6"} -->
