### PR TITLE
LPD-103028 Cover Shared With Me editing and folder navigation

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharedWithMe.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharedWithMe.spec.ts
@@ -405,3 +405,227 @@ test(
 		});
 	}
 );
+
+test(
+	'Content shared with Update can be edited from its title',
+	{tag: '@LPD-103028'},
+	async ({apiHelpers, contentsPage, page, sharedWithMePage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		let space = null;
+
+		await test.step('Create a new space', async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const editableTitle = `Content ${getRandomString()}`;
+		const updatedTitle = `Content ${getRandomString()}`;
+		const viewOnlyTitle = `Content ${getRandomString()}`;
+		let editableObjectEntry = null;
+		let viewOnlyObjectEntry = null;
+
+		await test.step('Create two contents in the space', async () => {
+			editableObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: editableTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+
+			viewOnlyObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: viewOnlyTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		let user = null;
+
+		await test.step('Create a user and add as space member', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Share one content with UPDATE and the other with VIEW only', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['UPDATE', 'VIEW'],
+						id: user.id,
+						share: false,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				editableObjectEntry.id
+			);
+
+			// Resharing is granted so that the view-only row still carries an
+			// Actions menu, leaving the Update permission as the only
+			// difference between the two rows.
+
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						id: user.id,
+						share: true,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				viewOnlyObjectEntry.id
+			);
+		});
+
+		await test.step('Only the content shared with UPDATE offers the Edit action', async () => {
+			await performUserSwitchViaApi(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+
+			const editMenuItem = page.getByRole('menuitem', {
+				exact: true,
+				name: 'Edit',
+			});
+
+			await page
+				.getByRole('row', {name: viewOnlyTitle})
+				.getByRole('button', {name: 'Actions'})
+				.click();
+
+			// Asserting Share proves the menu opened, so the absence of Edit
+			// below cannot pass on an unopened menu.
+
+			await expect(
+				page.getByRole('menuitem', {exact: true, name: 'Share'})
+			).toBeVisible();
+
+			await expect(editMenuItem).toHaveCount(0);
+
+			await page.keyboard.press('Escape');
+
+			await page
+				.getByRole('row', {name: editableTitle})
+				.getByRole('button', {name: 'Actions'})
+				.click();
+
+			await expect(editMenuItem).toBeVisible();
+
+			await page.keyboard.press('Escape');
+		});
+
+		await test.step('Clicking the title opens the editor and the change is published', async () => {
+			await page
+				.getByRole('row', {name: editableTitle})
+				.getByRole('link', {name: editableTitle})
+				.click();
+
+			await contentsPage.fillData([
+				{label: 'Title', value: updatedTitle},
+			]);
+
+			await contentsPage.publishButton.click();
+
+			await expect(
+				page.getByRole('row', {name: updatedTitle})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'A shared folder opens from its title in Shared With Me',
+	{tag: '@LPD-103028'},
+	async ({apiHelpers, page, sharedWithMePage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		let space = null;
+
+		await test.step('Create a new space', async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const folderTitle = `Folder ${getRandomString()}`;
+		let objectEntryFolder = null;
+
+		await test.step('Create a folder in the space', async () => {
+			objectEntryFolder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					scopeKey: spaceName,
+					title: folderTitle,
+				});
+		});
+
+		let user = null;
+
+		await test.step('Create a user and add as space member', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Share the folder with the user', async () => {
+			await apiHelpers.objectFolder.postObjectEntryFolderCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						id: user.id,
+						share: false,
+						type: 'User',
+					},
+				],
+				objectEntryFolder.id
+			);
+		});
+
+		await test.step('Clicking the folder title opens the folder', async () => {
+			await performUserSwitchViaApi(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+
+			await page
+				.getByRole('row', {name: folderTitle})
+				.getByRole('link', {name: folderTitle})
+				.click();
+
+			await expect(page).toHaveURL(/\/e\/view-folder\//);
+
+			await expect(
+				page.getByTestId(`testId${folderTitle}`)
+			).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharedWithMe.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharedWithMe.spec.ts
@@ -8,7 +8,7 @@ import {Locator, Page, expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
-import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const _PNG_BASE64 =
@@ -155,7 +155,7 @@ test(
 		});
 
 		await test.step('Switch to the user', async () => {
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 
 			await sharedWithMePage.goto();
 		});
@@ -270,7 +270,7 @@ test(
 		});
 
 		await test.step('Verify that the user can see the shared assets', async () => {
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 
 			await sharedWithMePage.expectAssetEntryToBeVisible(
 				objectEntryTitle
@@ -281,7 +281,7 @@ test(
 		});
 
 		await test.step('Delete the content and the folder so they go into the Recycle Bin', async () => {
-			await performUserSwitch(page, 'test');
+			await performUserSwitchViaApi(page, 'test');
 
 			await expect(
 				await apiHelpers.objectEntry.deleteObjectEntry(
@@ -298,7 +298,7 @@ test(
 		});
 
 		await test.step('Verify that the user can see deleted shared assets as "Not Visible"', async () => {
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 
 			await sharedWithMePage.expectAssetEntryNotToBeVisible(
 				objectEntryTitle
@@ -377,7 +377,7 @@ test(
 		});
 
 		await test.step('Switch to the user', async () => {
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 
 			await sharedWithMePage.goto();
 		});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103028

## What Is Being Fixed

`ViewSharedWithMeSectionDisplayContext` offers nine actions on a shared asset: view, share, view-file, view-content, edit, download, view-folder, edit-folder and download-folder. Only three of them were covered, by the read-only View modal test, the file preview test and the Share availability tests. The story's central claim, that a collaborator can act on a shared asset according to the permissions granted and that clicking its title executes those permissions, had no coverage for either editing or folders. Nothing asserted that Edit appears for a collaborator holding Update and is withheld from one holding only View, and nothing covered a shared folder at all, even though `SharedItemRenderer` gives a folder row a title that links into the folder view.

## How It Is Being Fixed

The first test shares two contents with the same user, one with `UPDATE` and one with `VIEW`, and grants resharing on the view-only one so that both rows carry an Actions menu and the Update permission is the only difference between them. It asserts Edit is offered on the first and absent from the second, then clicks the first row's title, which lands on the content editor, changes the title, publishes, and asserts the Shared With Me listing comes back carrying the new name. Absence of Edit is asserted only after asserting Share is visible in that same menu, so it cannot pass against a menu that never opened.

The second test shares a folder and asserts that clicking its title in Shared With Me opens the folder view, checking both the resulting URL and the folder marker on the page.

A separate commit switches the three existing tests in the file from `performUserSwitch` to `performUserSwitchViaApi`. The UI variant signs out and back in through the login form and is a known flake source; this is the same cleanup that landed on the sibling `sharingPermissions.spec.ts` under LPD-102734.

Download and download-folder are deliberately left out while LPD-102636 is open, since folder download there checks the Document Library file entry's `DOWNLOAD` rather than the `DOWNLOAD_FILE` the UI manages on the object entry, so a permission shaped test would be asserting broken behaviour.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/sharedWithMe.spec.ts
```

## PR Check

**pr-check: PASS** — tested on `c04b44fc5a9de34ed26c63105e35b8130ffc6e90`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Per-Module Compile and JavaScript Unit Tests matched the diff but have no work in `modules/test/playwright`: the module applies only the node plugin, so it exposes no `deploy` task, and its `npm test` is the Playwright suite rather than a unit suite. The whole spec file was run, plus three repeats of each new test, all passing.

<!-- pr-check {"result": "success", "sha": "c04b44fc5a9de34ed26c63105e35b8130ffc6e90"} -->
