### PR TITLE
LPD-102745 Cover the Contents section filters

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts
@@ -128,3 +128,54 @@ test(
 		});
 	}
 );
+
+test(
+	'Filtering the Contents section by Folder excludes contents',
+	{tag: '@LPD-102745'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const contentTitle = `Content ${getRandomString()}`;
+		const folderTitle = getRandomString();
+
+		await test.step('Create a folder and a content in a fresh Space', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: space.name,
+				title: folderTitle,
+			});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				'cms/basic-web-contents',
+				space.name
+			);
+		});
+
+		await test.step('Both the folder and the content are visible before filtering', async () => {
+			await assetsPage.gotoContents();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await expect(assetsPage.getItem(folderTitle)).toBeVisible();
+			await expect(assetsPage.getItem(contentTitle)).toBeVisible();
+		});
+
+		await test.step('Filtering by Type Folder shows only the folder', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Type',
+				value: 'Folder',
+			});
+
+			await expect(assetsPage.getItem(folderTitle)).toBeVisible();
+			await expect(assetsPage.getItem(contentTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/filterAvailability.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/searchFiltering/filterAvailability.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, mergeTests} from '@playwright/test';
+import {Page, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../../fixtures/loginTest';
@@ -12,16 +12,15 @@ import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
-// CMP Project is registered for the Files section too, but CMP is not part of
-// the portal bundle, so it is left out.
+// CMP Project is registered for both sections, but CMP is not part of the
+// portal bundle, so it is left out.
 
-const FILTERS = [
+const CONTENTS_FILTERS = [
 	'Author',
 	'Category',
 	'Create Date',
 	'Display Date',
 	'Expiration Date',
-	'Extension',
 	'Modified Date',
 	'Review Date',
 	'Space',
@@ -30,14 +29,27 @@ const FILTERS = [
 	'Type',
 ];
 
+const FILES_FILTERS = [...CONTENTS_FILTERS, 'Extension'];
+
+// Both tests create an asset first because an empty section renders its empty
+// state instead of the data set, which carries the Filter menu.
+
+async function openFilterMenu(page: Page) {
+	const filterButton = page.getByRole('button', {
+		exact: true,
+		name: 'Filter',
+	});
+
+	await expect(filterButton).toBeVisible();
+
+	await filterButton.click();
+}
+
 test(
 	'The Files section offers every expected filter',
 	{tag: '@LPD-102741'},
 	async ({apiHelpers, assetsPage, page}) => {
 		const fileTitle = `${getRandomString()}.txt`;
-
-		// An empty Files section renders its empty state instead of the data
-		// set, which carries the Filter menu, so one file has to exist.
 
 		await apiHelpers.objectEntry.postObjectEntry(
 			{
@@ -55,19 +67,43 @@ test(
 
 		await assetsPage.gotoFiles();
 
-		const filterButton = page.getByRole('button', {
-			exact: true,
-			name: 'Filter',
-		});
+		await openFilterMenu(page);
 
-		await expect(filterButton).toBeVisible();
-
-		await filterButton.click();
-
-		for (const filter of FILTERS) {
+		for (const filter of FILES_FILTERS) {
 			await expect(
 				page.getByRole('menuitem', {exact: true, name: filter})
 			).toBeVisible();
 		}
+	}
+);
+
+test(
+	'The Contents section offers every expected filter but Extension',
+	{tag: '@LPD-102745'},
+	async ({apiHelpers, assetsPage, page}) => {
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: `Content ${getRandomString()}`,
+			},
+			'cms/basic-web-contents',
+			'Default'
+		);
+
+		await assetsPage.gotoContents();
+
+		await openFilterMenu(page);
+
+		for (const filter of CONTENTS_FILTERS) {
+			await expect(
+				page.getByRole('menuitem', {exact: true, name: filter})
+			).toBeVisible();
+		}
+
+		// Extension is registered for the Files section only.
+
+		await expect(
+			page.getByRole('menuitem', {exact: true, name: 'Extension'})
+		).toHaveCount(0);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102745

## What Is Being Fixed

CMS registers its data set filters per data set, and the Contents section had no filter coverage at all. Every filter test in `all.spec.ts` exercises the All section, and the only section specific filter tests were the two covering Files. Nothing asserted which filters the Contents section offers, and in particular nothing asserted that Extension is offered on Files but withheld from Contents, so a regression that registered it on the wrong section, or dropped it from the right one, would go unnoticed. Filtering the Contents section by Folder was untested as well, even though content folders live under `L_CONTENTS` and `BaseObjectDefinitionSelectionFDSFilter` contributes a Folder item to every section that does not exclude it.

## How It Is Being Fixed

One test asserts that the Contents section offers its eleven expected filters and that Extension is absent. Since the difference between the two sections is a single filter, the shared list moved into `CONTENTS_FILTERS` and the Files list is now derived as `[...CONTENTS_FILTERS, 'Extension']`, which states that difference once instead of duplicating eleven strings across two literal lists. Absence is asserted with `toHaveCount(0)` because the menu item is not rendered at all, and the Files test passing on the same locator is what demonstrates the assertion can fail. Opening the Filter menu moved into a small helper shared by both tests.

The second test creates a content folder and a Basic Web Content in a fresh Space, confirms both are listed, then applies `Type: Folder` and asserts only the folder survives. Each test creates an asset before navigating, because an empty section renders its empty state in place of the data set that carries the Filter menu.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/searchFiltering/contentTypeFilter.spec.ts tests/site-cms-site-initializer/main/searchFiltering/filterAvailability.spec.ts
```

## PR Check

**pr-check: PASS** — tested on `06459d15e284340db8f45038eba45b3a1bdaf490`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Per-Module Compile and JavaScript Unit Tests matched the diff but have no work in `modules/test/playwright`: the module applies only the node plugin, so it exposes no `deploy` task, and its `npm test` is the Playwright suite rather than a unit suite. Both spec files were run in full, plus three repeats of each new test, all passing.

<!-- pr-check {"result": "success", "sha": "06459d15e284340db8f45038eba45b3a1bdaf490"} -->
