### PR TITLE
LPD-101973 Render the highlighted structure title as plain text

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -173,7 +173,7 @@ else {
 						<clay:sheet
 							size="full"
 						>
-							<h2 class="sheet-title"><%= journalDisplayContext.getTitle() %></h2>
+							<h2 class="sheet-title"><%= HtmlUtil.escape(journalDisplayContext.getTitle()) %></h2>
 
 							<%@ include file="/view_form.jspf" %>
 						</clay:sheet>

--- a/modules/test/playwright/tests/journal-web/main/journalStructure.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalStructure.spec.ts
@@ -124,3 +124,63 @@ test(
 		).toBeDisabled();
 	}
 );
+
+test(
+	'HTML in the name of a highlighted structure is not executed',
+	{
+		tag: '@LPD-101973',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		page.on('dialog', (dialog) => {
+			dialog.accept();
+
+			expect(
+				dialog.message(),
+				'This alert should not be shown'
+			).toBeNull();
+		});
+
+		const structurePrefix = getRandomString();
+		const structureName = `${structurePrefix} <img src=x onerror=alert(1)>`;
+
+		await apiHelpers.dataEngine.createStructure(
+			site.id,
+			getDataStructureDefinition({
+				defaultLanguageId: 'en_US',
+				fields: [{name: 'TextFieldTest', repeatable: false}],
+				name: structureName,
+			})
+		);
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page
+			.getByTestId('headerOptions')
+			.getByLabel('Options')
+			.and(page.locator('[aria-haspopup]'))
+			.click();
+
+		await page.getByRole('menuitem', {name: 'Configuration'}).click();
+
+		await page.getByLabel('Select Highlighted Structures').click();
+
+		await page
+			.frameLocator('iframe[title="Select Structures"]')
+			.getByLabel(structurePrefix)
+			.click();
+
+		await page.getByRole('button', {name: 'Add'}).click();
+
+		await expect(page.getByText(structurePrefix)).toBeVisible();
+
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await page.getByText('Success:You have successfully').waitFor();
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.locator('a[href*="highlightedDDMStructureId"]').click();
+
+		await expect(page.locator('h2.sheet-title')).toHaveText(structureName);
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101973

## What Is Being Fixed

Web Content structure names are stored without any HTML validation, and the Web Content admin printed the name of the highlighted structure straight into the page header. Any markup stored in the name was therefore parsed by the browser instead of being shown to the reader, so a structure named `<img src=x onerror=alert(1)>` ran its handler for every user who opened that admin screen.

## How It Is Being Fixed

The value now goes through `HtmlUtil` at the render site in `view.jsp`, which is how the same `ddmStructure.getName(locale)` is already rendered in the info panel of the very same module.

The processing was applied in the JSP rather than in `JournalDisplayContext.getTitle()` on purpose: sibling display contexts hand their `getTitle()` result to `renderResponse.setTitle()`, where the value must stay untouched.

The ticket also reported `view_more_menu_items.jsp:54` as a second sink. That one is a false positive and has been left alone: its `liferay-ui:search-container-row` declares `escapedModel="<%= true %>"`, so `SearchContainerRowTag` hands the JSP the model returned by `toEscapedModel()`, and `getName(Locale)` carries `@AutoEscape` in `DDMStructureModel`. The value already arrives processed there, and adding a second pass would render the entities literally to the user. The left navigation is not a sink either, since `clay:vertical-nav` renders its labels through React.

The test commit adds a Playwright test to `journalStructure.spec.ts` that creates a structure whose name carries markup, highlights it through the Configuration screen, and then asserts both that no browser dialog is raised and that the header shows the name verbatim. It was validated by reverting the product change, which makes it fail on both counts, and it passed five consecutive runs against a local bundle.

## PR Check

**pr-check: PASS** — tested on `15de27b36314f3bbec4b3cf1478e878f66134ee1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

JavaScript Unit Tests ran as the TypeScript project check for `modules/test/playwright`; that module's `npm test` is the Playwright suite itself, which pr-check places out of scope.

<!-- pr-check {"result": "success", "sha": "15de27b36314f3bbec4b3cf1478e878f66134ee1"} -->
