### PR TITLE
LPD-98985 Extract the broken links query and bound its terms chunks

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
@@ -111,13 +111,13 @@ public class BrokenLinkAssetSearcher {
 
 		String[] values = outboundLinkTokens.toArray(new String[0]);
 
-		for (int i = 0; i < values.length; i += _MAX_TERMS_COUNT) {
+		for (int i = 0; i < values.length; i += _TERMS_QUERY_CHUNK_SIZE) {
 			booleanQuery.addShouldQueryClauses(
 				_getTermsQuery(
 					"outboundLinks",
 					ArrayUtil.subset(
 						values, i,
-						Math.min(i + _MAX_TERMS_COUNT, values.length))));
+						Math.min(i + _TERMS_QUERY_CHUNK_SIZE, values.length))));
 		}
 
 		booleanQuery.setMinimumShouldMatch(1);
@@ -133,7 +133,7 @@ public class BrokenLinkAssetSearcher {
 		return termsQuery;
 	}
 
-	private static final int _MAX_TERMS_COUNT = 65536;
+	private static final int _TERMS_QUERY_CHUNK_SIZE = 4096;
 
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final Searcher _searcher;

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.links;
+
+import com.liferay.object.model.ObjectEntryTable;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
+import com.liferay.site.cms.site.initializer.util.CMSOutboundLinksUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class BrokenLinkAssetSearcher {
+
+	public BrokenLinkAssetSearcher(
+		ObjectEntryLocalService objectEntryLocalService, Searcher searcher,
+		SearchRequestBuilderFactory searchRequestBuilderFactory) {
+
+		_objectEntryLocalService = objectEntryLocalService;
+		_searcher = searcher;
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+	}
+
+	public long getCount(
+		long companyId, Long[] groupIds, List<String> outboundLinkTokens) {
+
+		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+		booleanQuery.addFilterQueryClauses(
+			_getOutboundLinksBooleanQuery(outboundLinkTokens),
+			_getTermsQuery("cms_section", "contents", "files"),
+			_getTermsQuery(
+				Field.STATUS,
+				ArrayUtil.toStringArray(CMSWorkflowConstants.STATUSES)),
+			QueriesUtil.term("rootDescendantNode", false));
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				companyId
+			).emptySearchEnabled(
+				true
+			).groupIds(
+				ArrayUtil.toArray(groupIds)
+			).query(
+				booleanQuery
+			).withSearchContext(
+				searchContext -> searchContext.setAttribute(
+					Field.STATUS, WorkflowConstants.STATUS_ANY)
+			).build());
+
+		return searchResponse.getCount();
+	}
+
+	public List<String> getExpiredAssetTokens(
+		long companyId, Long[] objectDefinitionIds) {
+
+		List<String> expiredAssetTokens = new ArrayList<>();
+
+		List<Object[]> results = _objectEntryLocalService.dslQuery(
+			DSLQueryFactoryUtil.select(
+				ObjectEntryTable.INSTANCE.externalReferenceCode,
+				ObjectEntryTable.INSTANCE.objectEntryId
+			).from(
+				ObjectEntryTable.INSTANCE
+			).where(
+				ObjectEntryTable.INSTANCE.companyId.eq(
+					companyId
+				).and(
+					ObjectEntryTable.INSTANCE.objectDefinitionId.in(
+						objectDefinitionIds)
+				).and(
+					ObjectEntryTable.INSTANCE.status.eq(
+						WorkflowConstants.STATUS_EXPIRED)
+				)
+			));
+
+		for (Object[] objects : results) {
+			expiredAssetTokens.add(
+				CMSOutboundLinksUtil.getObjectEntryExternalReferenceCodeToken(
+					GetterUtil.getString(objects[0])));
+			expiredAssetTokens.add(
+				CMSOutboundLinksUtil.getObjectEntryIdToken(
+					GetterUtil.getLong(objects[1])));
+		}
+
+		return expiredAssetTokens;
+	}
+
+	private BooleanQuery _getOutboundLinksBooleanQuery(
+		List<String> outboundLinkTokens) {
+
+		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+		String[] values = outboundLinkTokens.toArray(new String[0]);
+
+		for (int i = 0; i < values.length; i += _MAX_TERMS_COUNT) {
+			booleanQuery.addShouldQueryClauses(
+				_getTermsQuery(
+					"outboundLinks",
+					ArrayUtil.subset(
+						values, i,
+						Math.min(i + _MAX_TERMS_COUNT, values.length))));
+		}
+
+		booleanQuery.setMinimumShouldMatch(1);
+
+		return booleanQuery;
+	}
+
+	private TermsQuery _getTermsQuery(String fieldName, String... values) {
+		TermsQuery termsQuery = QueriesUtil.terms(fieldName);
+
+		termsQuery.addValues(values);
+
+		return termsQuery;
+	}
+
+	private static final int _MAX_TERMS_COUNT = 65536;
+
+	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final Searcher _searcher;
+	private final SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -9,34 +9,26 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
+import com.liferay.headless.cms.internal.links.BrokenLinkAssetSearcher;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.search.query.BooleanQuery;
-import com.liferay.portal.search.query.QueriesUtil;
-import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
-import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
-import com.liferay.site.cms.site.initializer.util.CMSOutboundLinksUtil;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -162,39 +154,21 @@ public class AssetStatisticsResourceImpl
 		}
 
 		try {
-			List<String> expiredAssetTokens = _getExpiredAssetTokens(
-				objectDefinitionIds);
+			BrokenLinkAssetSearcher brokenLinkAssetSearcher =
+				new BrokenLinkAssetSearcher(
+					_objectEntryLocalService, _searcher,
+					_searchRequestBuilderFactory);
+
+			List<String> expiredAssetTokens =
+				brokenLinkAssetSearcher.getExpiredAssetTokens(
+					contextCompany.getCompanyId(), objectDefinitionIds);
 
 			if (expiredAssetTokens.isEmpty()) {
 				return 0;
 			}
 
-			BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
-
-			booleanQuery.addFilterQueryClauses(
-				_getOutboundLinksBooleanQuery(expiredAssetTokens),
-				_getTermsQuery("cms_section", "contents", "files"),
-				_getTermsQuery(
-					Field.STATUS,
-					ArrayUtil.toStringArray(CMSWorkflowConstants.STATUSES)),
-				QueriesUtil.term("rootDescendantNode", false));
-
-			SearchResponse searchResponse = _searcher.search(
-				_searchRequestBuilderFactory.builder(
-				).companyId(
-					contextCompany.getCompanyId()
-				).emptySearchEnabled(
-					true
-				).groupIds(
-					ArrayUtil.toArray(groupIds)
-				).query(
-					booleanQuery
-				).withSearchContext(
-					searchContext -> searchContext.setAttribute(
-						Field.STATUS, WorkflowConstants.STATUS_ANY)
-				).build());
-
-			return searchResponse.getCount();
+			return brokenLinkAssetSearcher.getCount(
+				contextCompany.getCompanyId(), groupIds, expiredAssetTokens);
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
@@ -222,39 +196,6 @@ public class AssetStatisticsResourceImpl
 		}
 	}
 
