### PR TITLE
LPD-94096 LPD-94093 Convert hardcoded colors to Clay variables

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -1,3 +1,4 @@
+@import 'atlas-custom-properties/_variables';
 @import 'atlas-variables';
 @import 'cadmin-variables';
 
@@ -224,7 +225,7 @@
 		}
 
 		.cke_editable {
-			background-color: white;
+			background-color: $white;
 		}
 
 		.entry-subtitle {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/css/main.scss
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/css/main.scss
@@ -1,3 +1,4 @@
+@import 'atlas-custom-properties/_variables';
 @import 'atlas-variables';
 
 @import 'variables';
@@ -28,9 +29,9 @@
 	}
 
 	.quote {
-		background: #fff url(@theme_image_path@/message_boards/quoteleft.png)
+		background: $white url(@theme_image_path@/message_boards/quoteleft.png)
 			left top no-repeat;
-		border: 1px solid #777;
+		border: 1px solid $gray-600;
 		padding: 5px 0 0 5px;
 	}
 
@@ -47,7 +48,7 @@
 	}
 
 	.title {
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid $gray-400;
 		font-size: large;
 		font-weight: normal;
 		padding: 5px;
@@ -63,7 +64,7 @@
 
 	.message-attachments {
 		h3 {
-			color: #333;
+			color: $gray-800;
 			font-size: 1em;
 		}
 
@@ -122,7 +123,7 @@
 	}
 
 	.thread-top {
-		border-bottom: 1px solid #eee;
+		border-bottom: 1px solid $gray-200;
 	}
 
 	.thread-bottom {
@@ -134,7 +135,7 @@
 	}
 
 	td.user-info {
-		border-right: 1px solid #ccc;
+		border-right: 1px solid $gray-400;
 		width: 150px;
 	}
 
@@ -160,7 +161,7 @@
 		padding: 15px;
 
 		td {
-			border: 1px solid #ccc;
+			border: 1px solid $gray-400;
 		}
 	}
 
@@ -235,8 +236,8 @@
 	}
 
 	.statistics-panel {
-		background-color: #fff;
-		border: 1px solid #e7e7ed;
+		background-color: $white;
+		border: 1px solid $gray-300;
 		border-radius: 4px;
 		box-sizing: border-box;
 		margin-top: 1.5rem;
@@ -283,7 +284,7 @@
 
 	.views {
 		clear: both;
-		color: #999;
+		color: $gray-500;
 		float: left;
 		padding: 5px 0;
 		text-align: center;
@@ -307,7 +308,7 @@
 	}
 
 	.toggle_id_message_boards_view_message_thread {
-		border: 1px solid #ccc;
+		border: 1px solid $gray-400;
 		clear: both;
 		margin: 5px 0 0;
 		width: 100%;
@@ -341,7 +342,7 @@
 	}
 
 	.emoticons {
-		border: 1px solid #ccc;
+		border: 1px solid $gray-400;
 		margin-left: 10px;
 	}
 
@@ -390,7 +391,7 @@
 	}
 
 	.search-root-entry {
-		color: #999;
+		color: $gray-500;
 		float: right;
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94096
https://liferay.atlassian.net/browse/LPD-94093

## What Is Being Fixed

The Message Boards and Blogs portlets did not adapt to dark mode. Several SCSS rules hardcoded hex and named color values, so borders and text colors stayed fixed regardless of the active theme.

## How It Is Being Fixed

Each hardcoded value is replaced with the equivalent Clay variable — the grays map to `$gray-200` through `$gray-800`, white maps to `$white`. Both stylesheets already imported `atlas-custom-properties/_variables`, which resolves each variable to a CSS custom property (`var(--gray-400)` and so on) rather than a literal, so the theme can retarget them at runtime and dark mode applies without further changes.

## Why Are There No Tests?

This change only replaces hardcoded color values with Clay variables in SCSS. There is no behavior to assert at any test layer.

## PR Check

**pr-check: PASS** — tested on `3c4d41c4544ed21843d25dd5d3768d60bf97084b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "3c4d41c4544ed21843d25dd5d3768d60bf97084b"} -->
