### PR TITLE
LPD-102154 Reject a size limit change from a member who cannot update

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -365,9 +365,6 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				group = _groupLocalService.updateGroup(group);
 			}
 
-			_updateDLSizeLimitConfiguration(
-				assetLibrary, group.getGroupId(), mimeTypeSizeLimits);
-
 			DepotEntry updatedDepotEntry = _depotEntryService.updateDepotEntry(
 				depotEntry.getDepotEntryId(), nameMap, descriptionMap,
 				_getDepotAppCustomizationMap(
@@ -380,6 +377,9 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				serviceContext);
 
 			_updateFriendlyURL(assetLibrary, group.getGroupId());
+
+			_updateDLSizeLimitConfiguration(
+				assetLibrary, group.getGroupId(), mimeTypeSizeLimits);
 
 			return updatedDepotEntry;
 		}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -17,6 +17,7 @@ import com.liferay.headless.asset.library.client.pagination.Page;
 import com.liferay.headless.asset.library.client.pagination.Pagination;
 import com.liferay.headless.asset.library.client.permission.Permission;
 import com.liferay.headless.asset.library.client.problem.Problem;
+import com.liferay.headless.asset.library.client.resource.v1_0.AssetLibraryResource;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
@@ -30,12 +31,15 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -165,6 +169,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-102154")
 	public void testPatchAssetLibrary() throws Exception {
 		super.testPatchAssetLibrary();
 
@@ -172,6 +177,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		_testPatchAssetLibrarySettings();
 		_testPatchAssetLibraryFriendlyURL();
 		_testPatchAssetLibraryFriendlyURLValidation();
+		_testPatchAssetLibraryWithoutUpdatePermission();
 	}
 
 	@Override
@@ -724,6 +730,78 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			trashEnabled, trashEntriesMaxAge, useCustomLanguages);
 	}
 
