### PR TITLE
LPD-102355 Enforce DOWNLOAD permission on /c/document_library/get_file

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/struts/test/GetFileStrutsActionTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/struts/test/GetFileStrutsActionTest.java
@@ -90,6 +90,7 @@ public class GetFileStrutsActionTest {
 		_testGetFileByTitleWithViewAndDownloadPermission();
 		_testGetFileByUuidWithOnlyViewPermission();
 		_testGetFileByUuidWithViewAndDownloadPermission();
+		_testGetFileWithVersionAndWithoutIdentifier();
 	}
 
 	private FileEntry _addFileEntry() throws Exception {
@@ -133,6 +134,14 @@ public class GetFileStrutsActionTest {
 		Assert.assertArrayEquals(
 			TestDataConstants.TEST_BYTE_ARRAY,
 			mockHttpServletResponse.getContentAsByteArray());
+	}
+
+	private void _assertNotFound(
+		MockHttpServletResponse mockHttpServletResponse) {
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_NOT_FOUND,
+			mockHttpServletResponse.getStatus());
 	}
 
 	private void _assertRedirectedToLogin(
@@ -381,6 +390,18 @@ public class GetFileStrutsActionTest {
 			_getMockHttpServletResponse(
 				_getFileEntryUuidParameters(fileEntry),
 				_addUser(fileEntry, ActionKeys.DOWNLOAD, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileWithVersionAndWithoutIdentifier()
+		throws Exception {
+
+		_assertNotFound(
+			_getMockHttpServletResponse(
+				HashMapBuilder.put(
+					"version", "1.0"
+				).build(),
+				_addUser(
+					_addFileEntry(), ActionKeys.DOWNLOAD, ActionKeys.VIEW)));
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/struts/test/GetFileStrutsActionTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/struts/test/GetFileStrutsActionTest.java
@@ -1,0 +1,413 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.struts.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Shakir Shamim
+ */
+@RunWith(Arquillian.class)
+public class GetFileStrutsActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetFile() throws Exception {
+		_testGetFileByIdAsGuestWithOnlyViewPermission();
+		_testGetFileByIdAsGuestWithViewAndDownloadPermission();
+		_testGetFileByIdWithOnlyDownloadPermission();
+		_testGetFileByIdWithOnlyViewPermission();
+		_testGetFileByIdWithoutViewAndDownloadPermission();
+		_testGetFileByIdWithViewAndDownloadPermission();
+		_testGetFileByNameWithOnlyViewPermission();
+		_testGetFileByNameWithViewAndDownloadPermission();
+		_testGetFileByTitleWithOnlyViewPermission();
+		_testGetFileByTitleWithViewAndDownloadPermission();
+		_testGetFileByUuidWithOnlyViewPermission();
+		_testGetFileByUuidWithViewAndDownloadPermission();
+	}
+
+	private FileEntry _addFileEntry() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		return _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			serviceContext);
+	}
+
+	private User _addUser(FileEntry fileEntry, String... actionIds)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(_group.getGroupId());
+
+		_users.add(user);
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_roles.add(role);
+
+		_setResourcePermissions(fileEntry, role, actionIds);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return user;
+	}
+
+	private void _assertFileSent(
+		MockHttpServletResponse mockHttpServletResponse) {
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+		Assert.assertArrayEquals(
+			TestDataConstants.TEST_BYTE_ARRAY,
+			mockHttpServletResponse.getContentAsByteArray());
+	}
+
+	private void _assertRedirectedToLogin(
+		MockHttpServletResponse mockHttpServletResponse) {
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_MOVED_TEMPORARILY,
+			mockHttpServletResponse.getStatus());
+
+		String redirectedURL = mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertTrue(
+			redirectedURL, redirectedURL.contains("/portal/login"));
+	}
+
+	private void _assertUnauthorized(
+		MockHttpServletResponse mockHttpServletResponse) {
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_UNAUTHORIZED,
+			mockHttpServletResponse.getStatus());
+	}
+
+	private Map<String, String> _getFileEntryIdParameters(FileEntry fileEntry) {
+		return HashMapBuilder.put(
+			"fileEntryId", String.valueOf(fileEntry.getFileEntryId())
+		).build();
+	}
+
+	private Map<String, String> _getFileEntryNameParameters(FileEntry fileEntry)
+		throws Exception {
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		return HashMapBuilder.put(
+			"folderId", String.valueOf(fileEntry.getFolderId())
+		).put(
+			"groupId", String.valueOf(_group.getGroupId())
+		).put(
+			"name", dlFileEntry.getName()
+		).build();
+	}
+
+	private Map<String, String> _getFileEntryTitleParameters(
+		FileEntry fileEntry) {
+
+		return HashMapBuilder.put(
+			"folderId", String.valueOf(fileEntry.getFolderId())
+		).put(
+			"groupId", String.valueOf(_group.getGroupId())
+		).put(
+			"title", fileEntry.getTitle()
+		).build();
+	}
+
+	private Map<String, String> _getFileEntryUuidParameters(
+		FileEntry fileEntry) {
+
+		return HashMapBuilder.put(
+			"groupId", String.valueOf(_group.getGroupId())
+		).put(
+			"uuid", fileEntry.getUuid()
+		).build();
+	}
+
+	private User _getGuestUser(FileEntry fileEntry, String... actionIds)
+		throws Exception {
+
+		_setResourcePermissions(
+			fileEntry,
+			_roleLocalService.getRole(
+				_group.getCompanyId(), RoleConstants.GUEST),
+			actionIds);
+
+		return _userLocalService.getGuestUser(_group.getCompanyId());
+	}
+
+	private MockHttpServletResponse _getMockHttpServletResponse(
+			Map<String, String> parameters, User user)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, permissionChecker)) {
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.setRequestURI(
+				"/c/document_library/get_file");
+
+			ThemeDisplay themeDisplay = new ThemeDisplay();
+
+			themeDisplay.setPermissionChecker(permissionChecker);
+			themeDisplay.setScopeGroupId(_group.getGroupId());
+
+			mockHttpServletRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, themeDisplay);
+
+			for (Map.Entry<String, String> entry : parameters.entrySet()) {
+				mockHttpServletRequest.setParameter(
+					entry.getKey(), entry.getValue());
+			}
+
+			MockHttpServletResponse mockHttpServletResponse =
+				new MockHttpServletResponse();
+
+			_getFileStrutsAction.execute(
+				mockHttpServletRequest, mockHttpServletResponse);
+
+			return mockHttpServletResponse;
+		}
+	}
+
+	private void _setResourcePermissions(
+			FileEntry fileEntry, Role role, String... actionIds)
+		throws Exception {
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			_group.getCompanyId(), DLFileEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(fileEntry.getFileEntryId()), role.getRoleId(),
+			actionIds);
+	}
+
+	private void _testGetFileByIdAsGuestWithOnlyViewPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertRedirectedToLogin(
+			_getMockHttpServletResponse(
+				_getFileEntryIdParameters(fileEntry),
+				_getGuestUser(fileEntry, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByIdAsGuestWithViewAndDownloadPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertFileSent(
+			_getMockHttpServletResponse(
+				_getFileEntryIdParameters(fileEntry),
+				_getGuestUser(
+					fileEntry, ActionKeys.DOWNLOAD, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByIdWithOnlyDownloadPermission() throws Exception {
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertUnauthorized(
+			_getMockHttpServletResponse(
+				_getFileEntryIdParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.DOWNLOAD)));
+	}
+
+	private void _testGetFileByIdWithOnlyViewPermission() throws Exception {
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertUnauthorized(
+			_getMockHttpServletResponse(
+				_getFileEntryIdParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByIdWithoutViewAndDownloadPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertUnauthorized(
+			_getMockHttpServletResponse(
+				_getFileEntryIdParameters(fileEntry), _addUser(fileEntry)));
+	}
+
+	private void _testGetFileByIdWithViewAndDownloadPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertFileSent(
+			_getMockHttpServletResponse(
+				_getFileEntryIdParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.DOWNLOAD, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByNameWithOnlyViewPermission() throws Exception {
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertUnauthorized(
+			_getMockHttpServletResponse(
+				_getFileEntryNameParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByNameWithViewAndDownloadPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertFileSent(
+			_getMockHttpServletResponse(
+				_getFileEntryNameParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.DOWNLOAD, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByTitleWithOnlyViewPermission() throws Exception {
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertUnauthorized(
+			_getMockHttpServletResponse(
+				_getFileEntryTitleParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByTitleWithViewAndDownloadPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertFileSent(
+			_getMockHttpServletResponse(
+				_getFileEntryTitleParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.DOWNLOAD, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByUuidWithOnlyViewPermission() throws Exception {
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertUnauthorized(
+			_getMockHttpServletResponse(
+				_getFileEntryUuidParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.VIEW)));
+	}
+
+	private void _testGetFileByUuidWithViewAndDownloadPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry();
+
+		_assertFileSent(
+			_getMockHttpServletResponse(
+				_getFileEntryUuidParameters(fileEntry),
+				_addUser(fileEntry, ActionKeys.DOWNLOAD, ActionKeys.VIEW)));
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject(filter = "path=/document_library/get_file")
+	private StrutsAction _getFileStrutsAction;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private final List<Role> _roles = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/helper/GetFileActionHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/helper/GetFileActionHelper.java
@@ -111,6 +111,10 @@ public class GetFileActionHelper {
 
 		name = FileUtil.stripExtension(name);
 
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
 		FileEntry fileEntry = null;
 
 		if (Validator.isNotNull(uuid) && (groupId > 0)) {
@@ -147,15 +151,11 @@ public class GetFileActionHelper {
 				}
 
 				if (dlFileEntry != null) {
-					ThemeDisplay themeDisplay =
-						(ThemeDisplay)httpServletRequest.getAttribute(
-							WebKeys.THEME_DISPLAY);
+					fileEntry = new LiferayFileEntry(dlFileEntry);
 
 					DLFileEntryPermission.check(
-						themeDisplay.getPermissionChecker(), dlFileEntry,
+						themeDisplay.getPermissionChecker(), fileEntry,
 						ActionKeys.VIEW);
-
-					fileEntry = new LiferayFileEntry(dlFileEntry);
 				}
 			}
 		}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/helper/GetFileActionHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/helper/GetFileActionHelper.java
@@ -180,6 +180,10 @@ public class GetFileActionHelper {
 			}
 		}
 
+		DLFileEntryPermission.check(
+			themeDisplay.getPermissionChecker(), fileEntry,
+			ActionKeys.DOWNLOAD);
+
 		FileVersion fileVersion = fileEntry.getFileVersion(version);
 
 		InputStream inputStream = fileVersion.getContentStream(true);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/helper/GetFileActionHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/helper/GetFileActionHelper.java
@@ -168,16 +168,16 @@ public class GetFileActionHelper {
 			fileEntry = DLAppServiceUtil.getFileEntry(fileEntryId);
 		}
 
-		if (Validator.isNull(version)) {
-			if ((fileEntry != null) &&
-				Validator.isNotNull(fileEntry.getVersion())) {
+		if ((fileEntry == null) ||
+			(Validator.isNull(version) &&
+			 Validator.isNull(fileEntry.getVersion()))) {
 
-				version = fileEntry.getVersion();
-			}
-			else {
-				throw new NoSuchFileEntryException(
-					"{fileEntryId=" + fileEntryId + "}");
-			}
+			throw new NoSuchFileEntryException(
+				"{fileEntryId=" + fileEntryId + "}");
+		}
+
+		if (Validator.isNull(version)) {
+			version = fileEntry.getVersion();
 		}
 
 		DLFileEntryPermission.check(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/security/permission/resource/DLFileEntryPermission.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/security/permission/resource/DLFileEntryPermission.java
@@ -5,7 +5,6 @@
 
 package com.liferay.document.library.web.internal.security.permission.resource;
 
-import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -18,26 +17,14 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 public class DLFileEntryPermission {
 
 	public static void check(
-			PermissionChecker permissionChecker, DLFileEntry fileEntry,
+			PermissionChecker permissionChecker, FileEntry fileEntry,
 			String actionId)
 		throws PortalException {
 
-		ModelResourcePermission<DLFileEntry> modelResourcePermission =
-			_dlFileEntryModelResourcePermissionSnapshot.get();
+		ModelResourcePermission<FileEntry> modelResourcePermission =
+			_fileEntryModelResourcePermissionSnapshot.get();
 
 		modelResourcePermission.check(permissionChecker, fileEntry, actionId);
-	}
-
-	public static boolean contains(
-			PermissionChecker permissionChecker, DLFileEntry dlFileEntry,
-			String actionId)
-		throws PortalException {
-
-		ModelResourcePermission<DLFileEntry> modelResourcePermission =
-			_dlFileEntryModelResourcePermissionSnapshot.get();
-
-		return modelResourcePermission.contains(
-			permissionChecker, dlFileEntry, actionId);
 	}
 
 	public static boolean contains(
@@ -64,13 +51,6 @@ public class DLFileEntryPermission {
 			permissionChecker, fileEntryId, actionId);
 	}
 
-	private static final Snapshot<ModelResourcePermission<DLFileEntry>>
-		_dlFileEntryModelResourcePermissionSnapshot = new Snapshot<>(
-			DLFileEntryPermission.class,
-			Snapshot.cast(ModelResourcePermission.class),
-			"(model.class.name=com.liferay.document.library.kernel.model." +
-				"DLFileEntry)",
-			true);
 	private static final Snapshot<ModelResourcePermission<FileEntry>>
 		_fileEntryModelResourcePermissionSnapshot = new Snapshot<>(
 			DLFileEntryPermission.class,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102355

## What Is Being Fixed

 `/c/document_library/get_file` resolved the file entry and opened its content stream after checking only VIEW. It now checks ActionKeys.DOWNLOAD on the resolved FileEntry before opening the stream, so a caller without that permission is rejected.

Every other download entry point already enforces DOWNLOAD, including /documents/, so the two endpoints behaved differently for the same user and the same file. Reported by a customer as LPP-65079.

## How It Is Being Fixed

The endpoint now checks ActionKeys.DOWNLOAD on the resolved FileEntry before opening the content stream, at the point where all five lookup branches converge, so it covers every way the file entry can be resolved as well as the targetExtension conversion path.

The check is made against the FileEntry rather than the DLFileEntry because a document in an external repository has no DLFileEntry row, so the check has to go through the FileEntry abstraction. DLFileEntryPermission previously offered check only for DLFileEntry, while its contains overloads already covered FileEntry. That method is retyped to take a FileEntry, the now-unused contains overload for DLFileEntry is removed along with the snapshot backing it, and the single caller in GetFileActionHelper now wraps the DLFileEntry into a LiferayFileEntry before checking VIEW, so both checks go through the FileEntry signature. Nothing else referenced the removed methods: DLFileEntryPermission is internal to document-library-web and the bundle exports no packages.

A separate commit hoists the null check on the resolved file entry out of the branch that defaults an absent version. A request supplying a version with no identifier previously skipped that check and failed with a NullPointerException, which surfaced as a 400; it now returns the 404 the endpoint already handles.

This is a breaking change and is registered in the commit that introduces it, following the breaking-changes process. Content that embeds `<img src="/c/document_library/get_file?uuid=...">` stops rendering for users who have VIEW but not DOWNLOAD. The same helper also backs the `/document_library/get_file` portlet action registered by GetFileMVCActionCommand, which DLFileEntryAssetRenderer.getURLExport builds, so the export action on a Documents and Media asset requires DOWNLOAD as well.

## How Can You Verify That It Works?

    cd modules/apps/document-library/document-library-web
    ../../../../gradlew deploy

    cd ../document-library-web-test
    ../../../../gradlew testIntegration --tests GetFileStrutsActionTest

The test drives the real StrutsAction through the OSGi registry across thirteen cases: four permission combinations on the fileEntryId path, VIEW-only and VIEW plus DOWNLOAD on the name, title, and uuid paths, two guest cases asserting the login redirect, and one case for a request carrying a version with no identifier, which returns 404. Each case creates its own file entry so grants do not leak between them. The VIEW-only cases fail without this change and pass with it.

## PR Check

**pr-check: PASS** — tested on `850e421e68fcb3c156269cafce1b767b4c6bd251`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "850e421e68fcb3c156269cafce1b767b4c6bd251"} -->










