### PR TITLE
LPD-103031 Cover Translate UI status, reset and auto translation

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sideBySideTranslation.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sideBySideTranslation.spec.ts
@@ -11,6 +11,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {systemSettingsPageTest} from '../../../fixtures/systemSettingsPageTest';
 import {ApiHelpers, DataApiHelpers} from '../../../helpers/ApiHelpers';
 import {LocalizationSelectPage} from '../../../pages/fragment-web/LocalizationSelectPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
@@ -152,7 +153,12 @@ async function getSampleStructureDefinition(apiHelpers: ApiHelpers) {
 	return SAMPLE_STRUCTURE_DEFINITION;
 }
 
-const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	loginTest(),
+	systemSettingsPageTest
+);
 
 test(
 	'Can translate a content with side by side view',
@@ -424,5 +430,162 @@ test(
 		expect(
 			await targetLocalizationSelectPage.getLanguageStatus('es-ES')
 		).toBe('not-translated');
+	}
+);
+
+test(
+	'Auto translate fills the translation once a translator is configured',
+	{tag: '@LPD-103031'},
+	async ({apiHelpers, contentsPage, page, systemSettingsPage}) => {
+		const contentTitle = getRandomString();
+
+		await createSampleStructureContent(
+			apiHelpers,
+			contentsPage,
+			contentTitle
+		);
+
+		const setAutoTranslation = async ({
+			enabled,
+			key,
+		}: {
+			enabled: boolean;
+			key?: string;
+		}) => {
+			await systemSettingsPage.goToSystemSetting(
+				'Translation',
+				'Translator Using Google Cloud'
+			);
+
+			if (enabled) {
+				await page.getByLabel('Enabled').check();
+			}
+			else {
+				await page.getByLabel('Enabled').uncheck();
+			}
+
+			if (key) {
+				await page.getByLabel('Service Account Private Key').fill(key);
+			}
+
+			await systemSettingsPage.saveAndWaitForAlert();
+		};
+
+		const openTranslationSide = async () => {
+			await contentsPage.goto();
+
+			await contentsPage.translateContent(contentTitle);
+
+			const targetLocalizationSelectPage = new LocalizationSelectPage(
+				page,
+				1
+			);
+
+			await targetLocalizationSelectPage.switchLanguage('es-ES');
+
+			return targetLocalizationSelectPage;
+		};
+
+		const autoTranslateMenuItem = page.getByRole('menuitem', {
+			name: 'Auto Translate',
+		});
+
+		await test.step('Auto Translate is not offered while no translator is configured', async () => {
+			const targetLocalizationSelectPage = await openTranslationSide();
+
+			await clickAndExpectToBeVisible({
+				target: page.getByRole('menuitem', {
+					name: 'Mark as Translated',
+				}),
+				trigger: targetLocalizationSelectPage.actionsDropdownTrigger,
+			});
+
+			await expect(autoTranslateMenuItem).toHaveCount(0);
+		});
+
+		try {
+			await test.step('Auto Translate fills the translation side from the response', async () => {
+				await setAutoTranslation({
+					enabled: true,
+					key: '{"type": "service_account"}',
+				});
+
+				const targetLocalizationSelectPage =
+					await openTranslationSide();
+
+				// The response echoes the requested field names, so the stub
+				// stays valid whatever the structure carries.
+
+				await page.route(
+					'**/o/translation/auto_translate',
+					async (route) => {
+						const {fields} = route.request().postDataJSON();
+
+						await route.fulfill({
+							body: JSON.stringify({
+								fields: Object.fromEntries(
+									Object.keys(fields).map((name) => [
+										name,
+										'Traducido',
+									])
+								),
+							}),
+							contentType: 'application/json',
+							status: 200,
+						});
+					}
+				);
+
+				await targetLocalizationSelectPage.autoTranslate('es-ES');
+
+				await expect(page.getByLabel('Title').nth(1)).toHaveValue(
+					'Traducido'
+				);
+				await expect(page.getByLabel('Long Text').nth(1)).toHaveValue(
+					'Traducido'
+				);
+			});
+
+			await test.step('A failing auto translation reports the error', async () => {
+				await page.route(
+					'**/o/translation/auto_translate',
+					async (route) => {
+						await route.fulfill({
+							body: JSON.stringify({
+								error: {
+									message: 'The translation key is invalid',
+								},
+							}),
+							contentType: 'application/json',
+							status: 200,
+						});
+					}
+				);
+
+				await clickAndExpectToBeVisible({
+					autoClick: true,
+					target: autoTranslateMenuItem,
+					trigger: page.getByLabel('Localization Actions'),
+				});
+
+				// The previous step translated the language, so the content
+				// override confirmation is always raised here.
+
+				const continueButton = page
+					.locator('.modal-footer')
+					.getByText('Continue');
+
+				await expect(continueButton).toBeVisible();
+
+				await continueButton.click();
+
+				await expect(
+					page.getByText('The translation key is invalid')
+				).toBeVisible();
+			});
+		}
+		finally {
+			await setAutoTranslation({enabled: false});
+		}
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sideBySideTranslation.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sideBySideTranslation.spec.ts
@@ -11,11 +11,13 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
-import {ApiHelpers} from '../../../helpers/ApiHelpers';
+import {ApiHelpers, DataApiHelpers} from '../../../helpers/ApiHelpers';
 import {LocalizationSelectPage} from '../../../pages/fragment-web/LocalizationSelectPage';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
+import {ContentsPage} from './pages/ContentsPage';
 
 async function getSampleStructureDefinition(apiHelpers: ApiHelpers) {
 	const assetLibraries =
@@ -283,5 +285,144 @@ test(
 		await expect(page.getByLabel('Title')).toHaveValue(spanishTitle);
 
 		await expect(page.getByLabel('Picklist')).toHaveValue('Apple');
+	}
+);
+
+async function createSampleStructureContent(
+	apiHelpers: DataApiHelpers,
+	contentsPage: ContentsPage,
+	contentTitle: string
+) {
+	const objectDefinitionAPIClient =
+		await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+	const sampleStructureDefinition =
+		await getSampleStructureDefinition(apiHelpers);
+
+	const {
+		body: {id: structureId},
+	} = await objectDefinitionAPIClient.postObjectDefinition(
+		sampleStructureDefinition
+	);
+
+	apiHelpers.data.push({id: structureId, type: 'objectDefinition'});
+
+	await contentsPage.goto();
+
+	await contentsPage.createContent(sampleStructureDefinition.label.en_US);
+
+	// Every field carries a default language value, because Mark as Translated
+	// copies that value into the translation and a field left empty in the
+	// default language is never counted as translated.
+
+	await contentsPage.fillData([
+		{label: 'Title', value: contentTitle},
+		{label: 'Long Text', value: 'This is a fruit'},
+		{label: 'Date', value: '2026-08-08'},
+		{label: 'Boolean', type: 'Checkbox', value: true},
+		{label: 'Picklist', type: 'Picklist', value: 'Banana'},
+	]);
+
+	await contentsPage.saveContent();
+}
+
+test(
+	'Translating every field marks the language as translated',
+	{tag: '@LPD-103031'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const contentTitle = getRandomString();
+
+		await createSampleStructureContent(
+			apiHelpers,
+			contentsPage,
+			contentTitle
+		);
+
+		await contentsPage.goto();
+
+		await contentsPage.translateContent(contentTitle);
+
+		const targetLocalizationSelectPage = new LocalizationSelectPage(
+			page,
+			1
+		);
+
+		await targetLocalizationSelectPage.switchLanguage('es-ES');
+
+		expect(
+			await targetLocalizationSelectPage.getLanguageStatus('es-ES')
+		).not.toBe('translated');
+
+		await contentsPage.fillData([
+			{label: 'Title', nth: 1, value: `Spanish ${contentTitle}`},
+			{label: 'Long Text', nth: 1, value: 'Esto es una fruta'},
+			{label: 'Date', nth: 1, value: '2026-08-15'},
+			{label: 'Boolean', nth: 1, type: 'Checkbox', value: false},
+			{label: 'Picklist', nth: 1, type: 'Picklist', value: 'Apple'},
+		]);
+
+		expect(
+			await targetLocalizationSelectPage.getLanguageStatus('es-ES')
+		).toBe('translated');
+
+		const markAsTranslatedMenuItem = page.getByRole('menuitem', {
+			name: 'Mark as Translated',
+		});
+
+		await clickAndExpectToBeVisible({
+			target: markAsTranslatedMenuItem,
+			trigger: targetLocalizationSelectPage.actionsDropdownTrigger,
+		});
+
+		await expect(markAsTranslatedMenuItem).toBeDisabled();
+	}
+);
+
+test(
+	'A language can be marked as translated and the translation reset',
+	{tag: '@LPD-103031'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const contentTitle = getRandomString();
+
+		await createSampleStructureContent(
+			apiHelpers,
+			contentsPage,
+			contentTitle
+		);
+
+		await contentsPage.goto();
+
+		await contentsPage.translateContent(contentTitle);
+
+		const targetLocalizationSelectPage = new LocalizationSelectPage(
+			page,
+			1
+		);
+
+		// No field is translated, so this is the manual override, and the
+		// helper asserts the language ends up translated.
+
+		await targetLocalizationSelectPage.markAsTranslated('es-ES');
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'Reset Translation'}),
+			trigger: targetLocalizationSelectPage.actionsDropdownTrigger,
+		});
+
+		await expect(
+			page.getByText(
+				'translation will be deleted and content fields will be set to default language'
+			)
+		).toBeVisible();
+
+		await page
+			.locator('.modal-footer')
+			.getByRole('button', {exact: true, name: 'Delete'})
+			.click();
+
+		expect(
+			await targetLocalizationSelectPage.getLanguageStatus('es-ES')
+		).toBe('not-translated');
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103031

