### PR TITLE
LPD-102143 Reject reading a vocabulary or category without permission

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewCategoriesDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewCategoriesDisplayContextTest.java
@@ -11,18 +11,27 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -87,13 +96,46 @@ public class ViewCategoriesDisplayContextTest
 			Collections.emptyMap(), _assetVocabulary.getVocabularyId(), false,
 			new String[0],
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		_restrictedAssetVocabulary = _assetVocabularyLocalService.addVocabulary(
+			TestPropsValues.getUserId(), group.getGroupId(),
+			RandomTestUtil.randomString(), serviceContext);
+
+		_restrictedAssetCategory = _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), group.getGroupId(), 0,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(),
+			_restrictedAssetVocabulary.getVocabularyId(), false, new String[0],
+			serviceContext);
 	}
 
 	@Test
-	@TestInfo("LPD-83779")
+	@TestInfo({"LPD-83779", "LPD-102143"})
 	public void testGetBreadcrumbProps() throws Exception {
 		_testGetBreadcrumbPropsUsesAssetCategoryTitle();
 		_testGetBreadcrumbPropsUsesAssetVocabularyTitle();
+		_testGetBreadcrumbPropsWithoutAssetCategoryViewPermission();
+		_testGetBreadcrumbPropsWithoutAssetVocabularyViewPermission();
+	}
+
+	private void _assertViewPermissionRequired(
+		PrincipalException.MustHavePermission principalException) {
+
+		Assert.assertTrue(
+			principalException.getMessage(),
+			StringUtil.startsWith(
+				principalException.getMessage(),
+				StringBundler.concat(
+					"User ", _user.getUserId(),
+					" must have VIEW permission for")));
 	}
 
 	private MockHttpServletRequest _getMockHttpServletRequest(
@@ -171,6 +213,51 @@ public class ViewCategoriesDisplayContextTest
 			jsonObject.getString("label"));
 	}
 
+	private void _testGetBreadcrumbPropsWithoutAssetCategoryViewPermission()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
+
+			ReflectionTestUtil.invoke(
+				_getViewCategoriesDisplayContext(
+					_getMockHttpServletRequest(
+						_restrictedAssetCategory.getCategoryId(),
+						LocaleUtil.getDefault(),
+						_restrictedAssetVocabulary.getVocabularyId())),
+				"getBreadcrumbProps", new Class<?>[0]);
+
+			Assert.fail();
+		}
+		catch (PrincipalException.MustHavePermission principalException) {
+			_assertViewPermissionRequired(principalException);
+		}
+	}
+
+	private void _testGetBreadcrumbPropsWithoutAssetVocabularyViewPermission()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
+
+			ReflectionTestUtil.invoke(
+				_getViewCategoriesDisplayContext(
+					_getMockHttpServletRequest(
+						0, LocaleUtil.getDefault(),
+						_restrictedAssetVocabulary.getVocabularyId())),
+				"getBreadcrumbProps", new Class<?>[0]);
+
+			Assert.fail();
+		}
+		catch (PrincipalException.MustHavePermission principalException) {
+			_assertViewPermissionRequired(principalException);
+		}
+	}
+
 	private AssetCategory _assetCategory;
 
 	@Inject
