### PR TITLE
LPD-94058 Convert notification-web hard coded colors to Clay variables

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,10 +1,12 @@
+@import 'atlas-custom-properties/_variables';
+
 .side-panel-iframe {
 	& &-content {
 		padding: 0 !important;
 	}
 
 	& &-header {
-		background-color: #fff !important;
+		background-color: $white !important;
 	}
 
 	&__tabs {
@@ -17,7 +19,7 @@
 }
 
 .side-panel-content {
-	background-color: #f1f2f5;
+	background-color: $gray-200;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -34,6 +36,6 @@
 }
 
 .text-small {
-	color: #a7a9bc !important;
+	color: $gray-500 !important;
 	font-size: 0.75rem;
 }

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.scss
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr__notification-template {
 	&-basic-info {
@@ -6,7 +6,7 @@
 	}
 
 	&-container {
-		background-color: #f1f2f5;
+		background-color: $gray-200;
 	}
 
 	&-cards {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94058

## What Is Being Fixed

The notification-web styles hard coded hex colors for the side panel header, the side panel and notification template containers, and the small helper text. Because those literals never resolve through the theme's token layer, the page background and the form and card containers kept their light-mode values when dark mode was active, leaving unreadable panels and containers that did not follow the dark mode tokens.

## How It Is Being Fixed

The hex literals are replaced with the equivalent Clay variables, so the colors resolve through the theme rather than being frozen at author time. `#fff` becomes `$white`, `#f1f2f5` becomes `$gray-200`, and `#a7a9bc` becomes `$gray-500`. To make those variables available, `main.scss` gains an import of `atlas-custom-properties/_variables`, and `EditNotificationTemplate.scss` switches its existing `atlas-variables` import to the same one, since the custom properties build is what emits the values dark mode overrides.

## PR Check

**pr-check: PASS** — tested on `64c1de45fc7f247d352e3d919825c2b183f92f25`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "64c1de45fc7f247d352e3d919825c2b183f92f25"} -->
