### PR TITLE
LPD-102741 Cover the Files section filters

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts
@@ -78,3 +78,60 @@ test(
 		});
 	}
 );
+
+test(
+	'Filtering the Files section by Folder excludes files',
+	{tag: '@LPD-102741'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const fileTitle = `${getRandomString()}.txt`;
+		const folderTitle = getRandomString();
+
+		await test.step('Create a folder and a file in a fresh Space', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				scopeKey: space.name,
+				title: folderTitle,
+			});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64:
+							Buffer.from('plain text content').toString(
+								'base64'
+							),
+						name: fileTitle,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: fileTitle,
+				},
+				'cms/basic-documents',
+				space.name
+			);
+		});
+
+		await test.step('Both the folder and the file are visible before filtering', async () => {
+			await assetsPage.gotoFiles();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await expect(assetsPage.getItem(folderTitle)).toBeVisible();
+			await expect(assetsPage.getItem(fileTitle)).toBeVisible();
+		});
+
+		await test.step('Filtering by Type Folder shows only the folder', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Type',
+				value: 'Folder',
+			});
+
+			await expect(assetsPage.getItem(folderTitle)).toBeVisible();
+			await expect(assetsPage.getItem(fileTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/filterAvailability.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/filterAvailability.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+
+// CMP Project is registered for the Files section too, but CMP is not part of
+// the portal bundle, so it is left out.
+
+const FILTERS = [
+	'Author',
+	'Category',
+	'Create Date',
+	'Display Date',
+	'Expiration Date',
+	'Extension',
+	'Modified Date',
+	'Review Date',
+	'Space',
+	'Status',
+	'Tags',
+	'Type',
+];
+
+test(
+	'The Files section offers every expected filter',
+	{tag: '@LPD-102741'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const fileTitle = `${getRandomString()}.txt`;
+
+		// An empty Files section renders its empty state instead of the data
+		// set, which carries the Filter menu, so one file has to exist.
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64:
+						Buffer.from('plain text content').toString('base64'),
+					name: fileTitle,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			'cms/basic-documents',
+			'Default'
+		);
+
+		await assetsPage.gotoFiles();
+
+		const filterButton = page.getByRole('button', {
+			exact: true,
+			name: 'Filter',
+		});
+
+		await expect(filterButton).toBeVisible();
+
+		await filterButton.click();
+
+		for (const filter of FILTERS) {
+			await expect(
+				page.getByRole('menuitem', {exact: true, name: filter})
+			).toBeVisible();
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102741

## What Is Being Fixed

FDS filters are registered per data set, and the counts differ by section: 14 on `FILES_SECTION`, 14 on `ALL_SECTION`, 13 on `CONTENTS_SECTION`. All twelve filter tests in `all.spec.ts` exercise only `ALL_SECTION`. Across the Contents and Files sections there was exactly one filter test between them, `searchFiltering/fileTypeFilter.spec.ts` on Extension.

The filter classes themselves are shared between sections, so per-filter logic is not really untested. What was untested is registration per section, which is precisely where a section can drift from its siblings, plus one filter option that has no coverage anywhere: the Folder asset type. `BaseObjectDefinitionSelectionFDSFilter` appends a `SelectionFDSFilterItem(language.get(locale, "folder"), ...OBJECT_ENTRY_FOLDER)` unless the subclass excludes it, and nothing exercised it.

## How It Is Being Fixed

Two tests, one per commit.

The first filters the Files section by `Type: Folder` in a fresh Space holding one folder and one file, asserting both are listed beforehand and only the folder afterwards. Only the filter changes between the two assertions, so it cannot pass for an unrelated reason.

The second opens the Filter menu in the Files section and asserts all twelve filters are offered: Author, Category, Create Date, Display Date, Expiration Date, Extension, Modified Date, Review Date, Space, Status, Tags and Type. That covers the story's "the following filters are available" criterion in one cheap test and guards the per-section registration directly. `CMP Project` is registered for this section as well but is left out, since CMP is not part of the portal bundle and asserting it would fail everywhere it runs.

Two details of the second test are worth knowing, since both cost a red run to find. An empty Files section renders its empty state in place of the data set, which removes the toolbar carrying Filter, so the test creates a file first. And Gallery view truncates card titles, so the readiness check is an assertion on the Filter button rather than on the created file; anything needing an exact title match in this section has to switch to Table view, as its neighbour does.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/searchFiltering/fileTypeFilter.spec.ts tests/site-cms-site-initializer/main/searchFiltering/filterAvailability.spec.ts --project=site-cms-site-initializer.main
```

Green in isolation, then three sequential runs of both files at 26.4s, 28.2s and 25.5s, five tests each, with no failures and no drift.

## PR Check

**pr-check: PASS** — tested on `6a6ead769c373`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Source Format ran as `ant format-source-current-branch -Dvalidate.commit.messages=true` and reported everything correctly formatted, including the TypeScript project check.

The two N/A rows fired on the `.ts` paths but have nothing to run in `modules/test/playwright`: the module is not a bundle and exposes no `deploy` task, only `runPlaywright`, and its `npm test` script maps to `playwright test`, which pr-check puts out of scope. The TypeScript compile signal comes from the project check inside the formatter.

<!-- pr-check {"result": "success", "sha": "6a6ead769c373c83cc1f836aa119de2754243df6"} -->
