### PR TITLE
LPD-42740 Align the DXP EULA license identifier with 2023-06

### DIFF
--- a/modules/apps/portal/portal-webdav-test/src/testIntegration/java/com/liferay/portal/webdav/test/WebDAVServletTest.java
+++ b/modules/apps/portal/portal-webdav-test/src/testIntegration/java/com/liferay/portal/webdav/test/WebDAVServletTest.java
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2024-09
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.portal.webdav.test;

--- a/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
+++ b/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2024-09
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.portal.webserver.test;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/BaseCMSServletTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/BaseCMSServletTestCase.java
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2024-09
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.site.cms.site.initializer.internal.servlet.test;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/DownloadObjectEntryFolderCMSServletTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/DownloadObjectEntryFolderCMSServletTest.java
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2024-09
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.site.cms.site.initializer.internal.servlet.test;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/TranslateObjectEntryCMSServletTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/TranslateObjectEntryCMSServletTest.java
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2024-09
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.site.cms.site.initializer.internal.servlet.test;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-42740

## What Is Being Fixed

5 test classes declared the SPDX license identifier `LicenseRef-Liferay-DXP-EULA-2.0.0-2024-09` in their copyright header. Every other file in the repository, along with the canonical `copyright.txt` template, declares `LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06`, so these 5 were the only outliers.

## How It Is Being Fixed

The identifier in each of the 5 headers is changed to `LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06`, matching `copyright.txt`. Only the license identifier moves; the `SPDX-FileCopyrightText` year on each file is left as it stands, and no other line changes.

## PR Check

**pr-check: PASS** — tested on `e3f1ba83f9126c893cd135a9d202690306d03dfb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e3f1ba83f9126c893cd135a9d202690306d03dfb"} -->