## What Is Being Fixed

The Translate action's side-by-side view had one test, covering the translation itself and the two independent language selectors. Everything the story says about translation status was uncovered from that view: reaching translated by filling every field, marking a language as translated by hand, the Mark as Translated item turning disabled once the status is translated, resetting a translation behind its confirmation, and auto translation.

`localizationSelectFragment.spec.ts` does cover those actions, but for the Localization Select fragment inside the content editor, reached only after customizing the structure's editor. The side-by-side view is a different surface built by `ActionUtil.generateTranslateContentLayoutStructure`, which passes `allowLocalizationManagement` itself, so it carries the same dropdown with no customization at all and nothing exercised it.

## How It Is Being Fixed

The first commit adds two tests. One fills every field on the translation pane and asserts the language dropdown reports translated, then asserts Mark as Translated is disabled. The other leaves the translation untouched, marks the language as translated by hand, and resets it, asserting the confirmation text before confirming the deletion and asserting the status returns to not translated.

The second commit covers auto translation, kept separate because it mutates an instance setting and restores it in a `finally`. It asserts Auto Translate is not offered while no translator is configured, configures the Google Cloud translator with a placeholder key, stubs `/o/translation/auto_translate` to echo back the field names it was sent so the stub holds whatever the structure carries, and asserts the translation pane is filled. It then stubs an error response and asserts the message is surfaced.

Three notes on the fixtures, each learned from a failing run. The status does not begin at not translated, because the friendly URL is localizable and already carries a target locale value, so the baseline asserts only that the language is not yet translated. Every field is given a default language value before translating, because Mark as Translated copies that value across and a field left empty in the default language is never counted. The translation pane's boolean is set to the opposite of the source value, since setting a checkbox to the value it already holds fires no change event.

## Test Execution

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/sideBySideTranslation.spec.ts
```

## PR Check

**pr-check: PASS** — tested on `d05d83dfa8eac0deece88333a9518c98d537ee39`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Per-Module Compile and JavaScript Unit Tests matched the diff but have no work in `modules/test/playwright`: the module applies only the node plugin, so it exposes no `deploy` task, and its `npm test` is the Playwright suite rather than a unit suite. The whole spec file was run, plus three repeats of each new test, all passing.

<!-- pr-check {"result": "success", "sha": "d05d83dfa8eac0deece88333a9518c98d537ee39"} -->
