### PR TITLE
LPD-102138 Prevent deleting a relationship of an unauthorized object

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -18,13 +18,23 @@ import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -170,7 +180,8 @@ public class UpdateStructureStrutsActionTest {
 		String name = StringUtil.randomId();
 
 		MockHttpServletRequest mockHttpServletRequest =
-			_getMockHttpServletRequest(_objectDefinition3);
+			_getMockHttpServletRequest(
+				_objectDefinition3, TestPropsValues.getUser());
 
 		mockHttpServletRequest.setParameter(
 			"objectRelationships",
@@ -239,7 +250,8 @@ public class UpdateStructureStrutsActionTest {
 			new MockHttpServletResponse();
 
 		_updateStructureStrutsAction.execute(
-			_getMockHttpServletRequest(_objectDefinition1),
+			_getMockHttpServletRequest(
+				_objectDefinition1, TestPropsValues.getUser()),
 			mockHttpServletResponse);
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
@@ -253,6 +265,72 @@ public class UpdateStructureStrutsActionTest {
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
 				objectRelationship.getObjectRelationshipId()));
+	}
+
+	@Test
+	@TestInfo("LPD-102138")
+	public void testExecuteDoesNotDeleteUnauthorizedObjectRelationships()
+		throws Exception {
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			_addEdgeObjectRelationship(_objectDefinition2, _objectDefinition3);
+
+		_user = UserTestUtil.addUser();
+
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(),
+			com.liferay.object.model.ObjectDefinition.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_objectDefinition1.getObjectDefinitionId()),
+			_role.getRoleId(),
+			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW});
+
+		_userLocalService.addRoleUser(_role.getRoleId(), _user.getUserId());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(_objectDefinition1, _user);
+
+		mockHttpServletRequest.setParameter(
+			"deletedObjectRelationships",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"objectDefinitionERC",
+					_objectDefinition2.getExternalReferenceCode()
+				).put(
+					"objectRelationshipERC",
+					objectRelationship.getExternalReferenceCode()
+				)
+			).toString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user)) {
+
+			_updateStructureStrutsAction.execute(
+				mockHttpServletRequest, mockHttpServletResponse);
+		}
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(
+			jsonObject.toString(), "PrincipalException.MustHavePermission",
+			jsonObject.getString("type"));
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+
+		_deleteEdgeObjectRelationship(objectRelationship);
 	}
 
 	private com.liferay.object.model.ObjectRelationship