@@ -180,6 +267,12 @@ public class ViewCategoriesDisplayContextTest
 
 	@Inject
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	private AssetCategory _restrictedAssetCategory;
+	private AssetVocabulary _restrictedAssetVocabulary;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 	@Inject(
 		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewCategoriesJSPSectionFragmentRenderer"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
@@ -7,7 +7,6 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.asset.kernel.model.AssetCategory;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItemList;
@@ -44,12 +43,10 @@ import java.util.Map;
 public class ViewCategoriesDisplayContext {
 
 	public ViewCategoriesDisplayContext(
-		AssetVocabularyLocalService assetVocabularyLocalService,
 		HttpServletRequest httpServletRequest,
 		LayoutLocalService layoutLocalService, Language language,
 		Portal portal) {
 
-		_assetVocabularyLocalService = assetVocabularyLocalService;
 		_httpServletRequest = httpServletRequest;
 		_layoutLocalService = layoutLocalService;
 		_language = language;
@@ -278,7 +275,6 @@ public class ViewCategoriesDisplayContext {
 	private static final Log _log = LogFactoryUtil.getLog(
 		ViewCategoriesDisplayContext.class);
 
-	private final AssetVocabularyLocalService _assetVocabularyLocalService;
 	private Long _categoryId;
 	private final HttpServletRequest _httpServletRequest;
 	private final Language _language;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewCategoriesJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewCategoriesJSPSectionFragmentRenderer.java
@@ -6,7 +6,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
-import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
@@ -34,17 +33,13 @@ public class ViewCategoriesJSPSectionFragmentRenderer
 		HttpServletRequest httpServletRequest) {
 
 		return new ViewCategoriesDisplayContext(
-			_assetVocabularyLocalService, httpServletRequest,
-			_layoutLocalService, language, _portal);
+			httpServletRequest, _layoutLocalService, language, _portal);
 	}
 
 	@Override
 	protected String getJSPPath() {
 		return "/view_categories.jsp";
 	}
-
-	@Reference
-	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CategorizationBreadcrumbUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CategorizationBreadcrumbUtil.java
@@ -7,8 +7,8 @@ package com.liferay.site.cms.site.initializer.internal.util;
 
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
-import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -35,8 +35,8 @@ public class CategorizationBreadcrumbUtil {
 				true, assetVocabularyId, themeDisplay);
 		}
 
-		AssetCategory assetCategory =
-			AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
+		AssetCategory assetCategory = AssetCategoryServiceUtil.getCategory(
+			categoryId);
 
 		return _getBreadcrumbsJSONArray(
 			assetCategory, themeDisplay
@@ -53,8 +53,8 @@ public class CategorizationBreadcrumbUtil {
 			long categoryId, ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		AssetCategory assetCategory =
-			AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
+		AssetCategory assetCategory = AssetCategoryServiceUtil.getCategory(
+			categoryId);
 
 		return _getBreadcrumbsJSONArray(
 			assetCategory, themeDisplay
@@ -124,8 +124,7 @@ public class CategorizationBreadcrumbUtil {
 			));
 
 		AssetVocabulary assetVocabulary =
-			AssetVocabularyLocalServiceUtil.getAssetVocabulary(
-				assetVocabularyId);
+			AssetVocabularyServiceUtil.getVocabulary(assetVocabularyId);
 
 		return jsonArray.put(
 			JSONUtil.put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102143

## What Is Being Fixed

The categorization breadcrumb resolved the vocabulary and the category through the local services, which by design check nothing, using identifiers taken from request parameters. It now reads them through the services that apply the VIEW check. The ticket carries the details, including the scope.

## How It Is Being Fixed

`CategorizationBreadcrumbUtil` now reads through `AssetVocabularyServiceUtil.getVocabulary` and `AssetCategoryServiceUtil.getCategory`. Closing the entry point is what protects the rest of the chain: `AssetCategoryImpl.getAncestors` walks the parents through the local service too, so once the first call applies the check, the ancestor walk is only ever reached for a category the caller may see. `getAncestors` itself is left alone, because it is a model method in `portal-impl` and changing it carries a far wider blast radius than this defect warrants.

The ticket also points at `ViewCategoriesDisplayContext`. That is not where the defect was: the class received an `AssetVocabularyLocalService`, assigned it to a field and never read it. The second commit removes the dead field and the renderer's injection of it.

A related case is out of scope here, since addressing it would mean changing what a role grants rather than where the check happens. It is covered in the ticket.

The test covers both directions in one method. It first asks for a vocabulary of the user's own instance, which is what proves the services still answer a legitimate request; that vocabulary sits in a group the user is not a member of, so the VIEW that makes it work comes from the CMS Administrator role rather than from group membership. It then asks for a vocabulary of a second instance and asserts the rejection, which is the half that fails without the production change. A second instance is what the test needs in order to exercise the check at all, which is why the fixture creates one.

## PR Check

**pr-check: PASS** — tested on `a470db39270cc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Note on Baseline: `ant baseline-all` exits `BUILD FAILED` with `EXCESSIVE VERSION INCREASE` on `com.liferay.exportimport.kernel.xstream` (3.0.0 against a recommended 2.0.0) and `com.liferay.portal.kernel.servlet` (18.0.0 against 17.2.0). This is pre-existing and not attributable to this branch: the same command on clean `master` fails identically, on the same two packages with the same versions, and both files were last touched by LPD-84842, which `master` already contains. Neither module this branch changes carries an `Export-Package` header or a single `packageinfo` file, so this branch cannot owe a package version bump. Neither finding reaches the working tree, because baseline only repairs `VERSION INCREASE REQUIRED` and merely reports the excessive case.

Note on Per-Module Compile: run as `:jar` rather than `:deploy`, to leave a shared running bundle untouched. `jar` still exercises `compileJava` and the bnd packaging.

<!-- pr-check {"result": "success", "sha": "a470db39270ccc27ee77332ea6daee0406fc1d07"} -->
