### PR TITLE
LPD-101901 Limit space admin permission on users to view only

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -344,7 +344,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 				}
 			}
 		}
-		else if (StringUtil.equals(name, User.class.getName())) {
+		else if (StringUtil.equals(name, User.class.getName()) &&
+				 StringUtil.equals(actionId, ActionKeys.VIEW)) {
+
 			try {
 				if (_isDepotGroupAdmin(groupId)) {
 					return true;

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -283,6 +284,44 @@ public class DepotPermissionCheckerWrapperTest {
 						depotEntry.getGroup(), Group.class.getName(),
 						depotEntry.getGroupId(), ActionKeys.VIEW_MEMBERS));
 			});
+	}
+
+	@Test
+	public void testHasPermissionWithUserAndAssetLibraryAdministrator()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		DepotTestUtil.withAssetLibraryMember(
+			depotEntry,
+			assetLibraryMemberUser ->
+				DepotTestUtil.withAssetLibraryAdministrator(
+					depotEntry,
+					user -> {
+						PermissionChecker permissionChecker =
+							_permissionCheckerFactory.create(user);
+
+						Assert.assertTrue(
+							permissionChecker.hasPermission(
+								null, User.class.getName(),
+								assetLibraryMemberUser.getUserId(),
+								ActionKeys.VIEW));
+
+						Assert.assertFalse(
+							permissionChecker.hasPermission(
+								null, User.class.getName(), _user.getUserId(),
+								ActionKeys.DELETE));
+						Assert.assertFalse(
+							permissionChecker.hasPermission(
+								null, User.class.getName(), _user.getUserId(),
+								ActionKeys.IMPERSONATE));
+						Assert.assertFalse(
+							permissionChecker.hasPermission(
+								null, User.class.getName(), _user.getUserId(),
+								ActionKeys.UPDATE));
+					}));
 	}
 
 	@Test
@@ -975,6 +1014,9 @@ public class DepotPermissionCheckerWrapperTest {
 
 	@Inject
 	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 	@Inject
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101901

## What Is Being Fixed

A user holding the Space Administrator or Asset Library Administrator role could modify, delete, and impersonate any other regular user in the instance.

`UserPermissionUtil.contains` calls the permission checker with a null group, so `DepotPermissionCheckerWrapper` resolved a group ID of `0`. Its `User` branch then called `_isDepotGroupAdmin(0)`, which scans every group role the caller holds and returns `true` as soon as any one of them administers a depot. Because the branch was not scoped to any action, that single `true` covered every action key on every user in the company, including `DELETE` and `IMPERSONATE`.

## How It Is Being Fixed

The `User` branch now applies only to `ActionKeys.VIEW`. Viewing is the case the branch was originally added for, since a depot administrator needs to list members and read their roles through `getUserById`, `getUserRoles`, and `hasGroupUser`. Every other action falls through to the wrapped permission checker, which denies it for a caller with no explicit grant.

Role management is unaffected. Assigning and removing roles is gated by `UserGroupRolePermissionUtil`, which consults `Group` and `Role` permissions rather than `User` permissions, so the space administrator flow that motivated the original branch keeps working.

The integration test creates an unrelated user, then asserts from an asset library administrator that `VIEW` is granted while `DELETE`, `IMPERSONATE`, and `UPDATE` are refused. Reverting the change makes the `DELETE` assertion fail, which reproduces the reported behavior.

## PR Check

**pr-check: PASS** — tested on `39eea0af62f418ab8c893e0a9fd57f1681190a3d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "39eea0af62f418ab8c893e0a9fd57f1681190a3d"} -->