@@ -293,7 +371,8 @@ public class UpdateStructureStrutsActionTest {
 	}
 
 	private MockHttpServletRequest _getMockHttpServletRequest(
-			com.liferay.object.model.ObjectDefinition objectDefinition)
+			com.liferay.object.model.ObjectDefinition objectDefinition,
+			User user)
 		throws Exception {
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -304,7 +383,7 @@ public class UpdateStructureStrutsActionTest {
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
 		themeDisplay.setLocale(LocaleUtil.US);
-		themeDisplay.setUser(TestPropsValues.getUser());
+		themeDisplay.setUser(user);
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -380,7 +459,19 @@ public class UpdateStructureStrutsActionTest {
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@DeleteAfterTestRun
+	private Role _role;
+
 	@Inject(filter = "path=/cms/update-structure")
 	private StrutsAction _updateStructureStrutsAction;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -13,6 +13,7 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -301,6 +302,9 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 	private ObjectRelationshipResource.Factory
 		_objectRelationshipResourceFactory;
 
+	@Reference
+	private ObjectRelationshipService _objectRelationshipService;
+
 	private class UpdateStructureCallable implements Callable<Void> {
 
 		@Override
@@ -334,25 +338,22 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 									objectDefinition.getObjectDefinitionId());
 
 					if (serviceBuilderObjectRelationship.isEdge()) {
-						serviceBuilderObjectRelationship =
-							_objectRelationshipLocalService.
-								updateObjectRelationship(
-									serviceBuilderObjectRelationship.
-										getExternalReferenceCode(),
-									serviceBuilderObjectRelationship.
-										getObjectRelationshipId(),
-									serviceBuilderObjectRelationship.
-										getParameterObjectFieldId(),
-									serviceBuilderObjectRelationship.
-										getDeletionType(),
-									false,
-									serviceBuilderObjectRelationship.
-										getLabelMap(),
-									null);
+						_objectRelationshipService.updateObjectRelationship(
+							serviceBuilderObjectRelationship.
+								getExternalReferenceCode(),
+							serviceBuilderObjectRelationship.
+								getObjectRelationshipId(),
+							serviceBuilderObjectRelationship.
+								getParameterObjectFieldId(),
+							serviceBuilderObjectRelationship.getDeletionType(),
+							false,
+							serviceBuilderObjectRelationship.getLabelMap(),
+							null);
 					}
 
-					_objectRelationshipLocalService.deleteObjectRelationship(
-						serviceBuilderObjectRelationship);
+					_objectRelationshipService.deleteObjectRelationship(
+						serviceBuilderObjectRelationship.
+							getObjectRelationshipId());
 				}
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102138

## What Is Being Fixed

`/c/cms/update-structure` deleted and updated object relationships through `ObjectRelationshipLocalService`, using an object definition identifier taken from the request body, so no permission was checked on the definition the request named. Both calls now go through the permission-checking remote service. The ticket carries the details.

## How It Is Being Fixed

Validating that the named definition is the one being updated is not viable. `StructureService.ts` sends one entry per relationship with `objectDefinitionERC` set to `relationship.structureERC`, and `updateHistory.ts` shows that value is legitimately the main structure, a child node's external reference code, or `child.relatedStructureERC`. There is no single owner to compare the request against.

Both mutating calls in the loop move instead to `ObjectRelationshipService`, the permission-checking remote layer. `deleteObjectRelationship` and `updateObjectRelationship` each check UPDATE on `objectRelationship.getObjectDefinitionId1()`, and the relationship is looked up with `findByERC_C_ODI1`, so that side is exactly the definition the request named. The check therefore lands on the named target itself rather than on a proxy for it.

The remote signatures line up with what the loop already passed: `updateObjectRelationship` takes the same seven arguments, and `deleteObjectRelationship` takes the relationship id where the local call passed the relationship. The permission checker is available where the loop runs — the same method already deletes repeatable groups through `ObjectDefinitionService`, and `TransactionInvokerUtil.invoke` runs the callable on the caller's thread.

One call in the same class deliberately stays on the local service. `_deleteRelationships` deletes the inbound one-to-many relationships of the structure being updated, and its object definition id comes from that structure's own external reference code rather than from the request. Migrating it would also change the action's effective permission: those relationships are found by `objectDefinitionId2`, so the remote check would test UPDATE on the other side of each relationship — a different definition than the one being updated — and could reject a user who can legitimately update their own structure.

The test grants the acting user UPDATE and VIEW on the structure it legitimately updates and nothing on a second object definition, then has the request name the second definition's relationship. Granting the legitimate half is what makes the test meaningful. The callable is configured with `rollbackFor = Exception.class`, so a caller holding no permission at all would have the change undone by the rollback and the test would pass with the defect still present. Verified by reverting the fix and re-running, where the test fails. The three pre-existing tests in the class cover the legitimate path and still pass, which is what shows the migration does not reject a caller who owns the structure. Beyond them, `DeleteStructureStrutsActionTest`, `GetObjectEntriesValuesStrutsActionTest`, `UpdateObjectValuesBulkSelectionActionTest` and `CMSObjectRelationshipEdgeUpgradeProcessTest` pass, the last covering the edge relationships the migrated update branch handles, and the Playwright specs `relatedContent.spec.ts`, `referencedStructures.spec.ts` and `repeatableGroups.spec.ts` pass, walking the same deletion through the UI as an administrator.

## PR Check

**pr-check: PASS** — tested on `7f00894391fbe074a87414744717fd0507e0a60b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7f00894391fbe074a87414744717fd0507e0a60b"} -->

