### PR TITLE
LPD-102088 Check update permission in the default permission bulk action

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/test/DefaultPermissionObjectBulkSelectionActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/test/DefaultPermissionObjectBulkSelectionActionTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.bulk.selection.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.bulk.selection.BulkSelectionAction;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@RunWith(Arquillian.class)
+public class DefaultPermissionObjectBulkSelectionActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testDoExecute() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		_invokeDoExecute(objectEntry, TestPropsValues.getUser());
+
+		ObjectEntry updatedObjectEntry =
+			_objectEntryLocalService.getObjectEntry(
+				objectEntry.getObjectEntryId());
+
+		Map<String, Serializable> values = updatedObjectEntry.getValues();
+
+		Assert.assertEquals(
+			_DEFAULT_PERMISSIONS, values.get("defaultPermissions"));
+	}
+
+	@Test
+	public void testDoExecuteWithoutUpdatePermission() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		_user = UserTestUtil.addUser();
+
+		try {
+			_invokeDoExecute(objectEntry, _user);
+
+			Assert.fail();
+		}
+		catch (PrincipalException.MustHavePermission principalException) {
+			String message = principalException.getMessage();
+
+			Assert.assertTrue(
+				message,
+				message.contains(
+					"User " + _user.getUserId() +
+						" must have UPDATE permission for"));
+		}
+
+		ObjectEntry updatedObjectEntry =
+			_objectEntryLocalService.getObjectEntry(
+				objectEntry.getObjectEntryId());
+
+		Map<String, Serializable> values = updatedObjectEntry.getValues();
+
+		Assert.assertNotEquals(
+			_DEFAULT_PERMISSIONS, values.get("defaultPermissions"));
+	}
+
+	private ObjectEntry _addObjectEntry() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"defaultPermissions"
+					).build()));
+
+		objectDefinition =
+			ObjectDefinitionLocalServiceUtil.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId());
+
+		return ObjectEntryLocalServiceUtil.addObjectEntry(
+			0L, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(), 0, null,
+			Collections.emptyMap(), ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _invokeDoExecute(ObjectEntry objectEntry, User user)
+		throws Exception {
+
+		ReflectionTestUtil.invoke(
+			_defaultPermissionObjectBulkSelectionAction, "doExecute",
+			new Class<?>[] {User.class, Map.class, Object.class}, user,
+			HashMapBuilder.<String, Serializable>put(
+				"defaultPermissions", _DEFAULT_PERMISSIONS
+			).build(),
+			objectEntry);
+	}
+
+	private static final String _DEFAULT_PERMISSIONS =
+		"{\"UPDATED_BY_THE_BULK_ACTION\":true}";
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.bulk.selection.DefaultPermissionObjectBulkSelectionAction"
+	)
+	private BulkSelectionAction<Object>
+		_defaultPermissionObjectBulkSelectionAction;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/DefaultPermissionObjectBulkSelectionAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/DefaultPermissionObjectBulkSelectionAction.java
@@ -8,10 +8,14 @@ package com.liferay.site.cms.site.initializer.internal.bulk.selection;
 import com.liferay.bulk.selection.BulkSelectionAction;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -40,6 +44,14 @@ public class DefaultPermissionObjectBulkSelectionAction
 		throws PortalException {
 
 		ObjectEntry objectObjectEntry = (ObjectEntry)object;
+
+		ModelResourcePermission<ObjectEntry> modelResourcePermission =
+			_objectEntryService.getModelResourcePermission(
+				objectObjectEntry.getObjectDefinitionId());
+
+		modelResourcePermission.check(
+			PermissionCheckerFactoryUtil.create(user), objectObjectEntry,
+			ActionKeys.UPDATE);
 
 		Map<String, Serializable> objectObjectEntryValues =
 			objectObjectEntry.getValues();
@@ -114,5 +126,8 @@ public class DefaultPermissionObjectBulkSelectionAction
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102088

## What Is Being Fixed

`DefaultPermissionObjectBulkSelectionAction.doExecute` wrote the new `defaultPermissions` value through `partialUpdateObjectEntry` on the local service. Local services perform no permission checking by design, so the action applied no gate of its own before the write.

## How It Is Being Fixed

The action now resolves the object entry's `ModelResourcePermission` through `ObjectEntryService.getModelResourcePermission` and checks `UPDATE` before touching any values, which is the same gate the REST path already applies.

The permission checker is built from the `User` passed into `doExecute` rather than read from `PermissionThreadLocal`, because bulk actions execute inside a background task where the initiating user arrives as an argument. This follows `EditObjectTagsBulkSelectionAction`, and `DeleteObjectBulkSelectionAction` gates its work the same way.

Because the check throws rather than skipping silently, `BaseObjectBulkSelectionAction` counts the item as failed and surfaces the reason in the task result, instead of reporting a success that never happened.

The integration tests invoke `doExecute` twice, once as an administrator to confirm the value is written and once as a user without `UPDATE` to confirm the call is refused and the stored value is left alone. Reverting the check makes the second test fail.

## PR Check

**pr-check: PASS** — tested on `8a6cd26312f5079216f47f5f6a10d0e1863567da`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8a6cd26312f5079216f47f5f6a10d0e1863567da"} -->
