### PR TITLE
LPD-102629 Cover the Download File permission

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/download.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/download.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-documents';
+
+async function getFileResponse(browser: Browser, url: string) {
+	const context = await browser.newContext();
+
+	try {
+		const response = await context.request.get(url);
+
+		return {
+			body: response.ok() ? await response.text() : '',
+			status: response.status(),
+		};
+	}
+	finally {
+		await context.close();
+	}
+}
+
+test(
+	'A file is downloadable only with the Download File permission',
+	{tag: '@LPD-102629'},
+	async ({apiHelpers, browser}) => {
+		const fileContent = `File content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const title = `title ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: Buffer.from(fileContent).toString('base64'),
+					name: `file_${getRandomString()}.txt`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title,
+			},
+			APPLICATION_NAME,
+			spaceName
+		);
+
+		const fileURL = objectEntry.file.link.href;
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			objectEntry.id,
+			[{actionIds: ['VIEW'], roleName: 'Guest'}]
+		);
+
+		const viewOnlyResponse = await getFileResponse(browser, fileURL);
+
+		// The file URL answers 404 rather than 403, so its existence is not
+		// leaked to a user who may view the asset but not download it.
+
+		expect(viewOnlyResponse.status).toBe(404);
+		expect(viewOnlyResponse.body).not.toContain(fileContent);
+
+		await apiHelpers.objectEntry.putObjectEntryPermissions(
+			APPLICATION_NAME,
+			objectEntry.id,
+			[{actionIds: ['DOWNLOAD_FILE', 'VIEW'], roleName: 'Guest'}]
+		);
+
+		const downloadResponse = await getFileResponse(browser, fileURL);
+
+		expect(downloadResponse.status).toBe(200);
+		expect(downloadResponse.body).toBe(fileContent);
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102629

## What Is Being Fixed

Nothing in the suite asserted that the Download File permission is enforced. The `permissions` project had ten specs and none of them touched download, and no test anywhere asserted a download is refused. The gap matters because two permission keys are in play: the item action carries no permission key at all, so enforcement happens when the file link is followed rather than when the menu is built, and `ObjectEntryModelResourcePermission` answers a `DOWNLOAD` check on a CMS file with the `DOWNLOAD_FILE` permission. Existing specs grant one key or the other and only ever assert the positive path.

## How It Is Being Fixed

One test in a new `permissions/download.spec.ts` drives the same file URL twice from a fresh anonymous browser context, changing nothing between the two attempts but the permission. Guest is the subject because it holds neither `VIEW` nor `DOWNLOAD_FILE` by default, which keeps the whole setup grant-only. With `VIEW` alone the URL is refused and the content is absent; with `DOWNLOAD_FILE` added it answers 200 with the exact bytes that were uploaded. Because the two attempts differ only by the grant, the test cannot pass for an unrelated reason.

The refusal is a 404 rather than a 403, so the assertion is written against 404 deliberately and the comment in the spec records why.

A second case covering folder download was planned and is deferred: the folder zip resolves the permission against a different resource than the item action does, so the case cannot pass today. It is tracked as LPD-102636 and lands once that is resolved.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/permissions/download.spec.ts
```

Run whole-file three times over with `--repeat-each=3`, green each time.

## PR Check

**pr-check: PASS** — tested on `1d9b76bd3cb6e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Source Format ran as `ant format-source-current-branch -Dvalidate.commit.messages=true` and reported everything correctly formatted, including the TypeScript project check.

The two N/A rows are validations whose triggers fired on the `.ts` path but which have nothing to run in `modules/test/playwright`: the module is not a bundle and exposes no `deploy` task, only `runPlaywright`, and its `npm test` script maps to `playwright test`, which pr-check puts out of scope. The TypeScript compile signal for this diff comes from the project check inside the formatter.

<!-- pr-check {"result": "success", "sha": "1d9b76bd3cb6eb8bc27f3916c9752d83dc3330ca"} -->