+	private void _testPatchAssetLibraryWithoutUpdatePermission()
+		throws Exception {
+
+		AssetLibrary assetLibrary = _postAssetLibraryWithSettings(
+			true, _getAvailableLanguageIds(LocaleUtil.US),
+			_language.getLanguageId(LocaleUtil.US),
+			RandomTestUtil.randomString(), new MimeTypeLimit[0], true, true,
+			RandomTestUtil.randomInt(), true);
+
+		DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(
+			assetLibrary.getId());
+
+		String password = RandomTestUtil.randomString();
+
+		_user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {depotEntry.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		Settings settings = new Settings();
+
+		settings.setMimeTypeLimits(
+			new MimeTypeLimit[] {
+				new MimeTypeLimit() {
+					{
+						maximumSize = 1;
+						mimeType = "image/png";
+					}
+				}
+			});
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setSettings(settings);
+
+		AssetLibraryResource userAssetLibraryResource =
+			AssetLibraryResource.builder(
+			).authentication(
+				_user.getEmailAddress(), password
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		try {
+			userAssetLibraryResource.patchAssetLibrary(
+				assetLibrary.getExternalReferenceCode(), patchAssetLibrary);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+
+		assetLibrary = assetLibraryResource.getAssetLibrary(
+			assetLibrary.getExternalReferenceCode());
+
+		settings = assetLibrary.getSettings();
+
+		MimeTypeLimit[] mimeTypeLimits = settings.getMimeTypeLimits();
+
+		Assert.assertEquals(
+			Arrays.toString(mimeTypeLimits), 0, mimeTypeLimits.length);
+	}
+
 	private void _testPostAssetLibrary(MimeTypeLimit[] mimeTypeLimits)
 		throws Exception {
 
@@ -901,5 +979,8 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Inject
 	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102154

## What Is Being Fixed

Updating an asset library wrote the document library size limit configuration before calling `_depotEntryService.updateDepotEntry`, which is the call that checks UPDATE. That configuration is an OSGi group configuration rather than a database row, so it does not take part in the request transaction: ordering rather than rollback is what protects it. The write now runs after the check. The ticket carries the details.

## How It Is Being Fixed

The configuration write moves to just after `updateDepotEntry`, which puts it behind the UPDATE check that call already performs. The create branch of the same method already had that shape, so this makes the update branch consistent with it.

An explicit permission check inside `_updateDLSizeLimitConfiguration` was considered and rejected. It would duplicate the check that happens three lines later, and the ordering does not go undocumented: the test asserts that the limits are still empty after the 403, so returning the write to its old position turns that test red.

The position of `_updateFriendlyURL` relative to `updateDepotEntry` is deliberately left exactly as it was. LPD-98285 moved the friendly URL update first, LPD-98560 fixed a stale group error, and LPD-98285 then reverted the ordering, so this is an area where reordering has caused regressions in both directions.

The test case is folded into the existing `testPatchAssetLibrary` rather than added as a test method of its own, because that method already gathers every case for the same API operation. Asserting the response is not enough, since the request is rejected with 403 either way; the assertion that discriminates is that the limits are still empty when read back afterwards.

## Known Pre-Existing Failure

Folding the case into `testPatchAssetLibrary` makes a pre-existing failure surface on that method, so it is worth being explicit about what is and is not caused by this branch. The class reports exactly one failure in every configuration, and this branch only moves which test it lands on:

| Run | Tests | Failures | Failing test |
| --- | --- | --- | --- |
| This branch, case as its own test method | 29 | 1 | `testBatchEngineDeleteImportTask` |
| Clean `master` | 28 | 1 | `testBatchEngineDeleteImportTask` |
| This branch, case folded in | 28 | 1 | `testPatchAssetLibrary` |

The failure is an `AssertionError` raised by `LogAssertionTestRule` for an ERROR that the Vulcan exception mapper logs on a request thread: `Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [com.liferay.portal.model.impl.GroupImpl#...]`. Because it is logged after the response, it is attributed to whichever test is active when it arrives, which is why adding one more request to `testPatchAssetLibrary` pulls it onto that method. It is filed as [LPD-102886](https://liferay.atlassian.net/browse/LPD-102886), together with the likely cause: `_addOrUpdateDepotEntry` passes `group.getTypeSettingsProperties()` from a `Group` instance read before `updateDepotEntry`, while `_updateFriendlyURL` updates the same group row afterwards. Fixing it here would mean changing the very ordering that LPD-98285 and LPD-98560 already reordered twice, which does not belong in a six-line fix.

## PR Check

**pr-check: PASS** — tested on `340ec36e5ddcd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Note on Baseline: `ant baseline-all` exits `BUILD FAILED` with `EXCESSIVE VERSION INCREASE` on `com.liferay.exportimport.kernel.xstream` (3.0.0 against a recommended 2.0.0) and `com.liferay.portal.kernel.servlet` (18.0.0 against 17.2.0). This is pre-existing and not attributable to this branch: the same command on clean `master` fails identically, on the same two packages with the same versions, and both files were last touched by LPD-84842, which `master` already contains. Neither module this branch changes carries an `Export-Package` header or a single `packageinfo` file, so this branch cannot owe a package version bump. Neither finding reaches the working tree, because baseline only repairs `VERSION INCREASE REQUIRED` and merely reports the excessive case.

Note on Per-Module Compile: run as `:jar` rather than `:deploy`, to leave the shared running bundle untouched. `jar` still exercises `compileJava` and the bnd packaging. Both this and Integration Test Compile first reported `UP-TO-DATE` or `FROM-CACHE`, so each was rerun with `--no-build-cache` after clearing the module's class output, to make sure the result reflects a real `javac` run over the branch's sources rather than a cache hit.

Note on Java Unit Tests: `headless-asset-library-impl` has no `src/test`, so the selection found no unit test to run.

<!-- pr-check {"result": "success", "sha": "340ec36e5ddcdc965c2f647b8576f10942f4d0ba"} -->

