### PR TITLE
LPD-102727 Cover downloading a folder as a zip

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import {expect, mergeTests} from '@playwright/test';
+import path from 'path';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
@@ -11,7 +12,9 @@ import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisibl
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {getTempDir} from '../../../utils/temp';
 import {waitForAlert} from '../../../utils/waitForAlert';
+import {checkInZip} from '../../../utils/zip';
 import {PermissionsPage} from '../permissions/pages/PermissionsPage';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
@@ -612,5 +615,89 @@ test(
 		await expect(
 			page.getByRole('menuitem', {exact: true, name: 'Folder'})
 		).toBeHidden();
+	}
+);
+
+test(
+	'Downloads a folder as a zip holding its files and its subfolders',
+	{tag: '@LPD-102727'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderTitle = getRandomString();
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			scopeKey: 'Default',
+			title: folderTitle,
+		});
+
+		const subfolderTitle = getRandomString();
+
+		const subfolder = await apiHelpers.objectFolder.createObjectEntryFolder(
+			{
+				parentObjectEntryFolderExternalReferenceCode:
+					folder.externalReferenceCode,
+				scopeKey: 'Default',
+				title: subfolderTitle,
+			}
+		);
+
+		const fileName = `${getRandomString()}.txt`;
+		const subfolderFileName = `${getRandomString()}.txt`;
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64:
+						Buffer.from(getRandomString()).toString('base64'),
+					name: fileName,
+				},
+				objectEntryFolderExternalReferenceCode:
+					folder.externalReferenceCode,
+				title: getRandomString(),
+			},
+			'cms/basic-documents',
+			'Default'
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64:
+						Buffer.from(getRandomString()).toString('base64'),
+					name: subfolderFileName,
+				},
+				objectEntryFolderExternalReferenceCode:
+					subfolder.externalReferenceCode,
+				title: getRandomString(),
+			},
+			'cms/basic-documents',
+			'Default'
+		);
+
+		await assetsPage.gotoFiles();
+
+		const downloadPromise = page.waitForEvent('download');
+
+		await assetsPage.execCardItemAction({
+			action: 'Download',
+			filter: folderTitle,
+		});
+
+		const download = await downloadPromise;
+
+		expect(download.suggestedFilename()).toBe(`${folderTitle}.zip`);
+
+		const filePath = path.join(getTempDir(), download.suggestedFilename());
+
+		await download.saveAs(filePath);
+
+		expect(await checkInZip(filePath, `${folderTitle}/${fileName}`)).toBe(
+			true
+		);
+		expect(
+			await checkInZip(
+				filePath,
+				`${folderTitle}/${subfolderTitle}/${subfolderFileName}`
+			)
+		).toBe(true);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102727

## What Is Being Fixed

Folder download had no coverage above the servlet. `DownloadObjectEntryFolderCMSServletTest` is dense and covers the servlet well: an empty folder, a subfolder skipped for lack of `VIEW`, a subfolder included with it, and both bulk branches. What it cannot cover is how the browser reaches that servlet, because it builds a `MockHttpServletRequest` and sets `WebKeys.THEME_DISPLAY` by hand.

Nothing exercised the path a user actually takes. There were no Playwright references to folder download at all: no `download-folder`, no `downloadFolder`. The nearest neighbour, "Bulk action download assets" in `bulkActions.spec.ts`, drives the bulk action rather than the folder action, and asserts the toast text and that `suggestedFilename()` is defined without ever opening the zip.

That left the wiring unguarded, and one part of it fails loudly: `_downloadObjectEntryFolder` throws a `RuntimeException` when the class name id in the path does not match `ObjectEntryFolder`, and that id is baked into the href built in `SectionDisplayContextUtil`.

## How It Is Being Fixed

One test in `main/folders.spec.ts`, placed there because the repository groups specs by topic and the action under test sits on a folder card. It builds a folder, a subfolder inside it, and one file in each through `apiHelpers`, then invokes the folder's Download action from the Files section and asserts two things about the real download: the attachment is named `<folder>.zip`, and both files are present in the archive at their nested paths, `<folder>/<file>` and `<folder>/<subfolder>/<file>`.

The paths are the point rather than incidental detail. `_zipObjectEntryFolder` seeds the recursion with the folder name and concatenates each subfolder name onto it, and `_zipObjectEntry` writes the Document Library file name rather than the object entry title, so a regression in either would move or rename these entries while everything else still looked fine.

Deliberately not covered here: permission scenarios, which the integration suite already owns and covers better than a UI test could, and the per-file `DOWNLOAD` skip, which cannot pass today for the reason recorded in LPD-102636.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/folders.spec.ts --project=site-cms-site-initializer.main
```

Green in isolation, then three sequential whole-file runs of all 16 tests in the spec, at 1.9m, 1.6m and 1.8m, with no failures and no drift between runs.

## PR Check

**pr-check: PASS** — tested on `a54245bf200db`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Source Format ran as `ant format-source-current-branch -Dvalidate.commit.messages=true` and reported everything correctly formatted, including the TypeScript project check.

The two N/A rows fired on the `.ts` path but have nothing to run in `modules/test/playwright`: the module is not a bundle and exposes no `deploy` task, only `runPlaywright`, and its `npm test` script maps to `playwright test`, which pr-check puts out of scope. The TypeScript compile signal comes from the project check inside the formatter.

<!-- pr-check {"result": "success", "sha": "a54245bf200dbc2bb366370f8549b14563b0a20d"} -->