-	private List<String> _getExpiredAssetTokens(Long[] objectDefinitionIds) {
-		List<String> expiredAssetTokens = new ArrayList<>();
-
-		List<Object[]> results = _objectEntryLocalService.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE.externalReferenceCode,
-				ObjectEntryTable.INSTANCE.objectEntryId
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					contextCompany.getCompanyId()
-				).and(
-					ObjectEntryTable.INSTANCE.objectDefinitionId.in(
-						objectDefinitionIds)
-				).and(
-					ObjectEntryTable.INSTANCE.status.eq(
-						WorkflowConstants.STATUS_EXPIRED)
-				)
-			));
-
-		for (Object[] objects : results) {
-			expiredAssetTokens.add(
-				CMSOutboundLinksUtil.getObjectEntryExternalReferenceCodeToken(
-					GetterUtil.getString(objects[0])));
-			expiredAssetTokens.add(
-				CMSOutboundLinksUtil.getObjectEntryIdToken(
-					GetterUtil.getLong(objects[1])));
-		}
-
-		return expiredAssetTokens;
-	}
-
 	private Long[] _getGroupIds(Long assetLibraryId) {
 		List<Long> depotEntryGroupIds =
 			_depotEntryService.getDepotEntryGroupIds(
@@ -276,32 +217,6 @@ public class AssetStatisticsResourceImpl
 		return new Long[] {groupId};
 	}
 
-	private BooleanQuery _getOutboundLinksBooleanQuery(
-		List<String> outboundLinkTokens) {
-
-		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
-
-		for (int i = 0; i < outboundLinkTokens.size(); i += _MAX_TERMS_COUNT) {
-			List<String> values = outboundLinkTokens.subList(
-				i, Math.min(i + _MAX_TERMS_COUNT, outboundLinkTokens.size()));
-
-			booleanQuery.addShouldQueryClauses(
-				_getTermsQuery("outboundLinks", values.toArray(new String[0])));
-		}
-
-		booleanQuery.setMinimumShouldMatch(1);
-
-		return booleanQuery;
-	}
-
-	private TermsQuery _getTermsQuery(String fieldName, String... values) {
-		TermsQuery termsQuery = QueriesUtil.terms(fieldName);
-
-		termsQuery.addValues(values);
-
-		return termsQuery;
-	}
-
 	private AssetStatistics _toAssetStatistics() {
 		return new AssetStatistics() {
 			{
@@ -320,8 +235,6 @@ public class AssetStatisticsResourceImpl
 	}
 
 	private static final int _EXPIRING_SOON_DAYS = 7;
-
-	private static final int _MAX_TERMS_COUNT = 65536;
 
 	private static final int _UPCOMING_REVIEW_DAYS = 7;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98985

This is the first of four pull requests that replace #8808, split into smaller pieces at Brian's request.

## What Is Being Fixed

The Attention Required card's broken links count is built from a query that sits inline in `AssetStatisticsResourceImpl`, and the Broken Links page that follows needs the same query. Leaving it inline would mean two copies that drift.

The query also chunks its terms clauses at 65536, which is exactly the default of `index.max_terms_count`. That setting is configurable, so an administrator who lowers it breaks the count rather than the query degrading.

## How It Is Being Fixed

The enumeration of expired assets and the count query move to a `BrokenLinkAssetSearcher` collaborator that the card now constructs and calls. It is a plain object rather than an OSGi component, because a bundle-internal type cannot be registered as a service. The first commit is behaviour preserving.

The second commit renames `_MAX_TERMS_COUNT` to `_TERMS_QUERY_CHUNK_SIZE`, since the value is a chunk size rather than a ceiling, and lowers it to 4096 so it stays clear of the configured limit instead of sitting on the default.

## Why Are There No Tests?

The first commit is a pure extraction, and its behaviour is already covered by `AssetStatisticsResourceTest`, which passes 6 of 6 against the deployed module. The chunk size is not reachable at integration scale, since exercising it would require seeding more than 4096 expired assets.

## PR Check

**pr-check: PASS** — tested on `1c9e0a20db2b851fc56799658c560d2dd9e71a4e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1c9e0a20db2b851fc56799658c560d2dd9e71a4e"} -->
