### PR TITLE
LPD-97867 Group near duplicate CMS content into similarity clusters

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
+++ b/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless CMS API
 Bundle-SymbolicName: com.liferay.headless.cms.api
-Bundle-Version: 3.0.1
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.headless.cms.dto.v1_0,\
 	com.liferay.headless.cms.resource.v1_0

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityCluster.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityCluster.java
@@ -1,0 +1,312 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A group of CMS content assets detected as near duplicates of one another.",
+	value = "SimilarityCluster"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A group of CMS content assets detected as near duplicates of one another."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarityCluster")
+public class SimilarityCluster implements Serializable {
+
+	public static SimilarityCluster toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarityCluster.class, json);
+	}
+
+	public static SimilarityCluster unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(SimilarityCluster.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The cluster's assets that fall inside the requested page. A cluster split across pages repeats in the next page with the remaining assets."
+	)
+	@Valid
+	public SimilarityClusterAsset[] getSimilarityClusterAssets() {
+		if (_similarityClusterAssetsSupplier != null) {
+			similarityClusterAssets = _similarityClusterAssetsSupplier.get();
+
+			_similarityClusterAssetsSupplier = null;
+		}
+
+		return similarityClusterAssets;
+	}
+
+	public void setSimilarityClusterAssets(
+		SimilarityClusterAsset[] similarityClusterAssets) {
+
+		this.similarityClusterAssets = similarityClusterAssets;
+
+		_similarityClusterAssetsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSimilarityClusterAssets(
+		UnsafeSupplier<SimilarityClusterAsset[], Exception>
+			similarityClusterAssetsUnsafeSupplier) {
+
+		_similarityClusterAssetsSupplier = () -> {
+			try {
+				return similarityClusterAssetsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The cluster's assets that fall inside the requested page. A cluster split across pages repeats in the next page with the remaining assets."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected SimilarityClusterAsset[] similarityClusterAssets;
+
+	@JsonIgnore
+	private Supplier<SimilarityClusterAsset[]> _similarityClusterAssetsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The total number of assets in the cluster, independent of the requested page."
+	)
+	public Integer getSize() {
+		if (_sizeSupplier != null) {
+			size = _sizeSupplier.get();
+
+			_sizeSupplier = null;
+		}
+
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+
+		_sizeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		_sizeSupplier = () -> {
+			try {
+				return sizeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The total number of assets in the cluster, independent of the requested page."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Integer size;
+
+	@JsonIgnore
+	private Supplier<Integer> _sizeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityCluster)) {
+			return false;
+		}
+
+		SimilarityCluster similarityCluster = (SimilarityCluster)object;
+
+		return Objects.equals(toString(), similarityCluster.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		SimilarityClusterAsset[] similarityClusterAssets =
+			getSimilarityClusterAssets();
+
+		if (similarityClusterAssets != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusterAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarityClusterAssets.length; i++) {
+				sb.append(String.valueOf(similarityClusterAssets[i]));
+
+				if ((i + 1) < similarityClusterAssets.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Integer size = getSize();
+
+		if (size != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(size);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarityCluster",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-663602045

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterAsset.java
@@ -1,0 +1,418 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A CMS content asset that belongs to a similarity cluster.",
+	value = "SimilarityClusterAsset"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A CMS content asset that belongs to a similarity cluster."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarityClusterAsset")
+public class SimilarityClusterAsset implements Serializable {
+
+	public static SimilarityClusterAsset toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarityClusterAsset.class, json);
+	}
+
+	public static SimilarityClusterAsset unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			SimilarityClusterAsset.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The localized label of the asset's content type."
+	)
+	public String getContentType() {
+		if (_contentTypeSupplier != null) {
+			contentType = _contentTypeSupplier.get();
+
+			_contentTypeSupplier = null;
+		}
+
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+
+		_contentTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		_contentTypeSupplier = () -> {
+			try {
+				return contentTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The localized label of the asset's content type."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String contentType;
+
+	@JsonIgnore
+	private Supplier<String> _contentTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterAsset)) {
+			return false;
+		}
+
+		SimilarityClusterAsset similarityClusterAsset =
+			(SimilarityClusterAsset)object;
+
+		return Objects.equals(toString(), similarityClusterAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		String contentType = getContentType();
+
+		if (contentType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentType));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarityClusterAsset",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-342421532

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterResult.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarityClusterResult.java
@@ -1,0 +1,309 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Near duplicate clusters of CMS content for the selected space.",
+	value = "SimilarityClusterResult"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "Near duplicate clusters of CMS content for the selected space."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarityClusterResult")
+public class SimilarityClusterResult implements Serializable {
+
+	public static SimilarityClusterResult toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarityClusterResult.class, json);
+	}
+
+	public static SimilarityClusterResult unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			SimilarityClusterResult.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public SimilarityCluster[] getSimilarityClusters() {
+		if (_similarityClustersSupplier != null) {
+			similarityClusters = _similarityClustersSupplier.get();
+
+			_similarityClustersSupplier = null;
+		}
+
+		return similarityClusters;
+	}
+
+	public void setSimilarityClusters(SimilarityCluster[] similarityClusters) {
+		this.similarityClusters = similarityClusters;
+
+		_similarityClustersSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSimilarityClusters(
+		UnsafeSupplier<SimilarityCluster[], Exception>
+			similarityClustersUnsafeSupplier) {
+
+		_similarityClustersSupplier = () -> {
+			try {
+				return similarityClustersUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected SimilarityCluster[] similarityClusters;
+
+	@JsonIgnore
+	private Supplier<SimilarityCluster[]> _similarityClustersSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The total number of clustered assets, independent of the requested page."
+	)
+	public Long getTotalCount() {
+		if (_totalCountSupplier != null) {
+			totalCount = _totalCountSupplier.get();
+
+			_totalCountSupplier = null;
+		}
+
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+
+		_totalCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		_totalCountSupplier = () -> {
+			try {
+				return totalCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The total number of clustered assets, independent of the requested page."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long totalCount;
+
+	@JsonIgnore
+	private Supplier<Long> _totalCountSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterResult)) {
+			return false;
+		}
+
+		SimilarityClusterResult similarityClusterResult =
+			(SimilarityClusterResult)object;
+
+		return Objects.equals(toString(), similarityClusterResult.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		SimilarityCluster[] similarityClusters = getSimilarityClusters();
+
+		if (similarityClusters != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusters\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarityClusters.length; i++) {
+				sb.append(String.valueOf(similarityClusters[i]));
+
+				if ((i + 1) < similarityClusters.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Long totalCount = getTotalCount();
+
+		if (totalCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(totalCount);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:994249262

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarityClusterResultResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarityClusterResultResource.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-cms/v1.0
+ *
+ * @author Crescenzo Rega
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface SimilarityClusterResultResource {
+
+	public SimilarityClusterResult getSimilarityCluster(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public SimilarityClusterResultResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1872855166

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityCluster.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityCluster.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityCluster implements Cloneable, Serializable {
+
+	public static SimilarityCluster toDTO(String json) {
+		return SimilarityClusterSerDes.toDTO(json);
+	}
+
+	public SimilarityClusterAsset[] getSimilarityClusterAssets() {
+		return similarityClusterAssets;
+	}
+
+	public void setSimilarityClusterAssets(
+		SimilarityClusterAsset[] similarityClusterAssets) {
+
+		this.similarityClusterAssets = similarityClusterAssets;
+	}
+
+	public void setSimilarityClusterAssets(
+		UnsafeSupplier<SimilarityClusterAsset[], Exception>
+			similarityClusterAssetsUnsafeSupplier) {
+
+		try {
+			similarityClusterAssets =
+				similarityClusterAssetsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected SimilarityClusterAsset[] similarityClusterAssets;
+
+	public Integer getSize() {
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+	}
+
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		try {
+			size = sizeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer size;
+
+	@Override
+	public SimilarityCluster clone() throws CloneNotSupportedException {
+		return (SimilarityCluster)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityCluster)) {
+			return false;
+		}
+
+		SimilarityCluster similarityCluster = (SimilarityCluster)object;
+
+		return Objects.equals(toString(), similarityCluster.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarityClusterSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1638321847

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterAsset.java
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterAsset implements Cloneable, Serializable {
+
+	public static SimilarityClusterAsset toDTO(String json) {
+		return SimilarityClusterAssetSerDes.toDTO(json);
+	}
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		try {
+			contentType = contentTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String contentType;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public SimilarityClusterAsset clone() throws CloneNotSupportedException {
+		return (SimilarityClusterAsset)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterAsset)) {
+			return false;
+		}
+
+		SimilarityClusterAsset similarityClusterAsset =
+			(SimilarityClusterAsset)object;
+
+		return Objects.equals(toString(), similarityClusterAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarityClusterAssetSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-942605612

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterResult.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarityClusterResult.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterResultSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterResult implements Cloneable, Serializable {
+
+	public static SimilarityClusterResult toDTO(String json) {
+		return SimilarityClusterResultSerDes.toDTO(json);
+	}
+
+	public SimilarityCluster[] getSimilarityClusters() {
+		return similarityClusters;
+	}
+
+	public void setSimilarityClusters(SimilarityCluster[] similarityClusters) {
+		this.similarityClusters = similarityClusters;
+	}
+
+	public void setSimilarityClusters(
+		UnsafeSupplier<SimilarityCluster[], Exception>
+			similarityClustersUnsafeSupplier) {
+
+		try {
+			similarityClusters = similarityClustersUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected SimilarityCluster[] similarityClusters;
+
+	public Long getTotalCount() {
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+	}
+
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		try {
+			totalCount = totalCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long totalCount;
+
+	@Override
+	public SimilarityClusterResult clone() throws CloneNotSupportedException {
+		return (SimilarityClusterResult)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarityClusterResult)) {
+			return false;
+		}
+
+		SimilarityClusterResult similarityClusterResult =
+			(SimilarityClusterResult)object;
+
+		return Objects.equals(toString(), similarityClusterResult.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarityClusterResultSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1869469088

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarityClusterResultResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarityClusterResultResource.java
@@ -1,0 +1,281 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.resource.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterResultSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public interface SimilarityClusterResultResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public SimilarityClusterResult getSimilarityCluster(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSimilarityClusterHttpResponse(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public SimilarityClusterResultResource build() {
+			return new SimilarityClusterResultResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class SimilarityClusterResultResourceImpl
+		implements SimilarityClusterResultResource {
+
+		public SimilarityClusterResult getSimilarityCluster(
+				Long assetLibraryId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSimilarityClusterHttpResponse(assetLibraryId, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return SimilarityClusterResultSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSimilarityClusterHttpResponse(
+				Long assetLibraryId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetLibraryId != null) {
+				httpInvoker.parameter(
+					"assetLibraryId", String.valueOf(assetLibraryId));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cms/v1.0/similarity-clusters");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private SimilarityClusterResultResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			SimilarityClusterResultResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:527749362

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterAssetSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterAssetSerDes.java
@@ -1,0 +1,310 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterAssetSerDes {
+
+	public static SimilarityClusterAsset toDTO(String json) {
+		SimilarityClusterAssetJSONParser similarityClusterAssetJSONParser =
+			new SimilarityClusterAssetJSONParser();
+
+		return similarityClusterAssetJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarityClusterAsset[] toDTOs(String json) {
+		SimilarityClusterAssetJSONParser similarityClusterAssetJSONParser =
+			new SimilarityClusterAssetJSONParser();
+
+		return similarityClusterAssetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarityClusterAsset similarityClusterAsset) {
+		if (similarityClusterAsset == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarityClusterAsset.getContentType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarityClusterAsset.getContentType()));
+
+			sb.append("\"");
+		}
+
+		if (similarityClusterAsset.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					similarityClusterAsset.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (similarityClusterAsset.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(similarityClusterAsset.getId());
+		}
+
+		if (similarityClusterAsset.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarityClusterAsset.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarityClusterAssetJSONParser similarityClusterAssetJSONParser =
+			new SimilarityClusterAssetJSONParser();
+
+		return similarityClusterAssetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		SimilarityClusterAsset similarityClusterAsset) {
+
+		if (similarityClusterAsset == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarityClusterAsset.getContentType() == null) {
+			map.put("contentType", null);
+		}
+		else {
+			map.put(
+				"contentType",
+				String.valueOf(similarityClusterAsset.getContentType()));
+		}
+
+		if (similarityClusterAsset.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(
+					similarityClusterAsset.getDateModified()));
+		}
+
+		if (similarityClusterAsset.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(similarityClusterAsset.getId()));
+		}
+
+		if (similarityClusterAsset.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(similarityClusterAsset.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarityClusterAssetJSONParser
+		extends BaseJSONParser<SimilarityClusterAsset> {
+
+		@Override
+		protected SimilarityClusterAsset createDTO() {
+			return new SimilarityClusterAsset();
+		}
+
+		@Override
+		protected SimilarityClusterAsset[] createDTOArray(int size) {
+			return new SimilarityClusterAsset[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarityClusterAsset similarityClusterAsset,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setContentType(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterAsset.setTitle(
+						(String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-719273329

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterResultSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterResultSerDes.java
@@ -1,0 +1,268 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterResultSerDes {
+
+	public static SimilarityClusterResult toDTO(String json) {
+		SimilarityClusterResultJSONParser similarityClusterResultJSONParser =
+			new SimilarityClusterResultJSONParser();
+
+		return similarityClusterResultJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarityClusterResult[] toDTOs(String json) {
+		SimilarityClusterResultJSONParser similarityClusterResultJSONParser =
+			new SimilarityClusterResultJSONParser();
+
+		return similarityClusterResultJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(
+		SimilarityClusterResult similarityClusterResult) {
+
+		if (similarityClusterResult == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (similarityClusterResult.getSimilarityClusters() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusters\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < similarityClusterResult.getSimilarityClusters().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(
+						similarityClusterResult.getSimilarityClusters()[i]));
+
+				if ((i + 1) <
+						similarityClusterResult.
+							getSimilarityClusters().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (similarityClusterResult.getTotalCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(similarityClusterResult.getTotalCount());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarityClusterResultJSONParser similarityClusterResultJSONParser =
+			new SimilarityClusterResultJSONParser();
+
+		return similarityClusterResultJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		SimilarityClusterResult similarityClusterResult) {
+
+		if (similarityClusterResult == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (similarityClusterResult.getSimilarityClusters() == null) {
+			map.put("similarityClusters", null);
+		}
+		else {
+			map.put(
+				"similarityClusters",
+				String.valueOf(
+					similarityClusterResult.getSimilarityClusters()));
+		}
+
+		if (similarityClusterResult.getTotalCount() == null) {
+			map.put("totalCount", null);
+		}
+		else {
+			map.put(
+				"totalCount",
+				String.valueOf(similarityClusterResult.getTotalCount()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarityClusterResultJSONParser
+		extends BaseJSONParser<SimilarityClusterResult> {
+
+		@Override
+		protected SimilarityClusterResult createDTO() {
+			return new SimilarityClusterResult();
+		}
+
+		@Override
+		protected SimilarityClusterResult[] createDTOArray(int size) {
+			return new SimilarityClusterResult[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "similarityClusters")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarityClusterResult similarityClusterResult,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "similarityClusters")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					SimilarityCluster[] similarityClustersArray =
+						new SimilarityCluster[jsonParserFieldValues.length];
+
+					for (int i = 0; i < similarityClustersArray.length; i++) {
+						similarityClustersArray[i] =
+							SimilarityClusterSerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					similarityClusterResult.setSimilarityClusters(
+						similarityClustersArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					similarityClusterResult.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-266726700

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarityClusterSerDes.java
@@ -1,0 +1,269 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarityClusterSerDes {
+
+	public static SimilarityCluster toDTO(String json) {
+		SimilarityClusterJSONParser similarityClusterJSONParser =
+			new SimilarityClusterJSONParser();
+
+		return similarityClusterJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarityCluster[] toDTOs(String json) {
+		SimilarityClusterJSONParser similarityClusterJSONParser =
+			new SimilarityClusterJSONParser();
+
+		return similarityClusterJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarityCluster similarityCluster) {
+		if (similarityCluster == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (similarityCluster.getSimilarityClusterAssets() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarityClusterAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < similarityCluster.getSimilarityClusterAssets().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(
+						similarityCluster.getSimilarityClusterAssets()[i]));
+
+				if ((i + 1) <
+						similarityCluster.getSimilarityClusterAssets().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (similarityCluster.getSize() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(similarityCluster.getSize());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarityClusterJSONParser similarityClusterJSONParser =
+			new SimilarityClusterJSONParser();
+
+		return similarityClusterJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		SimilarityCluster similarityCluster) {
+
+		if (similarityCluster == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (similarityCluster.getSimilarityClusterAssets() == null) {
+			map.put("similarityClusterAssets", null);
+		}
+		else {
+			map.put(
+				"similarityClusterAssets",
+				String.valueOf(similarityCluster.getSimilarityClusterAssets()));
+		}
+
+		if (similarityCluster.getSize() == null) {
+			map.put("size", null);
+		}
+		else {
+			map.put("size", String.valueOf(similarityCluster.getSize()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarityClusterJSONParser
+		extends BaseJSONParser<SimilarityCluster> {
+
+		@Override
+		protected SimilarityCluster createDTO() {
+			return new SimilarityCluster();
+		}
+
+		@Override
+		protected SimilarityCluster[] createDTOArray(int size) {
+			return new SimilarityCluster[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(
+					jsonParserFieldName, "similarityClusterAssets")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarityCluster similarityCluster, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(
+					jsonParserFieldName, "similarityClusterAssets")) {
+
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					SimilarityClusterAsset[] similarityClusterAssetsArray =
+						new SimilarityClusterAsset
+							[jsonParserFieldValues.length];
+
+					for (int i = 0; i < similarityClusterAssetsArray.length;
+						 i++) {
+
+						similarityClusterAssetsArray[i] =
+							SimilarityClusterAssetSerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					similarityCluster.setSimilarityClusterAssets(
+						similarityClusterAssetsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				if (jsonParserFieldValue != null) {
+					similarityCluster.setSize(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1026318494

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -64,6 +64,57 @@ components:
         ResetAssetPermissionAction:
             allOf:
                 -   $ref: "#/components/schemas/AssetPermissionAction"
+        SimilarityCluster:
+            description:
+                A group of CMS content assets detected as near duplicates of one another.
+            properties:
+                similarityClusterAssets:
+                    description:
+                        The cluster's assets that fall inside the requested page. A cluster split across pages repeats in the next page with the remaining assets.
+                    items:
+                        $ref: "#/components/schemas/SimilarityClusterAsset"
+                    readOnly: true
+                    type: array
+                size:
+                    description:
+                        The total number of assets in the cluster, independent of the requested page.
+                    readOnly: true
+                    type: integer
+        SimilarityClusterAsset:
+            description:
+                A CMS content asset that belongs to a similarity cluster.
+            properties:
+                contentType:
+                    description:
+                        The localized label of the asset's content type.
+                    readOnly: true
+                    type: string
+                dateModified:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                title:
+                    readOnly: true
+                    type: string
+        SimilarityClusterResult:
+            description:
+                Near duplicate clusters of CMS content for the selected space.
+            properties:
+                similarityClusters:
+                    items:
+                        $ref: "#/components/schemas/SimilarityCluster"
+                    readOnly: true
+                    type: array
+                totalCount:
+                    description:
+                        The total number of clustered assets, independent of the requested page.
+                    format: int64
+                    readOnly: true
+                    type: integer
 info:
     license:
         name: Apache 2.0
@@ -154,3 +205,32 @@ paths:
                                     $ref: "#/components/schemas/AssetUsage"
                                 type: array
             tags: ["AssetUsage"]
+    "/similarity-clusters":
+        get:
+            description:
+                List the clusters of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and clustering always spans the whole space, so a cluster's size never depends on the requested page. Omit assetLibraryId to span all accessible spaces.
+            operationId: getSimilarityCluster
+            parameters:
+                -   in: query
+                    name: assetLibraryId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/SimilarityClusterResult"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/SimilarityClusterResult"
+            tags: ["SimilarityClusterResult"]

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -7,8 +7,10 @@ package com.liferay.headless.cms.internal.graphql.query.v1_0;
 
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -58,6 +60,15 @@ public class Query {
 			assetUsageResourceComponentServiceObjects;
 	}
 
+	public static void
+		setSimilarityClusterResultResourceComponentServiceObjects(
+			ComponentServiceObjects<SimilarityClusterResultResource>
+				similarityClusterResultResourceComponentServiceObjects) {
+
+		_similarityClusterResultResourceComponentServiceObjects =
+			similarityClusterResultResourceComponentServiceObjects;
+	}
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -97,6 +108,29 @@ public class Query {
 				assetUsageResource.getAssetUsagesAssetPage(
 					assetId, search, Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(assetUsageResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {similarityCluster(assetLibraryId: ___, page: ___, pageSize: ___){similarityClusters, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "List the clusters of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and clustering always spans the whole space, so a cluster's size never depends on the requested page. Omit assetLibraryId to span all accessible spaces."
+	)
+	public SimilarityClusterResult similarityCluster(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_similarityClusterResultResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			similarityClusterResultResource ->
+				similarityClusterResultResource.getSimilarityCluster(
+					Long.valueOf(assetLibraryId),
+					Pagination.of(page, pageSize)));
 	}
 
 	@GraphQLName("AssetStatisticsPage")
@@ -150,6 +184,39 @@ public class Query {
 
 		@GraphQLField
 		protected java.util.Collection<AssetUsage> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("SimilarityClusterResultPage")
+	public class SimilarityClusterResultPage {
+
+		public SimilarityClusterResultPage(Page similarityClusterResultPage) {
+			actions = similarityClusterResultPage.getActions();
+
+			items = similarityClusterResultPage.getItems();
+			lastPage = similarityClusterResultPage.getLastPage();
+			page = similarityClusterResultPage.getPage();
+			pageSize = similarityClusterResultPage.getPageSize();
+			totalCount = similarityClusterResultPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<SimilarityClusterResult> items;
 
 		@GraphQLField
 		protected long lastPage;
@@ -221,10 +288,34 @@ public class Query {
 		assetUsageResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private void _populateResourceContext(
+			SimilarityClusterResultResource similarityClusterResultResource)
+		throws Exception {
+
+		similarityClusterResultResource.setContextAcceptLanguage(
+			_acceptLanguage);
+		similarityClusterResultResource.setContextCompany(_company);
+		similarityClusterResultResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		similarityClusterResultResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		similarityClusterResultResource.setContextUriInfo(_uriInfo);
+		similarityClusterResultResource.setContextUser(_user);
+		similarityClusterResultResource.setGroupLocalService(
+			_groupLocalService);
+		similarityClusterResultResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarityClusterResultResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarityClusterResultResource.setRoleLocalService(_roleLocalService);
+	}
+
 	private static ComponentServiceObjects<AssetStatisticsResource>
 		_assetStatisticsResourceComponentServiceObjects;
 	private static ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
+	private static ComponentServiceObjects<SimilarityClusterResultResource>
+		_similarityClusterResultResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
 	private com.liferay.portal.kernel.model.Company _company;
@@ -243,4 +334,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1260038530
+// LIFERAY-REST-BUILDER-HASH:1562894836

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -10,9 +10,11 @@ import com.liferay.headless.cms.internal.graphql.query.v1_0.Query;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetPermissionActionResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetStatisticsResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetUsageResourceImpl;
+import com.liferay.headless.cms.internal.resource.v1_0.SimilarityClusterResultResourceImpl;
 import com.liferay.headless.cms.resource.v1_0.AssetPermissionActionResource;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 
@@ -45,6 +47,8 @@ public class ServletDataImpl implements ServletData {
 			_assetStatisticsResourceComponentServiceObjects);
 		Query.setAssetUsageResourceComponentServiceObjects(
 			_assetUsageResourceComponentServiceObjects);
+		Query.setSimilarityClusterResultResourceComponentServiceObjects(
+			_similarityClusterResultResourceComponentServiceObjects);
 	}
 
 	public String getApplicationName() {
@@ -97,6 +101,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							AssetUsageResourceImpl.class,
 							"getAssetUsagesAssetPage"));
+					put(
+						"query#similarityCluster",
+						new ObjectValuePair<>(
+							SimilarityClusterResultResourceImpl.class,
+							"getSimilarityCluster"));
 				}
 			};
 
@@ -112,5 +121,9 @@ public class ServletDataImpl implements ServletData {
 	private ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
 
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarityClusterResultResource>
+		_similarityClusterResultResourceComponentServiceObjects;
+
 }
-// LIFERAY-REST-BUILDER-HASH:-1043047869
+// LIFERAY-REST-BUILDER-HASH:-1811138682

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarityClusterResultResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarityClusterResultResourceImpl.java
@@ -1,0 +1,536 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseSimilarityClusterResultResourceImpl
+	implements SimilarityClusterResultResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-cms/v1.0/similarity-clusters'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "List the clusters of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and clustering always spans the whole space, so a cluster's size never depends on the requested page. Omit assetLibraryId to span all accessible spaces."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "SimilarityClusterResult"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/similarity-clusters")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public SimilarityClusterResult getSimilarityCluster(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetLibraryId")
+			Long assetLibraryId,
+			@jakarta.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return new SimilarityClusterResult();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-cms";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSimilarityClusterResultResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:1531224140

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -91,9 +91,11 @@ public class OpenAPIResourceImpl {
 
 			add(AssetUsageResourceImpl.class);
 
+			add(SimilarityClusterResultResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1867425424
+// LIFERAY-REST-BUILDER-HASH:143483010

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarityClusterResultResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarityClusterResultResourceImpl.java
@@ -1,0 +1,435 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.headless.cms.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.internal.similarity.SimilarityClusterUtil;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.IncludeExcludeClause;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.GroupUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/similarity-cluster-result.properties",
+	scope = ServiceScope.PROTOTYPE,
+	service = SimilarityClusterResultResource.class
+)
+public class SimilarityClusterResultResourceImpl
+	extends BaseSimilarityClusterResultResourceImpl {
+
+	@Override
+	public SimilarityClusterResult getSimilarityCluster(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception {
+
+		List<ObjectDefinition> objectDefinitions = _getCMSObjectDefinitions();
+
+		Long[] groupIds = _getGroupIds(assetLibraryId);
+
+		if (ArrayUtil.isEmpty(groupIds) || objectDefinitions.isEmpty()) {
+			return _toSimilarityClusterResult(new ArrayList<>(), 0);
+		}
+
+		String[] entryClassNames = ArrayUtil.toStringArray(
+			ListUtil.toList(objectDefinitions, ObjectDefinition::getClassName));
+		String languageId = contextAcceptLanguage.getPreferredLanguageId();
+
+		List<String> sharedBands = _searchSharedBands(
+			entryClassNames, groupIds, languageId);
+
+		Map<Long, List<Long>> objectEntryIdsMap =
+			SimilarityClusterUtil.getClusters(
+				_FIELD_NAME_BANDS,
+				_searchClusteredDocuments(
+					entryClassNames, groupIds, sharedBands),
+				new HashSet<>(sharedBands));
+
+		long totalCount = 0;
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			totalCount += objectEntryIds.size();
+		}
+
+		Map<Long, ObjectDefinition> objectDefinitionsMap = new HashMap<>();
+
+		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			objectDefinitionsMap.put(
+				objectDefinition.getObjectDefinitionId(), objectDefinition);
+		}
+
+		return _toSimilarityClusterResult(
+			_getSimilarityClusters(
+				languageId, objectDefinitionsMap, objectEntryIdsMap,
+				pagination),
+			totalCount);
+	}
+
+	private List<ObjectDefinition> _getCMSObjectDefinitions() throws Exception {
+		return _objectDefinitionService.getCMSObjectDefinitions(
+			contextCompany.getCompanyId(),
+			new String[] {
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+			});
+	}
+
+	private Long[] _getGroupIds(Long assetLibraryId) {
+		List<Long> depotEntryGroupIds =
+			_depotEntryService.getDepotEntryGroupIds(
+				contextCompany.getCompanyId(), contextUser.getUserId(),
+				DepotConstants.TYPE_SPACE);
+
+		if (assetLibraryId == null) {
+			return depotEntryGroupIds.toArray(new Long[0]);
+		}
+
+		Long groupId = GroupUtil.getDepotGroupId(
+			String.valueOf(assetLibraryId), contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService);
+
+		if ((groupId == null) || !depotEntryGroupIds.contains(groupId)) {
+			return new Long[0];
+		}
+
+		return new Long[] {groupId};
+	}
+
+	private Consumer<SearchContext> _getSearchContextConsumer(Long[] groupIds) {
+		long[] scopedGroupIds = ArrayUtil.toArray(groupIds);
+
+		return searchContext -> {
+			searchContext.setAttribute(
+				Field.STATUS, WorkflowConstants.STATUS_APPROVED);
+			searchContext.setGroupIds(scopedGroupIds);
+
+			_setPermissionFilterUserId(searchContext);
+		};
+	}
+
+	private List<SimilarityCluster> _getSimilarityClusters(
+			String languageId, Map<Long, ObjectDefinition> objectDefinitionsMap,
+			Map<Long, List<Long>> objectEntryIdsMap, Pagination pagination)
+		throws Exception {
+
+		List<SimilarityCluster> similarityClusters = new ArrayList<>();
+
+		int endPosition = -1;
+		int startPosition = -1;
+
+		if (pagination != null) {
+			endPosition = pagination.getEndPosition();
+			startPosition = pagination.getStartPosition();
+		}
+
+		int position = 0;
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			int clusterStartPosition = position;
+
+			position += objectEntryIds.size();
+
+			List<Long> pageObjectEntryIds = objectEntryIds;
+
+			if ((endPosition >= 0) && (startPosition >= 0)) {
+				if (position <= startPosition) {
+					continue;
+				}
+
+				if (clusterStartPosition >= endPosition) {
+					break;
+				}
+
+				pageObjectEntryIds = objectEntryIds.subList(
+					Math.max(startPosition - clusterStartPosition, 0),
+					Math.min(
+						endPosition - clusterStartPosition,
+						objectEntryIds.size()));
+			}
+
+			similarityClusters.add(
+				_toSimilarityCluster(
+					languageId, objectDefinitionsMap, pageObjectEntryIds,
+					objectEntryIds.size()));
+		}
+
+		return similarityClusters;
+	}
+
+	private List<Document> _searchClusteredDocuments(
+		String[] entryClassNames, Long[] groupIds, List<String> sharedBands) {
+
+		List<Document> documents = new ArrayList<>();
+
+		if (sharedBands.isEmpty()) {
+			return documents;
+		}
+
+		TermsQuery termsQuery = QueriesUtil.terms(_FIELD_NAME_BANDS);
+
+		termsQuery.addValues(sharedBands.toArray());
+
+		SearchRequestBuilder searchRequestBuilder =
+			_searchRequestBuilderFactory.builder();
+
+		searchRequestBuilder.addComplexQueryPart(
+			_complexQueryPartBuilderFactory.builder(
+			).occur(
+				"must"
+			).query(
+				termsQuery
+			).build()
+		).companyId(
+			contextCompany.getCompanyId()
+		).emptySearchEnabled(
+			true
+		).entryClassNames(
+			entryClassNames
+		).fetchSourceIncludes(
+			new String[] {
+				SimilarityClusterUtil.FIELD_NAME_OBJECT_ENTRY_ID,
+				_FIELD_NAME_BANDS
+			}
+		).size(
+			_MAX_CLUSTERED_ASSETS
+		).withSearchContext(
+			_getSearchContextConsumer(groupIds)
+		);
+
+		SearchResponse searchResponse = _searcher.search(
+			searchRequestBuilder.build());
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		for (SearchHit searchHit : searchHits.getSearchHits()) {
+			documents.add(searchHit.getDocument());
+		}
+
+		return documents;
+	}
+
+	private List<String> _searchSharedBands(
+		String[] entryClassNames, Long[] groupIds, String languageId) {
+
+		List<String> sharedBands = new ArrayList<>();
+
+		TermsAggregation termsAggregation = _aggregations.terms(
+			_BANDS_AGGREGATION_NAME, _FIELD_NAME_BANDS);
+
+		termsAggregation.setMinDocCount(2);
+		termsAggregation.setIncludeExcludeClause(
+			new IncludeExcludeClauseImpl(
+				SimilarityClusterUtil.getTokenPrefix(languageId) + ".*", null));
+		termsAggregation.setSize(_MAX_BANDS);
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).addAggregation(
+				termsAggregation
+			).companyId(
+				contextCompany.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				entryClassNames
+			).size(
+				0
+			).withSearchContext(
+				_getSearchContextConsumer(groupIds)
+			).build());
+
+		TermsAggregationResult termsAggregationResult =
+			(TermsAggregationResult)searchResponse.getAggregationResult(
+				_BANDS_AGGREGATION_NAME);
+
+		if (termsAggregationResult == null) {
+			return sharedBands;
+		}
+
+		for (Bucket bucket : termsAggregationResult.getBuckets()) {
+			sharedBands.add(bucket.getKey());
+		}
+
+		return sharedBands;
+	}
+
+	private void _setPermissionFilterUserId(SearchContext searchContext) {
+		searchContext.setUserId(contextUser.getUserId());
+	}
+
+	private SimilarityCluster _toSimilarityCluster(
+			String languageId, Map<Long, ObjectDefinition> objectDefinitionsMap,
+			List<Long> objectEntryIds, int size)
+		throws Exception {
+
+		SimilarityCluster similarityCluster = new SimilarityCluster();
+
+		SimilarityClusterAsset[] similarityClusterAssets = transformToArray(
+			objectEntryIds,
+			objectEntryId -> {
+				ObjectEntry objectEntry =
+					_objectEntryLocalService.fetchObjectEntry(objectEntryId);
+
+				if (objectEntry == null) {
+					return null;
+				}
+
+				SimilarityClusterAsset similarityClusterAsset =
+					new SimilarityClusterAsset();
+
+				similarityClusterAsset.setDateModified(
+					objectEntry::getModifiedDate);
+				similarityClusterAsset.setId(() -> objectEntryId);
+				similarityClusterAsset.setTitle(
+					() -> objectEntry.getTitleValue(languageId, true));
+
+				ObjectDefinition objectDefinition = objectDefinitionsMap.get(
+					objectEntry.getObjectDefinitionId());
+
+				if (objectDefinition != null) {
+					similarityClusterAsset.setContentType(
+						() -> objectDefinition.getLabel(languageId, true));
+				}
+
+				return similarityClusterAsset;
+			},
+			SimilarityClusterAsset.class);
+
+		similarityCluster.setSimilarityClusterAssets(
+			() -> similarityClusterAssets);
+
+		similarityCluster.setSize(() -> size);
+
+		return similarityCluster;
+	}
+
+	private SimilarityClusterResult _toSimilarityClusterResult(
+		List<SimilarityCluster> similarityClusters, long totalCount) {
+
+		SimilarityCluster[] similarityClustersArray =
+			similarityClusters.toArray(new SimilarityCluster[0]);
+
+		SimilarityClusterResult similarityClusterResult =
+			new SimilarityClusterResult();
+
+		similarityClusterResult.setSimilarityClusters(
+			() -> similarityClustersArray);
+		similarityClusterResult.setTotalCount(() -> totalCount);
+
+		return similarityClusterResult;
+	}
+
+	private static final String _BANDS_AGGREGATION_NAME = "bands";
+
+	private static final String _FIELD_NAME_BANDS = "textSimilarityBands";
+
+	private static final int _MAX_BANDS = 10000;
+
+	private static final int _MAX_CLUSTERED_ASSETS = 10000;
+
+	@Reference
+	private Aggregations _aggregations;
+
+	@Reference
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private DepotEntryService _depotEntryService;
+
+	@Reference
+	private ObjectDefinitionService _objectDefinitionService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	private static class IncludeExcludeClauseImpl
+		implements IncludeExcludeClause {
+
+		public IncludeExcludeClauseImpl(
+			String includeRegex, String excludeRegex) {
+
+			_includeRegex = includeRegex;
+			_excludeRegex = excludeRegex;
+		}
+
+		@Override
+		public String[] getExcludedValues() {
+			return null;
+		}
+
+		@Override
+		public String getExcludeRegex() {
+			return _excludeRegex;
+		}
+
+		@Override
+		public String[] getIncludedValues() {
+			return null;
+		}
+
+		@Override
+		public String getIncludeRegex() {
+			return _includeRegex;
+		}
+
+		private final String _excludeRegex;
+		private final String _includeRegex;
+
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarityClusterResultResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarityClusterResultResourceFactoryImpl.java
@@ -1,0 +1,343 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0.factory;
+
+import com.liferay.headless.cms.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-cms/v1.0/SimilarityClusterResult",
+	service = SimilarityClusterResultResource.Factory.class
+)
+@Generated("")
+public class SimilarityClusterResultResourceFactoryImpl
+	implements SimilarityClusterResultResource.Factory {
+
+	@Override
+	public SimilarityClusterResultResource.Builder create() {
+		return new SimilarityClusterResultResource.Builder() {
+
+			@Override
+			public SimilarityClusterResultResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, SimilarityClusterResultResource>
+					similarityClusterResultResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_similarityClusterResultResourceProxyProviderFunction;
+
+				return similarityClusterResultResourceProxyProviderFunction.
+					apply(
+						(proxy, method, arguments) -> _invoke(
+							method, arguments, _checkPermissions,
+							_httpServletRequest, _httpServletResponse,
+							_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder uriInfo(
+				UriInfo uriInfo) {
+
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public SimilarityClusterResultResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, SimilarityClusterResultResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			SimilarityClusterResultResource.class.getClassLoader(),
+			SimilarityClusterResultResource.class);
+
+		try {
+			Constructor<SimilarityClusterResultResource> constructor =
+				(Constructor<SimilarityClusterResultResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		SimilarityClusterResultResource similarityClusterResultResource =
+			_componentServiceObjects.getService();
+
+		similarityClusterResultResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		similarityClusterResultResource.setContextCompany(company);
+
+		similarityClusterResultResource.setContextHttpServletRequest(
+			httpServletRequest);
+		similarityClusterResultResource.setContextHttpServletResponse(
+			httpServletResponse);
+		similarityClusterResultResource.setContextUriInfo(uriInfo);
+		similarityClusterResultResource.setContextUser(user);
+		similarityClusterResultResource.setExpressionConvert(
+			_expressionConvert);
+		similarityClusterResultResource.setFilterParserProvider(
+			_filterParserProvider);
+		similarityClusterResultResource.setGroupLocalService(
+			_groupLocalService);
+		similarityClusterResultResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarityClusterResultResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarityClusterResultResource.setRoleLocalService(_roleLocalService);
+		similarityClusterResultResource.setSortParserProvider(
+			_sortParserProvider);
+
+		try {
+			return method.invoke(similarityClusterResultResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(
+				similarityClusterResultResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarityClusterResultResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, SimilarityClusterResultResource>
+				_similarityClusterResultResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:127491409

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/similarity/SimilarityClusterUtil.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/similarity/SimilarityClusterUtil.java
@@ -1,0 +1,181 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.similarity;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.search.document.Document;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Mikel Lorza
+ */
+public class SimilarityClusterUtil {
+
+	public static final String FIELD_NAME_OBJECT_ENTRY_ID = "objectEntryId";
+
+	public static Map<Long, List<Long>> getClusters(
+		String bandField, List<Document> documents, Set<String> sharedBands) {
+
+		Map<Long, Long> parents = new LinkedHashMap<>();
+		Map<String, List<Long>> objectEntryIdsByBand = new HashMap<>();
+
+		for (Document document : documents) {
+			Long objectEntryId = document.getLong(FIELD_NAME_OBJECT_ENTRY_ID);
+
+			if (objectEntryId == null) {
+				continue;
+			}
+
+			parents.putIfAbsent(objectEntryId, objectEntryId);
+
+			for (String band : document.getStrings(bandField)) {
+				if (!sharedBands.contains(band)) {
+					continue;
+				}
+
+				List<Long> bandObjectEntryIds =
+					objectEntryIdsByBand.computeIfAbsent(
+						band, key -> new ArrayList<>());
+
+				bandObjectEntryIds.add(objectEntryId);
+			}
+		}
+
+		_union(objectEntryIdsByBand, parents);
+
+		return _getObjectEntryIdsMap(parents);
+	}
+
+	public static String getTokenPrefix(String languageId) {
+		return languageId + StringPool.UNDERLINE;
+	}
+
+	private static Long _find(Long objectEntryId, Map<Long, Long> parents) {
+		Long parent = parents.get(objectEntryId);
+
+		while (!parent.equals(objectEntryId)) {
+			objectEntryId = parent;
+
+			parent = parents.get(objectEntryId);
+		}
+
+		return objectEntryId;
+	}
+
+	private static Map<Long, List<Long>> _getObjectEntryIdsMap(
+		Map<Long, Long> parents) {
+
+		Map<Long, List<Long>> objectEntryIdsByRoot = new LinkedHashMap<>();
+
+		for (Long objectEntryId : parents.keySet()) {
+			List<Long> rootObjectEntryIds =
+				objectEntryIdsByRoot.computeIfAbsent(
+					_find(objectEntryId, parents), root -> new ArrayList<>());
+
+			rootObjectEntryIds.add(objectEntryId);
+		}
+
+		Map<Long, List<Long>> objectEntryIdsMap = new HashMap<>();
+
+		for (List<Long> objectEntryIds : objectEntryIdsByRoot.values()) {
+			if (objectEntryIds.size() < 2) {
+				continue;
+			}
+
+			Collections.sort(objectEntryIds);
+
+			objectEntryIdsMap.put(objectEntryIds.get(0), objectEntryIds);
+		}
+
+		return _getSortedObjectEntryIdsMap(objectEntryIdsMap);
+	}
+
+	private static Map<Long, List<Long>> _getSortedObjectEntryIdsMap(
+		Map<Long, List<Long>> objectEntryIdsMap) {
+
+		List<Long> clusterIds = ListUtil.fromMapKeys(objectEntryIdsMap);
+
+		clusterIds.sort(
+			Comparator.comparingInt(
+				(Long clusterId) -> {
+					List<Long> objectEntryIds = objectEntryIdsMap.get(
+						clusterId);
+
+					return objectEntryIds.size();
+				}
+			).reversed(
+			).thenComparing(
+				Comparator.naturalOrder()
+			));
+
+		Map<Long, List<Long>> sortedObjectEntryIdsMap = new LinkedHashMap<>();
+
+		for (Long clusterId : clusterIds) {
+			sortedObjectEntryIdsMap.put(
+				clusterId, objectEntryIdsMap.get(clusterId));
+		}
+
+		return sortedObjectEntryIdsMap;
+	}
+
+	private static void _union(
+		Long objectEntryId1, Long objectEntryId2, Map<Long, Long> parents) {
+
+		Long root1 = _find(objectEntryId1, parents);
+		Long root2 = _find(objectEntryId2, parents);
+
+		if (!root1.equals(root2)) {
+			parents.put(root1, root2);
+		}
+	}
+
+	private static void _union(
+		Map<String, List<Long>> objectEntryIdsByBand, Map<Long, Long> parents) {
+
+		Map<Long, Map<Long, Integer>> sharedBandCounts = new HashMap<>();
+
+		for (List<Long> objectEntryIds : objectEntryIdsByBand.values()) {
+			for (int i = 0; i < objectEntryIds.size(); i++) {
+				for (int j = i + 1; j < objectEntryIds.size(); j++) {
+					Long objectEntryId1 = objectEntryIds.get(i);
+					Long objectEntryId2 = objectEntryIds.get(j);
+
+					Long root1 = _find(objectEntryId1, parents);
+					Long root2 = _find(objectEntryId2, parents);
+
+					if (root1.equals(root2)) {
+						continue;
+					}
+
+					Map<Long, Integer> counts =
+						sharedBandCounts.computeIfAbsent(
+							Math.min(objectEntryId1, objectEntryId2),
+							key -> new HashMap<>());
+
+					int count = counts.merge(
+						Math.max(objectEntryId1, objectEntryId2), 1,
+						Integer::sum);
+
+					if (count >= _MIN_SHARED_BANDS) {
+						_union(objectEntryId1, objectEntryId2, parents);
+					}
+				}
+			}
+		}
+	}
+
+	private static final int _MIN_SHARED_BANDS = 3;
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similarity-cluster-result.properties
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similarity-cluster-result.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.CMS)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/test/java/com/liferay/headless/cms/internal/similarity/SimilarityClusterUtilTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/test/java/com/liferay/headless/cms/internal/similarity/SimilarityClusterUtilTest.java
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.similarity;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Mikel Lorza
+ */
+public class SimilarityClusterUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetClustersChainsAssetsThroughSharedBands() {
+		Map<Long, List<Long>> objectEntryIdsMap =
+			SimilarityClusterUtil.getClusters(
+				_BAND_FIELD,
+				Arrays.asList(
+					_mockDocument(1L, "b1", "b2", "b3"),
+					_mockDocument(2L, "b1", "b2", "b3", "b4", "b5", "b6"),
+					_mockDocument(3L, "b4", "b5", "b6")),
+				_toSet("b1", "b2", "b3", "b4", "b5", "b6"));
+
+		Assert.assertEquals(
+			objectEntryIdsMap.toString(), 1, objectEntryIdsMap.size());
+		Assert.assertEquals(
+			Arrays.asList(1L, 2L, 3L), objectEntryIdsMap.get(1L));
+	}
+
+	@Test
+	public void testGetClustersDropsAssetsSharingNoBand() {
+		Map<Long, List<Long>> objectEntryIdsMap =
+			SimilarityClusterUtil.getClusters(
+				_BAND_FIELD,
+				Arrays.asList(
+					_mockDocument(1L, "b1", "b2", "b3"),
+					_mockDocument(2L, "b1", "b2", "b3"),
+					_mockDocument(3L, "b7")),
+				_toSet("b1", "b2", "b3"));
+
+		Assert.assertEquals(
+			objectEntryIdsMap.toString(), 1, objectEntryIdsMap.size());
+		Assert.assertEquals(Arrays.asList(1L, 2L), objectEntryIdsMap.get(1L));
+	}
+
+	@Test
+	public void testGetClustersIgnoresBandsThatAreNotShared() {
+		Assert.assertEquals(
+			Collections.emptyMap(),
+			SimilarityClusterUtil.getClusters(
+				_BAND_FIELD,
+				Arrays.asList(_mockDocument(1L, "b9"), _mockDocument(2L, "b9")),
+				_toSet("b1")));
+	}
+
+	@Test
+	public void testGetClustersKeysClustersByLowestObjectEntryId() {
+		Map<Long, List<Long>> objectEntryIdsMap =
+			SimilarityClusterUtil.getClusters(
+				_BAND_FIELD,
+				Arrays.asList(
+					_mockDocument(7L, "b1", "b2", "b3"),
+					_mockDocument(2L, "b1", "b2", "b3"),
+					_mockDocument(5L, "b1", "b2", "b3")),
+				_toSet("b1", "b2", "b3"));
+
+		Assert.assertEquals(
+			Arrays.asList(2L, 5L, 7L), objectEntryIdsMap.get(2L));
+	}
+
+	@Test
+	public void testGetClustersNeedsMoreThanTwoSharedBands() {
+		Assert.assertEquals(
+			Collections.emptyMap(),
+			SimilarityClusterUtil.getClusters(
+				_BAND_FIELD,
+				Arrays.asList(
+					_mockDocument(1L, "b1", "b2"),
+					_mockDocument(2L, "b1", "b2")),
+				_toSet("b1", "b2")));
+	}
+
+	@Test
+	public void testGetClustersOrdersBiggestClustersFirst() {
+		Map<Long, List<Long>> objectEntryIdsMap =
+			SimilarityClusterUtil.getClusters(
+				_BAND_FIELD,
+				Arrays.asList(
+					_mockDocument(1L, "b1", "b2", "b3"),
+					_mockDocument(2L, "b1", "b2", "b3"),
+					_mockDocument(3L, "b4", "b5", "b6"),
+					_mockDocument(4L, "b4", "b5", "b6"),
+					_mockDocument(5L, "b7", "b8", "b9"),
+					_mockDocument(6L, "b7", "b8", "b9"),
+					_mockDocument(7L, "b7", "b8", "b9")),
+				_toSet("b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9"));
+
+		Assert.assertEquals(
+			Arrays.asList(5L, 1L, 3L),
+			new ArrayList<>(objectEntryIdsMap.keySet()));
+	}
+
+	private Document _mockDocument(Long objectEntryId, String... bands) {
+		Document document = Mockito.mock(Document.class);
+
+		Mockito.when(
+			document.getLong("objectEntryId")
+		).thenReturn(
+			objectEntryId
+		);
+
+		Mockito.when(
+			document.getStrings(_BAND_FIELD)
+		).thenReturn(
+			ListUtil.fromArray(bands)
+		);
+
+		return document;
+	}
+
+	private Set<String> _toSet(String... bands) {
+		return new HashSet<>(Arrays.asList(bands));
+	}
+
+	private static final String _BAND_FIELD = RandomTestUtil.randomString();
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarityClusterResultResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarityClusterResultResourceTestCase.java
@@ -1,0 +1,861 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarityClusterResultSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.JAXRSWhiteboardTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public abstract class BaseSimilarityClusterResultResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		JAXRSWhiteboardTestUtil.ensureReady();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_similarityClusterResultResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		similarityClusterResultResource =
+			SimilarityClusterResultResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarityClusterResult similarityClusterResult1 =
+			randomSimilarityClusterResult();
+
+		String json = objectMapper.writeValueAsString(similarityClusterResult1);
+
+		SimilarityClusterResult similarityClusterResult2 =
+			SimilarityClusterResultSerDes.toDTO(json);
+
+		Assert.assertTrue(
+			equals(similarityClusterResult1, similarityClusterResult2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarityClusterResult similarityClusterResult =
+			randomSimilarityClusterResult();
+
+		String json1 = objectMapper.writeValueAsString(similarityClusterResult);
+		String json2 = SimilarityClusterResultSerDes.toJSON(
+			similarityClusterResult);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		SimilarityClusterResult similarityClusterResult =
+			randomSimilarityClusterResult();
+
+		String json = SimilarityClusterResultSerDes.toJSON(
+			similarityClusterResult);
+
+		Assert.assertFalse(json.contains(regex));
+
+		similarityClusterResult = SimilarityClusterResultSerDes.toDTO(json);
+	}
+
+	@Test
+	public void testGetSimilarityCluster() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGraphQLGetSimilarityCluster() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGraphQLGetSimilarityClusterNotFound() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	protected void assertContains(
+		SimilarityClusterResult similarityClusterResult,
+		List<SimilarityClusterResult> similarityClusterResults) {
+
+		boolean contains = false;
+
+		for (SimilarityClusterResult item : similarityClusterResults) {
+			if (equals(similarityClusterResult, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			similarityClusterResults + " does not contain " +
+				similarityClusterResult,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		SimilarityClusterResult similarityClusterResult1,
+		SimilarityClusterResult similarityClusterResult2) {
+
+		Assert.assertTrue(
+			similarityClusterResult1 + " does not equal " +
+				similarityClusterResult2,
+			equals(similarityClusterResult1, similarityClusterResult2));
+	}
+
+	protected void assertEquals(
+		List<SimilarityClusterResult> similarityClusterResults1,
+		List<SimilarityClusterResult> similarityClusterResults2) {
+
+		Assert.assertEquals(
+			similarityClusterResults1.size(), similarityClusterResults2.size());
+
+		for (int i = 0; i < similarityClusterResults1.size(); i++) {
+			SimilarityClusterResult similarityClusterResult1 =
+				similarityClusterResults1.get(i);
+			SimilarityClusterResult similarityClusterResult2 =
+				similarityClusterResults2.get(i);
+
+			assertEquals(similarityClusterResult1, similarityClusterResult2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<SimilarityClusterResult> similarityClusterResults1,
+		List<SimilarityClusterResult> similarityClusterResults2) {
+
+		Assert.assertEquals(
+			similarityClusterResults1.size(), similarityClusterResults2.size());
+
+		for (SimilarityClusterResult similarityClusterResult1 :
+				similarityClusterResults1) {
+
+			boolean contains = false;
+
+			for (SimilarityClusterResult similarityClusterResult2 :
+					similarityClusterResults2) {
+
+				if (equals(
+						similarityClusterResult1, similarityClusterResult2)) {
+
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				similarityClusterResults2 + " does not contain " +
+					similarityClusterResult1,
+				contains);
+		}
+	}
+
+	protected void assertValid(SimilarityClusterResult similarityClusterResult)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"similarityClusters", additionalAssertFieldName)) {
+
+				if (similarityClusterResult.getSimilarityClusters() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (similarityClusterResult.getTotalCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<SimilarityClusterResult> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<SimilarityClusterResult> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<SimilarityClusterResult> similarityClusterResults =
+			page.getItems();
+
+		int size = similarityClusterResults.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.cms.dto.v1_0.SimilarityClusterResult.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		SimilarityClusterResult similarityClusterResult1,
+		SimilarityClusterResult similarityClusterResult2) {
+
+		if (similarityClusterResult1 == similarityClusterResult2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"similarityClusters", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						similarityClusterResult1.getSimilarityClusters(),
+						similarityClusterResult2.getSimilarityClusters())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						similarityClusterResult1.getTotalCount(),
+						similarityClusterResult2.getTotalCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_similarityClusterResultResource instanceof
+				EntityModelResource)) {
+
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_similarityClusterResultResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		SimilarityClusterResult similarityClusterResult) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("similarityClusters")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("totalCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected SimilarityClusterResult randomSimilarityClusterResult()
+		throws Exception {
+
+		return new SimilarityClusterResult() {
+			{
+				totalCount = RandomTestUtil.randomLong();
+			}
+		};
+	}
+
+	protected SimilarityClusterResult randomIrrelevantSimilarityClusterResult()
+		throws Exception {
+
+		SimilarityClusterResult randomIrrelevantSimilarityClusterResult =
+			randomSimilarityClusterResult();
+
+		return randomIrrelevantSimilarityClusterResult;
+	}
+
+	protected SimilarityClusterResult randomPatchSimilarityClusterResult()
+		throws Exception {
+
+		return randomSimilarityClusterResult();
+	}
+
+	protected SimilarityClusterResultResource similarityClusterResultResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(
+			BaseSimilarityClusterResultResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private
+		com.liferay.headless.cms.resource.v1_0.SimilarityClusterResultResource
+			_similarityClusterResultResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-30038311

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarityClusterResultResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarityClusterResultResourceTest.java
@@ -1,0 +1,578 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityCluster;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterAsset;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarityClusterResult;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.SimilarityClusterResultResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class SimilarityClusterResultResourceTest
+	extends BaseSimilarityClusterResultResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetSimilarityCluster() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		SimilarityClusterResult similarityClusterResult = _getSimilarityCluster(
+			groupId, null);
+
+		Assert.assertEquals(
+			0, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		SimilarityCluster[] similarityClusters =
+			similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 0, similarityClusters.length);
+
+		ObjectEntry nearDuplicateObjectEntry1 = _addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT);
+		ObjectEntry nearDuplicateObjectEntry2 = _addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT +
+				" You can also contact support for help.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT);
+
+		similarityClusterResult = _getSimilarityCluster(groupId, null);
+
+		Assert.assertEquals(
+			2, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		similarityClusters = similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 1, similarityClusters.length);
+
+		SimilarityCluster similarityCluster = similarityClusters[0];
+
+		Assert.assertEquals(
+			2, GetterUtil.getInteger(similarityCluster.getSize()));
+
+		SimilarityClusterAsset[] similarityClusterAssets =
+			similarityCluster.getSimilarityClusterAssets();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusterAssets), 2,
+			similarityClusterAssets.length);
+
+		List<Long> objectEntryIds = new ArrayList<>();
+
+		for (SimilarityClusterAsset similarityClusterAsset :
+				similarityClusterAssets) {
+
+			objectEntryIds.add(similarityClusterAsset.getId());
+
+			Assert.assertEquals(
+				_NEAR_DUPLICATE_TITLE, similarityClusterAsset.getTitle());
+			Assert.assertNotNull(similarityClusterAsset.getContentType());
+			Assert.assertNotNull(similarityClusterAsset.getDateModified());
+		}
+
+		Assert.assertTrue(
+			objectEntryIds.contains(
+				nearDuplicateObjectEntry1.getObjectEntryId()));
+		Assert.assertTrue(
+			objectEntryIds.contains(
+				nearDuplicateObjectEntry2.getObjectEntryId()));
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+
+		_testGetSimilarityClusterPage();
+		_testGetSimilarityClusterPermissions();
+		_testGetSimilarityClusterTranslation();
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetSimilarityCluster() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT +
+				" You can also contact support for help.");
+
+		GraphQLField graphQLField = new GraphQLField(
+			"similarityCluster",
+			HashMapBuilder.<String, Object>put(
+				"assetLibraryId", "\"" + depotEntry.getGroupId() + "\""
+			).build(),
+			new GraphQLField("similarityClusters", new GraphQLField("size")),
+			new GraphQLField("totalCount"));
+
+		JSONObject similarityClusterResultJSONObject =
+			JSONUtil.getValueAsJSONObject(
+				invokeGraphQLQuery(graphQLField), "JSONObject/data",
+				"JSONObject/similarityCluster");
+
+		Assert.assertEquals(
+			2, similarityClusterResultJSONObject.getLong("totalCount"));
+
+		JSONArray similarityClustersJSONArray =
+			similarityClusterResultJSONObject.getJSONArray(
+				"similarityClusters");
+
+		Assert.assertEquals(
+			similarityClustersJSONArray.toString(), 1,
+			similarityClustersJSONArray.length());
+
+		JSONObject similarityClusterJSONObject =
+			similarityClustersJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(2, similarityClusterJSONObject.getInt("size"));
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private ObjectEntry _addObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)content
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)title
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _addSimilarityClusters(DepotEntry depotEntry)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Big Summer Sale",
+			_SUMMER_SALE_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Summer Sale 2026",
+			_SUMMER_SALE_CONTENT + " The offer ends this Sunday.");
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Summer Sale Highlights",
+			_SUMMER_SALE_CONTENT +
+				" The offer ends this Sunday and stock is limited.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _PRODUCT_LAUNCH_TITLE,
+			_PRODUCT_LAUNCH_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, _PRODUCT_LAUNCH_TITLE,
+			_PRODUCT_LAUNCH_CONTENT +
+				" Contact the press office for further details.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT);
+	}
+
+	private DepotEntry _addSpaceDepotEntry(ServiceContext serviceContext)
+		throws Exception {
+
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+	}
+
+	private ObjectEntry _addTranslatedObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content, String spanishTitle,
+			String spanishContent)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", content
+				).put(
+					"es_ES", spanishContent
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", title
+				).put(
+					"es_ES", spanishTitle
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertSimilarityCluster(
+		SimilarityCluster similarityCluster, int size, String[] titles) {
+
+		Assert.assertEquals(
+			size, GetterUtil.getInteger(similarityCluster.getSize()));
+
+		SimilarityClusterAsset[] similarityClusterAssets =
+			similarityCluster.getSimilarityClusterAssets();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusterAssets), titles.length,
+			similarityClusterAssets.length);
+
+		for (int i = 0; i < titles.length; i++) {
+			SimilarityClusterAsset similarityClusterAsset =
+				similarityClusterAssets[i];
+
+			Assert.assertEquals(titles[i], similarityClusterAsset.getTitle());
+		}
+	}
+
+	private String _getAdminUserEmailAddress() throws Exception {
+		User user = UserTestUtil.getAdminUser(testCompany.getCompanyId());
+
+		return user.getEmailAddress();
+	}
+
+	private ObjectDefinition _getBasicWebContentObjectDefinition()
+		throws Exception {
+
+		Group cmsGroup = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+	}
+
+	private SimilarityClusterResult _getSimilarityCluster(
+			long groupId, Pagination pagination)
+		throws Exception {
+
+		return similarityClusterResultResource.getSimilarityCluster(
+			groupId, pagination);
+	}
+
+	private void _testGetSimilarityClusterPage() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		_addSimilarityClusters(depotEntry);
+
+		SimilarityClusterResult similarityClusterResult = _getSimilarityCluster(
+			groupId, Pagination.of(1, 2));
+
+		Assert.assertEquals(
+			5, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		SimilarityCluster[] similarityClusters =
+			similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 1, similarityClusters.length);
+
+		_assertSimilarityCluster(
+			similarityClusters[0], 3,
+			new String[] {"Big Summer Sale", "Summer Sale 2026"});
+
+		similarityClusterResult = _getSimilarityCluster(
+			groupId, Pagination.of(2, 2));
+
+		Assert.assertEquals(
+			5, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		similarityClusters = similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 2, similarityClusters.length);
+
+		_assertSimilarityCluster(
+			similarityClusters[0], 3, new String[] {"Summer Sale Highlights"});
+		_assertSimilarityCluster(
+			similarityClusters[1], 2, new String[] {_PRODUCT_LAUNCH_TITLE});
+
+		similarityClusterResult = _getSimilarityCluster(
+			groupId, Pagination.of(3, 2));
+
+		Assert.assertEquals(
+			5, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		similarityClusters = similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 1, similarityClusters.length);
+
+		_assertSimilarityCluster(
+			similarityClusters[0], 2, new String[] {_PRODUCT_LAUNCH_TITLE});
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private void _testGetSimilarityClusterPermissions() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT +
+				" You can also contact support for help.");
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userLocalService.addGroupUser(groupId, user.getUserId());
+
+		SimilarityClusterResultResource userSimilarityClusterResultResource =
+			SimilarityClusterResultResource.builder(
+			).authentication(
+				user.getEmailAddress(), password
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		SimilarityClusterResult similarityClusterResult =
+			userSimilarityClusterResultResource.getSimilarityCluster(
+				groupId, null);
+
+		Assert.assertEquals(
+			2, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		SimilarityCluster[] similarityClusters =
+			similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 1, similarityClusters.length);
+
+		_assertSimilarityCluster(
+			similarityClusters[0], 2,
+			new String[] {_NEAR_DUPLICATE_TITLE, _NEAR_DUPLICATE_TITLE});
+
+		_userLocalService.deleteUser(user);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private void _testGetSimilarityClusterTranslation() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addTranslatedObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT, "Oferta de Verano Grande",
+			_SPANISH_SUMMER_SALE_CONTENT);
+		_addTranslatedObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT, "Oferta de Verano 2026",
+			_SPANISH_SUMMER_SALE_CONTENT + " La oferta acaba el domingo.");
+
+		SimilarityClusterResultResource spanishSimilarityClusterResultResource =
+			SimilarityClusterResultResource.builder(
+			).authentication(
+				_getAdminUserEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.SPAIN
+			).build();
+
+		SimilarityClusterResult similarityClusterResult =
+			spanishSimilarityClusterResultResource.getSimilarityCluster(
+				groupId, null);
+
+		Assert.assertEquals(
+			2, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		SimilarityCluster[] similarityClusters =
+			similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 1, similarityClusters.length);
+
+		_assertSimilarityCluster(
+			similarityClusters[0], 2,
+			new String[] {"Oferta de Verano Grande", "Oferta de Verano 2026"});
+
+		similarityClusterResult = _getSimilarityCluster(groupId, null);
+
+		Assert.assertEquals(
+			0, GetterUtil.getLong(similarityClusterResult.getTotalCount()));
+
+		similarityClusters = similarityClusterResult.getSimilarityClusters();
+
+		Assert.assertEquals(
+			Arrays.toString(similarityClusters), 0, similarityClusters.length);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private static final String _DISTINCT_CONTENT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market with product categories in retail and wholesale " +
+				"increasing during the last fiscal period.";
+
+	private static final String _NEAR_DUPLICATE_CONTENT =
+		"If you forgot your password go to the login page and click the " +
+			"forgot password link enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	private static final String _NEAR_DUPLICATE_TITLE = "Reset Your Password";
+
+	private static final String _PRODUCT_LAUNCH_CONTENT =
+		"The new generation of our platform is available today with a " +
+			"redesigned workspace faster search and a set of integrations " +
+				"that our customers have been asking for during this year.";
+
+	private static final String _PRODUCT_LAUNCH_TITLE =
+		"Product Launch Press Release";
+
+	private static final String _SPANISH_SUMMER_SALE_CONTENT =
+		"Nuestras rebajas de verano traen descuentos de hasta el cincuenta " +
+			"por ciento en toda la coleccion de exterior incluidas tiendas " +
+				"mochilas y botas de montana mientras queden existencias.";
+
+	private static final String _SUMMER_SALE_CONTENT =
+		"Our summer sale brings discounts of up to fifty percent on every " +
+			"outdoor collection including tents backpacks and hiking boots " +
+				"while stock lasts in all of our stores.";
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similarity/CMSContentTextSimilarityTextExtractor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similarity/CMSContentTextSimilarityTextExtractor.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similarity;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.HtmlParser;
+
+import java.io.Serializable;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSContentTextSimilarityTextExtractor {
+
+	public CMSContentTextSimilarityTextExtractor(HtmlParser htmlParser) {
+		_htmlParser = htmlParser;
+	}
+
+	public Set<String> getLanguageIds(ObjectEntry objectEntry)
+		throws Exception {
+
+		Set<String> languageIds = new LinkedHashSet<>();
+
+		languageIds.add(objectEntry.getDefaultLanguageId());
+
+		Map<String, Serializable> indexedValues =
+			objectEntry.getIndexedValues();
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		for (ObjectField objectField :
+				_getSignatureObjectFields(objectDefinition)) {
+
+			if (!objectField.isLocalized()) {
+				continue;
+			}
+
+			Object localizedValues = indexedValues.get(
+				objectField.getI18nObjectFieldName());
+
+			if (!(localizedValues instanceof Map)) {
+				continue;
+			}
+
+			Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+			for (Object languageId : localizedValuesMap.keySet()) {
+				languageIds.add(String.valueOf(languageId));
+			}
+		}
+
+		return languageIds;
+	}
+
+	public String getText(String languageId, ObjectEntry objectEntry)
+		throws Exception {
+
+		Map<String, Serializable> indexedValues =
+			objectEntry.getIndexedValues();
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		StringBundler sb = new StringBundler();
+
+		for (ObjectField objectField :
+				_getSignatureObjectFields(objectDefinition)) {
+
+			Object indexedValue = null;
+
+			if (objectField.isLocalized()) {
+				Object localizedValues = indexedValues.get(
+					objectField.getI18nObjectFieldName());
+
+				if (localizedValues instanceof Map) {
+					Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+					indexedValue = localizedValuesMap.get(languageId);
+				}
+			}
+			else {
+				indexedValue = indexedValues.get(objectField.getName());
+			}
+
+			if (indexedValue == null) {
+				continue;
+			}
+
+			String indexedValueString = String.valueOf(indexedValue);
+
+			if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+				indexedValueString = _htmlParser.extractText(
+					indexedValueString);
+			}
+
+			sb.append(indexedValueString);
+			sb.append(CharPool.SPACE);
+		}
+
+		return sb.toString();
+	}
+
+	private Iterable<ObjectField> _getSignatureObjectFields(
+		ObjectDefinition objectDefinition) {
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		Set<ObjectField> objectFields = new LinkedHashSet<>();
+
+		for (ObjectField objectField :
+				objectFieldBag.getIndexedObjectFields()) {
+
+			if (_isTitleObjectField(objectDefinition, objectField)) {
+				continue;
+			}
+
+			if (_isTextObjectField(objectField)) {
+				objectFields.add(objectField);
+			}
+		}
+
+		return objectFields;
+	}
+
+	private boolean _isTextObjectField(ObjectField objectField) {
+		String businessType = objectField.getBusinessType();
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_TEXT) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isTitleObjectField(
+		ObjectDefinition objectDefinition, ObjectField objectField) {
+
+		if (objectField.getObjectFieldId() ==
+				objectDefinition.getTitleObjectFieldId()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private final HtmlParser _htmlParser;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtil.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similarity;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Mikel Lorza
+ */
+public class TextSimilaritySignatureUtil {
+
+	public static String[] getBandSignatures(String text) {
+		if (text == null) {
+			return new String[0];
+		}
+
+		Set<String> shingles = _getShingles(text);
+
+		if (shingles.isEmpty()) {
+			return new String[0];
+		}
+
+		long[] signature = _getMinHashSignature(shingles);
+
+		String[] bands = new String[_BANDS];
+
+		for (int band = 0; band < _BANDS; band++) {
+			long bandHash = _FNV_OFFSET_BASIS;
+
+			for (int row = 0; row < _ROWS; row++) {
+				bandHash = _mix(bandHash, signature[(band * _ROWS) + row]);
+			}
+
+			bands[band] = StringBundler.concat(
+				"b", band, "_", Long.toHexString(bandHash));
+		}
+
+		return bands;
+	}
+
+	private static long _fnv1a(String value) {
+		long hash = _FNV_OFFSET_BASIS;
+
+		for (int i = 0; i < value.length(); i++) {
+			hash ^= value.charAt(i);
+			hash *= _FNV_PRIME;
+		}
+
+		return hash & Long.MAX_VALUE;
+	}
+
+	private static long[] _getMinHashSignature(Set<String> shingles) {
+		long[] signature = new long[_HASH_COUNT];
+
+		for (int i = 0; i < _HASH_COUNT; i++) {
+			signature[i] = Long.MAX_VALUE;
+		}
+
+		for (String shingle : shingles) {
+			long baseHash = _fnv1a(shingle);
+
+			for (int i = 0; i < _HASH_COUNT; i++) {
+				long permuted =
+					((_PERMUTATION_A[i] * baseHash) + _PERMUTATION_B[i]) %
+						_MERSENNE_PRIME;
+
+				if (permuted < 0) {
+					permuted += _MERSENNE_PRIME;
+				}
+
+				if (permuted < signature[i]) {
+					signature[i] = permuted;
+				}
+			}
+		}
+
+		return signature;
+	}
+
+	private static Set<String> _getShingles(String text) {
+		Set<String> shingles = new HashSet<>();
+
+		String[] tokens = text.toLowerCase(
+		).replaceAll(
+			"[^\\p{L}\\p{Nd}]+", " "
+		).trim(
+		).split(
+			"\\s+"
+		);
+
+		if ((tokens.length == 1) && tokens[0].isEmpty()) {
+			return shingles;
+		}
+
+		if (tokens.length < _SHINGLE_SIZE) {
+			for (String token : tokens) {
+				shingles.add(token);
+			}
+
+			return shingles;
+		}
+
+		for (int i = 0; i <= (tokens.length - _SHINGLE_SIZE); i++) {
+			StringBundler sb = new StringBundler();
+
+			for (int j = 0; j < _SHINGLE_SIZE; j++) {
+				if (j > 0) {
+					sb.append(StringPool.SPACE);
+				}
+
+				sb.append(tokens[i + j]);
+			}
+
+			shingles.add(sb.toString());
+		}
+
+		return shingles;
+	}
+
+	private static long _mix(long hash, long value) {
+		for (int shift = 0; shift < 64; shift += 8) {
+			hash ^= (value >>> shift) & 0xff;
+			hash *= _FNV_PRIME;
+		}
+
+		return hash;
+	}
+
+	private static final int _BANDS = 32;
+
+	private static final long _FNV_OFFSET_BASIS = 0xcbf29ce484222325L;
+
+	private static final long _FNV_PRIME = 0x100000001b3L;
+
+	private static final int _HASH_COUNT = 128;
+
+	private static final long _MERSENNE_PRIME = (1L << 61) - 1;
+
+	private static final long[] _PERMUTATION_A = new long[_HASH_COUNT];
+
+	private static final long[] _PERMUTATION_B = new long[_HASH_COUNT];
+
+	private static final int _ROWS = 4;
+
+	private static final int _SHINGLE_SIZE = 3;
+
+	static {
+		long state = 0x9e3779b97f4a7c15L;
+
+		for (int i = 0; i < _HASH_COUNT; i++) {
+			state = (state * 6364136223846793005L) + 1442695040888963407L;
+
+			_PERMUTATION_A[i] = ((state >>> 1) % (_MERSENNE_PRIME - 1)) + 1;
+
+			state = (state * 6364136223846793005L) + 1442695040888963407L;
+
+			_PERMUTATION_B[i] = (state >>> 1) % _MERSENNE_PRIME;
+		}
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSTextSimilarityCompanyIndexConfigurationContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSTextSimilarityCompanyIndexConfigurationContributor.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.CompanyIndexConfigurationContributor;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.SettingsHelper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = CompanyIndexConfigurationContributor.class)
+public class CMSTextSimilarityCompanyIndexConfigurationContributor
+	implements CompanyIndexConfigurationContributor {
+
+	@Override
+	public void contributeMappings(
+		long companyId, MappingsHelper mappingsHelper) {
+
+		mappingsHelper.putMappings(
+			StringUtil.read(
+				getClass(), "dependencies/text-similarity-type-mappings.json"));
+	}
+
+	@Override
+	public void contributeSettings(
+		long companyId, SettingsHelper settingsHelper) {
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentTextSimilarityDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentTextSimilarityDocumentContributor.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentContributor;
+import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.site.cms.site.initializer.internal.search.similarity.CMSContentTextSimilarityTextExtractor;
+import com.liferay.site.cms.site.initializer.internal.search.similarity.TextSimilaritySignatureUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = DocumentContributor.class)
+public class CMSContentTextSimilarityDocumentContributor
+	implements DocumentContributor<ObjectEntry> {
+
+	@Override
+	public void contribute(
+		Document document, BaseModel<ObjectEntry> baseModel) {
+
+		if (!(baseModel instanceof ObjectEntry)) {
+			return;
+		}
+
+		ObjectEntry objectEntry = (ObjectEntry)baseModel;
+
+		try {
+			ObjectDefinition objectDefinition =
+				objectEntry.getObjectDefinition();
+
+			if (!objectDefinition.isCMS()) {
+				return;
+			}
+
+			List<String> bandSignatures = new ArrayList<>();
+
+			for (String languageId :
+					_cmsContentTextSimilarityTextExtractor.getLanguageIds(
+						objectEntry)) {
+
+				bandSignatures.addAll(
+					TransformUtil.transformToList(
+						TextSimilaritySignatureUtil.getBandSignatures(
+							_cmsContentTextSimilarityTextExtractor.getText(
+								languageId, objectEntry)),
+						bandSignature -> StringBundler.concat(
+							languageId, StringPool.UNDERLINE, bandSignature)));
+			}
+
+			if (bandSignatures.isEmpty()) {
+				return;
+			}
+
+			document.addKeyword(
+				"textSimilarityBands", bandSignatures.toArray(new String[0]));
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to contribute text similarity bands for object " +
+						"entry " + objectEntry.getObjectEntryId(),
+					exception);
+			}
+		}
+	}
+
+	@Activate
+	protected void activate() {
+		_cmsContentTextSimilarityTextExtractor =
+			new CMSContentTextSimilarityTextExtractor(_htmlParser);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CMSContentTextSimilarityDocumentContributor.class);
+
+	private CMSContentTextSimilarityTextExtractor
+		_cmsContentTextSimilarityTextExtractor;
+
+	@Reference
+	private HtmlParser _htmlParser;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/text-similarity-type-mappings.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/text-similarity-type-mappings.json
@@ -1,0 +1,7 @@
+{
+	"properties": {
+		"textSimilarityBands": {
+			"type": "keyword"
+		}
+	}
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similarity/CMSContentTextSimilarityTextExtractorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similarity/CMSContentTextSimilarityTextExtractorTest.java
@@ -1,0 +1,267 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similarity;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSContentTextSimilarityTextExtractorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		HtmlParser htmlParser = Mockito.mock(HtmlParser.class);
+
+		Mockito.when(
+			htmlParser.extractText(Mockito.anyString())
+		).thenAnswer(
+			invocation -> {
+				String html = invocation.getArgument(0, String.class);
+
+				return html.replaceAll("<[^>]+>", "");
+			}
+		);
+
+		_cmsContentTextSimilarityTextExtractor =
+			new CMSContentTextSimilarityTextExtractor(htmlParser);
+	}
+
+	@Test
+	public void testGetLanguageIds() throws Exception {
+		Assert.assertEquals(
+			Arrays.asList("en_US", "es_ES"),
+			ListUtil.fromCollection(
+				_cmsContentTextSimilarityTextExtractor.getLanguageIds(
+					_mockObjectEntry(
+						HashMapBuilder.<String, Serializable>put(
+							"i18nContent",
+							HashMapBuilder.put(
+								"en_US", "<p>Body</p>"
+							).put(
+								"es_ES", "<p>Cuerpo</p>"
+							).build()
+						).build()))));
+	}
+
+	@Test
+	public void testGetLanguageIdsWithTitleOnlyTranslation() throws Exception {
+		Assert.assertEquals(
+			Arrays.asList("en_US"),
+			ListUtil.fromCollection(
+				_cmsContentTextSimilarityTextExtractor.getLanguageIds(
+					_mockObjectEntry(
+						HashMapBuilder.<String, Serializable>put(
+							"i18nContent",
+							HashMapBuilder.put(
+								"en_US", "<p>Body</p>"
+							).build()
+						).put(
+							"i18nTitle",
+							HashMapBuilder.put(
+								"en_US", "Title"
+							).put(
+								"ja_JP", "タイトル"
+							).build()
+						).build()))));
+	}
+
+	@Test
+	public void testGetTextWithNonlocalizedField() throws Exception {
+		Assert.assertEquals(
+			"The body ACME-1234 ",
+			_cmsContentTextSimilarityTextExtractor.getText(
+				"en_US",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body</p>"
+						).build()
+					).put(
+						"reference", "ACME-1234"
+					).build())));
+	}
+
+	@Test
+	public void testGetTextWithoutTranslation() throws Exception {
+		Assert.assertEquals(
+			"",
+			_cmsContentTextSimilarityTextExtractor.getText(
+				"es_ES",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body</p>"
+						).build()
+					).put(
+						"i18nTitle",
+						HashMapBuilder.put(
+							"es_ES", "Solo el titulo"
+						).build()
+					).build())));
+	}
+
+	@Test
+	public void testGetTextWithTitle() throws Exception {
+		Assert.assertEquals(
+			"The body of the content ",
+			_cmsContentTextSimilarityTextExtractor.getText(
+				"en_US",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body of the content</p>"
+						).build()
+					).put(
+						"i18nTitle",
+						HashMapBuilder.put(
+							"en_US", "Zeta Quarterly Report Alpha"
+						).build()
+					).build())));
+	}
+
+	private ObjectEntry _mockObjectEntry(
+			Map<String, Serializable> indexedValues)
+		throws Exception {
+
+		ObjectField contentObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT, "i18nContent", true,
+			_OBJECT_FIELD_ID_CONTENT, "content");
+		ObjectField referenceObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, null, false,
+			_OBJECT_FIELD_ID_REFERENCE, "reference");
+		ObjectField titleObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, "i18nTitle", true,
+			_OBJECT_FIELD_ID_TITLE, "title");
+
+		List<ObjectField> objectFields = Arrays.asList(
+			contentObjectField, referenceObjectField, titleObjectField);
+
+		ObjectFieldBag objectFieldBag = new ObjectFieldBag(objectFields);
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getObjectFieldBag()
+		).thenReturn(
+			objectFieldBag
+		);
+
+		Mockito.when(
+			objectDefinition.getTitleObjectFieldId()
+		).thenReturn(
+			_OBJECT_FIELD_ID_TITLE
+		);
+
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			objectEntry.getDefaultLanguageId()
+		).thenReturn(
+			"en_US"
+		);
+
+		Mockito.when(
+			objectEntry.getIndexedValues()
+		).thenReturn(
+			indexedValues
+		);
+
+		Mockito.when(
+			objectEntry.getObjectDefinition()
+		).thenReturn(
+			objectDefinition
+		);
+
+		return objectEntry;
+	}
+
+	private ObjectField _mockObjectField(
+		String businessType, String i18nObjectFieldName, boolean localized,
+		long objectFieldId, String name) {
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getBusinessType()
+		).thenReturn(
+			businessType
+		);
+
+		Mockito.when(
+			objectField.getI18nObjectFieldName()
+		).thenReturn(
+			i18nObjectFieldName
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			objectField.getObjectFieldId()
+		).thenReturn(
+			objectFieldId
+		);
+
+		Mockito.when(
+			objectField.isIndexed()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			localized
+		);
+
+		return objectField;
+	}
+
+	private static final long _OBJECT_FIELD_ID_CONTENT = 2;
+
+	private static final long _OBJECT_FIELD_ID_REFERENCE = 3;
+
+	private static final long _OBJECT_FIELD_ID_TITLE = 1;
+
+	private CMSContentTextSimilarityTextExtractor
+		_cmsContentTextSimilarityTextExtractor;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similarity/TextSimilaritySignatureUtilTest.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similarity;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Mikel Lorza
+ */
+public class TextSimilaritySignatureUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBlankTextYieldsNoBands() {
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getBandSignatures(null).length);
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getBandSignatures("").length);
+		Assert.assertEquals(
+			0, TextSimilaritySignatureUtil.getBandSignatures("   ").length);
+	}
+
+	@Test
+	public void testDeterministic() {
+		Assert.assertArrayEquals(
+			TextSimilaritySignatureUtil.getBandSignatures(_A),
+			TextSimilaritySignatureUtil.getBandSignatures(_A));
+	}
+
+	@Test
+	public void testDistinctTextSharesNoBands() {
+		Assert.assertEquals(0, _sharedBandCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testNearDuplicateSharesMoreThanDistinct() {
+		Assert.assertTrue(
+			_sharedBandCount(_A, _A + " 2") > _sharedBandCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testNearDuplicateSharesMostBands() {
+		Assert.assertTrue(_sharedBandCount(_A, _A + " 2") >= 20);
+	}
+
+	private int _sharedBandCount(String text1, String text2) {
+		Set<String> bands = new HashSet<>();
+
+		for (String band :
+				TextSimilaritySignatureUtil.getBandSignatures(text1)) {
+
+			bands.add(band);
+		}
+
+		int count = 0;
+
+		for (String band :
+				TextSimilaritySignatureUtil.getBandSignatures(text2)) {
+
+			if (bands.contains(band)) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	private static final String _A =
+		"If you forgot your password, go to the login page and click the " +
+			"forgot password link. Enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	private static final String _DISTINCT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market. Product categories in retail and wholesale " +
+				"increased during the last fiscal period.";
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSTextSimilarityCompanyIndexConfigurationContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSTextSimilarityCompanyIndexConfigurationContributorTest.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSTextSimilarityCompanyIndexConfigurationContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContributeMappings() {
+		String mappingsJSON = StringUtil.read(
+			CMSTextSimilarityCompanyIndexConfigurationContributor.class,
+			"dependencies/text-similarity-type-mappings.json");
+
+		Assert.assertTrue(mappingsJSON.contains("\"textSimilarityBands\""));
+		Assert.assertTrue(mappingsJSON.contains("\"keyword\""));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97867

## What Is Being Fixed

The Content Governance Dashboard has to report which CMS contents are near duplicates of each other, and nothing in the index says how similar two contents are. Answering it at read time means one similarity query per document, which neither scales nor gives the same answer twice as the corpus grows.

## How It Is Being Fixed

Every CMS content is signed when it is indexed, and the endpoint groups the signatures that collide. This is the first of three slices, and it is end to end: it writes the field, reads it back, and answers with the clusters, so the whole path can be exercised.

On the write side, the text of a content — every indexed text, long text and rich text field except the title — is reduced to word shingles, condensed into a 128 position MinHash signature and split into 32 LSH bands of 4 positions each. The bands are indexed as a multivalued keyword field, one token per language, because a field whose name ends in a language ID is claimed by the platform's dynamic template and mapped to analyzed text, which cannot back an aggregation. The mappings resource declares the field a keyword for the same reason, and a unit test asserts the resource names the field the writer writes and types it as a keyword — that is the drift that would otherwise fail silently, with no clusters and no error.

On the read side, `GET /o/headless-cms/v1.0/similarity-clusters` runs a flat terms aggregation over the band field to find the bands more than one content shares, fetches those contents, and joins them with a union find. Both searches carry the caller's permissions, so a cluster never counts or shows content the caller cannot view. Clusters come back biggest first, and a cluster split across a page boundary repeats in the next page carrying its full size.

Two contents are joined only once they share **three** bands, not one. With a `(32, 4)` split, one shared band is reached by 0.54% of unrelated pairs, and grouping is transitive, so a single false link collapses a few hundred contents into one cluster. Three bands are reached by 0.008% of unrelated pairs and by every real near duplicate.

The aggregation is flat rather than nested for a measured reason: a nested aggregation creates a bucket per cluster member as well as per band, and blows past Elasticsearch's own `search.max_buckets` ceiling once a Space holds a few thousand near duplicates — the endpoint then answers with zero clusters and no error. Two limits bound the rest: the aggregation asks for 10,000 bands, and beyond that budget whole small groups are lost, pairs first, because a terms aggregation returns the most frequent buckets first; and the document search asks for 10,000 contents, which sits exactly on the default `index.max_result_window`, so it has no headroom left if it ever has to paginate.

The two slices still to come add each cluster's name, its representative and the similarity percentage — which is where the MinHash signature field and its reader arrive together, so a reindex is needed then — and after that the search, sort and dimension parameters.

Compared to the previous revision, `_toSimilarityCluster` now builds its array with `transformToArray` and `_searchSharedBands` inlines its request builder, as requested in review. Both are behavior neutral.

## How To Verify

```bash
cd modules/apps/site/site-cms-site-initializer && ../../../../gradlew test --tests '*TextSimilarity*' --tests '*CMSContentTextSimilarity*'
cd modules/apps/headless/headless-cms/headless-cms-impl && ../../../../../gradlew test --tests '*SimilarityClusterUtilTest'
cd modules/apps/headless/headless-cms/headless-cms-test && ../../../../../gradlew testIntegration --tests '*SimilarityClusterResultResourceTest'
```

## PR Check

**pr-check: PASS** — tested on `0df2af9759b8c619694fb2b49c64b04b201c0d63`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

`SimilarityClusterResultResourceTest` was run against a bundle rebuilt from the previous revision of this branch: 6 tests, 0 failures. This revision differs from it only by the behavior-neutral refactor below.

<!-- pr-check {"result": "success", "sha": "0df2af9759b8c619694fb2b49c64b04b201c0d63"} -->
