### PR TITLE
LPD-102748 Match the vocabulary visibility select exactly

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/EditVocabularyPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/EditVocabularyPage.ts
@@ -58,7 +58,9 @@ export class EditVocabularyPage {
 			name: 'Make this vocabulary available in all spaces',
 		});
 		this.spaceSelector = this.page.getByLabel('Space Selector');
-		this.visibilitySelector = this.page.getByLabel('Visibility');
+		this.visibilitySelector = this.page.getByLabel('Visibility', {
+			exact: true,
+		});
 	}
 
 	async goto() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102748

## What Is Being Fixed

The "Can create and update vocabulary" test failed in strict mode, with `getByLabel('Visibility')` resolving to two elements. The Visibility field of a vocabulary renders a help tooltip as a `<span role="img">` whose accessible name is the help text, ending in "Visibility configuration cannot be reverted". Since `getByLabel` matches a substring, the locator took both that tooltip and the `<select aria-label="Visibility">` it was meant for.

## How It Is Being Fixed

The page object now matches the label exactly, which leaves the select alone. The fix belongs there rather than in the spec so that every caller of `visibilitySelector` gets it, and it follows what the same spec already does for the Space Selector. The product markup is untouched: the tooltip is correct, only the locator was too loose.

## Why Are There No Tests?

The change is itself a test fix: it repairs the locator of an existing Playwright test, which passes again with it.

## PR Check

**pr-check: PASS** — tested on `b17bb2f2430c5493532d72f2201ceb7b40f4b313`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b17bb2f2430c5493532d72f2201ceb7b40f4b313"} -->
