### PR TITLE
LPD-102064 Fix 400 error when sorting categories by subcategories

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryModelDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryModelDocumentContributor.java
@@ -8,6 +8,7 @@ package com.liferay.asset.categories.internal.search.spi.model.index.contributor
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -51,6 +52,10 @@ public class AssetCategoryModelDocumentContributor
 	public void contribute(Document document, AssetCategory assetCategory) {
 		document.addKeyword(
 			Field.ASSET_CATEGORY_ID, assetCategory.getCategoryId());
+		document.addNumber(
+			"childCategoriesCount",
+			_assetCategoryLocalService.getChildCategoriesCount(
+				assetCategory.getCategoryId()));
 
 		_addSearchAssetCategoryTitles(
 			document, Field.ASSET_CATEGORY_TITLE,
@@ -179,6 +184,9 @@ public class AssetCategoryModelDocumentContributor
 			return ReflectionUtil.throwException(portalException);
 		}
 	}
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
 
 	@Reference
 	private AssetVocabularyLocalService _assetVocabularyLocalService;

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
@@ -19,6 +19,9 @@ import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
@@ -106,6 +109,36 @@ public class AssetCategoryIndexerReindexTest {
 		reindexAllIndexerModels();
 
 		assertFieldValues(fieldName, map, locale, searchTerm);
+	}
+
+	@Test
+	public void testReindexChildCategoriesCount() throws Exception {
+		AssetCategory parentAssetCategory =
+			_assetCategoryFixture.createAssetCategory();
+
+		assertFieldValues(
+			"childCategoriesCount",
+			Collections.singletonMap("childCategoriesCount", "0"),
+			LocaleUtil.US, parentAssetCategory.getName());
+
+		AssetCategory childAssetCategory = assetCategoryService.addCategory(
+			parentAssetCategory.getGroupId(),
+			parentAssetCategory.getCategoryId(),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			Collections.emptyMap(), parentAssetCategory.getVocabularyId(),
+			new String[0],
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_assetCategories.add(childAssetCategory);
+
+		reindexAllIndexerModels();
+
+		assertFieldValues(
+			"childCategoriesCount",
+			Collections.singletonMap("childCategoriesCount", "1"),
+			LocaleUtil.US, parentAssetCategory.getName());
 	}
 
 	@Rule

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
@@ -12,6 +12,7 @@ import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.IdEntityField;
+import com.liferay.portal.odata.entity.IntegerEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
@@ -38,6 +39,9 @@ public class CategoryEntityModel implements EntityModel {
 			new IdEntityField(
 				"projects", locale -> "projectDepotEntryGroupIds",
 				String::valueOf),
+			new IntegerEntityField(
+				"numberOfTaxonomyCategories",
+				locale -> Field.getSortableFieldName("childCategoriesCount")),
 			new StringEntityField(
 				"externalReferenceCode", locale -> "externalReferenceCode"),
 			new StringEntityField(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -288,6 +289,52 @@ public class TaxonomyCategoryResourceTest
 			parentAssetCategory, serviceContext);
 		AssetCategory assetCategory2 = _addAssetCategory(
 			_assetVocabulary, new Date(), parentAssetCategory, serviceContext);
+
+		for (EntityField entityField : entityFields) {
+			_assertTaxonomyCategoriesPageOrder(
+				entityField, assetCategory1, assetCategory2, "asc",
+				parentAssetCategory);
+			_assertTaxonomyCategoriesPageOrder(
+				entityField, assetCategory2, assetCategory1, "desc",
+				parentAssetCategory);
+		}
+	}
+
+	@Override
+	@Test
+	public void testGetTaxonomyCategoryTaxonomyCategoriesPageWithSortInteger()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.INTEGER);
+
+		if (ListUtil.isEmpty(entityFields)) {
+			return;
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		AssetCategory parentAssetCategory =
+			_assetCategoryLocalService.addCategory(
+				TestPropsValues.getUserId(), testGroup.getGroupId(),
+				RandomTestUtil.randomString(),
+				_assetVocabulary.getVocabularyId(), serviceContext);
+
+		AssetCategory assetCategory1 = _addAssetCategory(
+			_assetVocabulary, new Date(), parentAssetCategory, serviceContext);
+
+		AssetCategory assetCategory2 = _addAssetCategory(
+			_assetVocabulary, new Date(), parentAssetCategory, serviceContext);
+
+		_addAssetCategory(
+			_assetVocabulary, new Date(), assetCategory2, serviceContext);
+
+		IndexerRegistryUtil.getIndexer(
+			AssetCategory.class
+		).reindexCompany(
+			testGroup.getCompanyId()
+		);
 
 		for (EntityField entityField : entityFields) {
 			_assertTaxonomyCategoriesPageOrder(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102064

## What Is Being Fixed

Sorting a category's subcategories by the "Subcategories" column in CMS > Categorization always returns an HTTP 400. The column is bound to a live, per-request computed child-category count that was never registered as a sortable field in the OData entity model for taxonomy categories, so the OData sort parser rejects the request outright and the framework surfaces that as a 400. A page refresh, which resubmits the same sort parameter, then crashes the whole categories list.

## How It Is Being Fixed

The fix follows the same approach the sibling Vocabulary entity already uses to expose its own category count as sortable: index the count at reindex time instead of computing it live per request, then register that indexed field in the OData entity model. `AssetCategoryModelDocumentContributor` now adds a `childCategoriesCount` field to each category's search document, and `CategoryEntityModel` registers `numberOfTaxonomyCategories` as a sortable `IntegerEntityField` pointing at that indexed field. No schema or migration work is needed, since the underlying count was already a live database query on both sides — it is now just computed once at index time rather than once per API request.

## PR Check

**pr-check: PASS** — tested on `ee932cea8b47164cf9527379121c1efe55e9b817`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ee932cea8b47164cf9527379121c1efe55e9b817"} -->
