### PR TITLE
LPD-94095 Convert knowledge-base-web hardcoded colors to Clay variables

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 @import 'atlas-variables';
 
 $productMenuTransitionDuration: 0.5s;
@@ -200,7 +202,7 @@ $toolbarZIndex: 971;
 					}
 
 					> .tbar-item:first-child {
-						border-top: solid thin #e7e7ed;
+						border-top: solid thin $gray-300;
 						order: 1;
 						width: 100%;
 					}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
@@ -1,5 +1,5 @@
 @import 'admin';
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 // ---------- Configuration ----------
 
@@ -296,7 +296,7 @@
 .knowledge-base-portlet {
 	a.text-default,
 	a.text-default:hover {
-		color: #869cad;
+		color: $gray-500;
 	}
 
 	.lfr-panel-container {
@@ -315,14 +315,14 @@
 	.kb-entity-body {
 		.kb-article-asset-entries {
 			.kb-info {
-				color: #7d7d7d;
+				color: $gray-600;
 			}
 
 			.kb-most-popular-column,
 			.kb-most-recent-column {
 				.kb-header {
-					border-bottom: 1px solid #ccc;
-					color: #555;
+					border-bottom: 1px solid $gray-400;
+					color: $gray-700;
 					font-weight: bold;
 				}
 			}
@@ -337,7 +337,7 @@
 		.kb-article-comments,
 		.kb-template-comments {
 			.kb-all-comments {
-				color: #7d7d7d;
+				color: $gray-600;
 				font-weight: bold;
 			}
 
@@ -351,21 +351,21 @@
 			}
 
 			.kb-no {
-				color: red;
+				color: $danger;
 			}
 
 			.kb-question {
-				color: #999;
+				color: $gray-500;
 			}
 
 			.kb-yes {
-				color: green;
+				color: $success;
 			}
 		}
 	}
 
 	.kb-entity-header {
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid $gray-400;
 
 		.kb-title {
 			font-weight: bold;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/css/main.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/css/main.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 // ---------- Portlet ----------
 
 .knowledge-base-portlet-section {
@@ -20,7 +22,7 @@
 	}
 
 	.kb-articles-sections-title {
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid $gray-400;
 		font-size: 1.2em;
 		font-weight: bold;
 		margin: 0 -5px 5px;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94095

## What Is Being Fixed

The Knowledge Base side menu and related admin views did not adapt to dark mode. Several SCSS rules hardcoded hex and named color values (`#e7e7ed`, `#869cad`, `#7d7d7d`, `#ccc`, `#555`, `#999`, `red`, `green`), so those borders and text colors stayed fixed regardless of the active theme.

## How It Is Being Fixed

Each hardcoded value is replaced with the equivalent Clay variable — the grays map to `$gray-300` through `$gray-700`, and the yes/no indicators map to `$success` and `$danger`. The three affected stylesheets now pull in `atlas-custom-properties/_variables`, which resolves each variable to a CSS custom property (`var(--gray-400)` and so on) rather than a literal, so the theme can retarget them at runtime and dark mode applies without further changes.

## Why Are There No Tests?

This change only replaces hardcoded color values with Clay variables in SCSS. There is no behavior to assert at any test layer.

## PR Check

**pr-check: PASS** — tested on `a0ca8f492992bf65ec0c04b36d207cfccfaa3eb0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a0ca8f492992bf65ec0c04b36d207cfccfaa3eb0"} -->
