### PR TITLE
LPD-102734 Cover removing access and the resharing gate

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
@@ -8,7 +8,7 @@ import {Locator, Page, expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
-import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
@@ -103,7 +103,7 @@ test(
 		});
 
 		await test.step('Switch to the user and open the Share modal', async () => {
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 
 			await sharedWithMePage.goto();
 
@@ -193,7 +193,7 @@ test(
 		});
 
 		await test.step('Switch to the user and open the Share modal', async () => {
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 
 			await sharedWithMePage.goto();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
@@ -217,3 +217,213 @@ test(
 		});
 	}
 );
+
+test(
+	'Removing access stops the collaborator from seeing the shared content',
+	{tag: '@LPD-102734'},
+	async ({apiHelpers, assetsPage, page, sharedWithMePage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		let space = null;
+
+		await test.step('Create a new space', async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const objectEntryTitle = `Content ${getRandomString()}`;
+		let objectEntry = null;
+
+		await test.step('Create a content in the space', async () => {
+			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: objectEntryTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		let user = null;
+
+		await test.step('Create a user and add as space member', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Share the content with the user', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						id: user.id,
+						share: false,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				objectEntry.id
+			);
+		});
+
+		const assetRow = page.getByRole('row', {name: objectEntryTitle});
+
+		await test.step('Verify the user sees the shared content', async () => {
+			await performUserSwitchViaApi(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+
+			await expect(assetRow).toBeVisible();
+		});
+
+		await test.step('Remove the access as the administrator', async () => {
+			await performUserSwitchViaApi(page, 'test');
+
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await openShareModal(page, assetRow, objectEntryTitle);
+
+			await page.getByLabel('More Options').click();
+
+			await page.getByLabel('Remove Access').click();
+
+			await page
+				.getByRole('button', {exact: true, name: 'Share'})
+				.click();
+		});
+
+		await test.step('Verify the user no longer sees the content', async () => {
+			await performUserSwitchViaApi(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+
+			await expect(assetRow).toBeHidden();
+		});
+	}
+);
+
+test(
+	'The Share action is offered only to a collaborator allowed to reshare',
+	{tag: '@LPD-102734'},
+	async ({apiHelpers, page, sharedWithMePage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		let space = null;
+
+		await test.step('Create a new space', async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const resharableTitle = `Content ${getRandomString()}`;
+		const viewOnlyTitle = `Content ${getRandomString()}`;
+		let resharableObjectEntry = null;
+		let viewOnlyObjectEntry = null;
+
+		await test.step('Create two contents in the space', async () => {
+			resharableObjectEntry =
+				await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: resharableTitle,
+					},
+					'cms/basic-web-contents',
+					spaceName
+				);
+
+			viewOnlyObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: viewOnlyTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		let user = null;
+
+		await test.step('Create a user and add as space member', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Share both contents, only one of them resharable', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						id: user.id,
+						share: true,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				resharableObjectEntry.id
+			);
+
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						id: user.id,
+						share: false,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				viewOnlyObjectEntry.id
+			);
+		});
+
+		await test.step('Verify only the resharable content offers the Share action', async () => {
+			await performUserSwitchViaApi(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+
+			const resharableRow = page.getByRole('row', {
+				name: resharableTitle,
+			});
+			const viewOnlyRow = page.getByRole('row', {name: viewOnlyTitle});
+
+			await expect(resharableRow).toBeVisible();
+			await expect(viewOnlyRow).toBeVisible();
+
+			// The view-only row carries no Actions button at all, since
+			// resharing is the only action a view-only collaborator has.
+
+			await expect(
+				viewOnlyRow.getByRole('button', {name: 'Actions'})
+			).toHaveCount(0);
+
+			await openShareModal(page, resharableRow, resharableTitle);
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102734

## What Is Being Fixed

Sharing is the densest area of this epic, so this started as an inventory rather than a proposal. Jest covers the share modal thoroughly (18 tests on `CMSShareModalContent`, 7 on `SharedItemRenderer`, 17 on the shared `ShareModalContent`), integration covers the sharing-entry permission matrices across three `ObjectEntrySharing*` classes, and `CollaboratorResourceTest` covers 24 collaborator REST methods in two modules.

What none of them covers is the effect of the two actions whose presence they assert. In `sharingPermissions.spec.ts` both tests end at visibility: `Remove Access` is asserted visible in one and absent in the other, and is never clicked. The shared Jest suite likewise asserts `remove-access` is rendered without ever firing it. So a regression that draws the button and does nothing, or removes the wrong collaborator, passes at every level. The REST `testDeleteObjectEntryCollaboratorByTypeCollaborator` covers the API contract and a `BAD_REQUEST` for a mismatched type; it says nothing about a recipient losing sight of the asset.

Both existing tests also pass `share: true`, so the collaborator who may not reshare was untested.

## How It Is Being Fixed

Two tests, added to the file that owns this topic.

The first shares a content with a space member, proves as that member that it appears in Shared With Me, switches back to the administrator to remove the collaborator through More Options and Remove Access, then switches back and asserts the asset is gone. The step before the removal is deliberate: without it the final assertion would pass just as readily if the share had never worked.

The second turned out to be more interesting than expected. It was written to assert that a `share: false` collaborator opens the Actions menu and finds no Share item, and it failed — with resharing withheld the row carries **no Actions button at all**, because resharing is the only action a view-only collaborator has. The Share item action is registered with `setPermissionKey("share")`, so the FDS layer omits it rather than rendering it disabled. The test now shares two contents with the same user in one run, one resharable and one not, and asserts the resharable row opens the Share modal while the view-only row has zero Actions buttons. Only the `share` flag differs between them, so neither half can pass for an unrelated reason.

The first commit is separate and touches only the two existing tests, moving them from `performUserSwitch` to `performUserSwitchViaApi`. The UI switch logs out and back in through the interface and flakes; the API switch is the standard. The whole-file runs below exercise that change as well as the new tests.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/sharingPermissions.spec.ts --project=site-cms-site-initializer.main
```

Green in isolation, then three sequential whole-file runs at 40.8s, 40.3s and 41.5s, all six tests passing each time with no drift.

## PR Check

**pr-check: PASS** — tested on `c9ba725efd00a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Source Format ran as `ant format-source-current-branch -Dvalidate.commit.messages=true` and reported everything correctly formatted, including the TypeScript project check.

The two N/A rows fired on the `.ts` path but have nothing to run in `modules/test/playwright`: the module is not a bundle and exposes no `deploy` task, only `runPlaywright`, and its `npm test` script maps to `playwright test`, which pr-check puts out of scope. The TypeScript compile signal comes from the project check inside the formatter.

<!-- pr-check {"result": "success", "sha": "c9ba725efd00ab30402b48b8653be0d6177405bf"} -->
