### PR TITLE
LPD-102891 Wait for the collection form reload before adding a filter

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/collectionDisplay.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/collectionDisplay.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Page} from '@playwright/test';
+import {Page, expect} from '@playwright/test';
 
 import {DataApiHelpers} from '../../../../../helpers/ApiHelpers';
 import {liferayConfig} from '../../../../../liferay.config';
@@ -153,6 +153,20 @@ export async function createEventStructure(
 	};
 }
 
+async function expandPanel(page: Page, name: string, contentSelector: string) {
+	await expect(async () => {
+		const panelToggle = page.getByRole('button', {name});
+
+		if ((await panelToggle.getAttribute('aria-expanded')) !== 'true') {
+			await panelToggle.click();
+		}
+
+		await expect(page.locator(contentSelector)).toHaveClass(/show/, {
+			timeout: 2000,
+		});
+	}).toPass();
+}
+
 /**
  * Creates a dynamic collection through the Collections editor UI: sets the item
  * type, scopes it to the given Space, and adds a tag or category filter. Returns
@@ -183,7 +197,7 @@ export async function createDynamicCollectionWithFilterViaUI(
 
 	// Scope to the Space
 
-	await page.getByRole('button', {name: 'Scope'}).click();
+	await expandPanel(page, 'Scope', '#scopeContent');
 	await page.getByRole('button', {name: 'Select Site'}).click();
 	await page
 		.getByRole('menuitem', {name: 'Other Site, Asset Library, or'})
@@ -194,11 +208,13 @@ export async function createDynamicCollectionWithFilterViaUI(
 	await scopeFrame.getByRole('link', {name: 'Spaces'}).click();
 	await scopeFrame.getByRole('link', {exact: true, name: spaceName}).click();
 
+	await expect(page.locator('#scopeContent')).toContainText(spaceName);
+
 	// Add the tag / category filter. The condition row defaults to "Tags"; the
 	// "of the following" select chooses the property. The filter value picker is
 	// opened by the last "Select" button (the first one belongs to Scope).
 
-	await page.getByRole('button', {name: 'Filter'}).click();
+	await expandPanel(page, 'Filter', '#filterContent');
 
 	await page.getByLabel('of the following').selectOption(filterProperty);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102891

## What Is Being Fixed

TC-7.c and TC-7.d in `collectionDisplay.spec.ts` timed out in CI after 90 seconds waiting for the `Select Tags` button. The trace shows that button present in the DOM but sitting inside a collapsed Filter panel, so it never entered the accessibility tree and `getByRole` never resolved it — the call log never got past `waiting for`.

The cause sits upstream of the panel. Selecting the Space in the Scope selector submits the collection form, which is then re-rendered through an SPA navigation, and everything the helper did against the pre-render document — opening the Filter panel, choosing the filter property — was discarded once the new form arrived. The expanded state of those panels is persisted server-side, so whether the re-rendered form came back with the Filter panel open was a race: the tests won it locally, where the persistence request lands before the re-render, and lost it on the slower CI agent, where that request was aborted by the navigation.

## How It Is Being Fixed

The helper now waits for the re-rendered form to list the Space before adding the filter, which settles the document before any of the filter interactions run. The wait asserts on text content rather than visibility, because the panel holding it can legitimately come back collapsed.

Expanding a panel goes through a single helper that clicks the header only when `aria-expanded` is not already `true`, then waits for the panel to finish expanding, all retried with `toPass`. That removes a second race the same server-side persistence created: a panel that came back already open was closed again by the old unconditional click.

The failure was reproduced locally by forcing the CI ordering with `page.route` — aborting the request that persists the panel state and delaying the form re-render by two seconds. Under that harness the old helper failed 2 of 2 runs and the new one passed 3 of 3; without the harness, TC-7.c and TC-7.d pass 3 repeats each.

## PR Check

**pr-check: PASS** — tested on `5fbae2860288b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| Baseline | N/A |
| JavaScript Unit Tests | N/A |

The three N/A validations match by regex but their triggers do not fire: `modules/test/playwright` has no `bnd.bnd` or `.lfrbuild-portal`, so it deploys no bundle; the diff touches no `.java`, `packageinfo` or `bnd.bnd`, so no exported API needs a version bump; and the module's `test` script is `playwright test`, which pr-check excludes by definition. The two affected Playwright specs were run anyway and pass.

<!-- pr-check {"result": "success", "sha": "5fbae2860288bb5a6d91a9eac95e6dcb081376ff"} -->
