### PR TITLE
LPD-101914 Check the site permission when connecting an asset library

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelServiceImpl.java
@@ -42,6 +42,9 @@ public class DepotEntryGroupRelServiceImpl
 		_depotEntryModelResourcePermission.check(
 			getPermissionChecker(), depotEntryId, ActionKeys.UPDATE);
 
+		GroupPermissionUtil.check(
+			getPermissionChecker(), toGroupId, ActionKeys.UPDATE);
+
 		return depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 			depotEntryId, toGroupId);
 	}
@@ -57,6 +60,10 @@ public class DepotEntryGroupRelServiceImpl
 
 		_depotEntryModelResourcePermission.check(
 			getPermissionChecker(), depotEntryGroupRel.getDepotEntryId(),
+			ActionKeys.UPDATE);
+
+		GroupPermissionUtil.check(
+			getPermissionChecker(), depotEntryGroupRel.getToGroupId(),
 			ActionKeys.UPDATE);
 
 		return depotEntryGroupRelLocalService.deleteDepotEntryGroupRel(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelServiceTest.java
@@ -12,6 +12,7 @@ import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryGroupRelService;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.test.util.DepotTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -24,6 +25,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -42,6 +44,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 
 /**
@@ -56,6 +59,56 @@ public class DepotEntryGroupRelServiceTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testDepotEntryGroupRelWithoutToGroupPermissions()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		DepotEntryGroupRel depotEntryGroupRel =
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry.getDepotEntryId(), group.getGroupId());
+
+		try {
+			DepotTestUtil.withAssetLibraryAdministrator(
+				depotEntry,
+				user -> {
+					PermissionChecker permissionChecker =
+						PermissionThreadLocal.getPermissionChecker();
+
+					try {
+						PermissionThreadLocal.setPermissionChecker(
+							_permissionCheckerFactory.create(user));
+
+						_assertMustHaveUpdatePermission(
+							user.getUserId(),
+							() ->
+								_depotEntryGroupRelService.
+									addDepotEntryGroupRel(
+										depotEntry.getDepotEntryId(),
+										group.getGroupId()));
+
+						_assertMustHaveUpdatePermission(
+							user.getUserId(),
+							() ->
+								_depotEntryGroupRelService.
+									deleteDepotEntryGroupRel(
+										depotEntryGroupRel.
+											getDepotEntryGroupRelId()));
+					}
+					finally {
+						PermissionThreadLocal.setPermissionChecker(
+							permissionChecker);
+					}
+				});
+		}
+		finally {
+			_groupLocalService.deleteGroup(group);
+		}
+	}
 
 	@Test
 	public void testGetDepotEntryGroupRelsWithoutPermissions()
@@ -158,6 +211,21 @@ public class DepotEntryGroupRelServiceTest {
 		_depotEntries.add(depotEntry);
 
 		return depotEntry;
+	}
+
+	private void _assertMustHaveUpdatePermission(
+		long userId, ThrowingRunnable throwingRunnable) {
+
+		PrincipalException.MustHavePermission principalException =
+			Assert.assertThrows(
+				PrincipalException.MustHavePermission.class, throwingRunnable);
+
+		String message = principalException.getMessage();
+
+		Assert.assertTrue(
+			message,
+			message.contains(
+				"User " + userId + " must have UPDATE permission for"));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSitesDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSitesDisplayContext.java
@@ -22,10 +22,14 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.item.selector.SiteItemSelectorCriterion;
 import com.liferay.staging.StagingGroupHelper;
 import com.liferay.staging.StagingGroupHelperUtil;
@@ -49,6 +53,8 @@ public class DepotAdminSitesDisplayContext {
 
 		_currentURL = PortletURLUtil.getCurrent(
 			liferayPortletRequest, liferayPortletResponse);
+		_themeDisplay = (ThemeDisplay)liferayPortletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	public DropdownItemList getConnectedSiteDropdownItems(
@@ -99,6 +105,9 @@ public class DepotAdminSitesDisplayContext {
 							depotEntryGroupRel)));
 			}
 		).add(
+			() -> GroupPermissionUtil.contains(
+				_themeDisplay.getPermissionChecker(),
+				depotEntryGroupRel.getToGroupId(), ActionKeys.UPDATE),
 			dropdownItem -> {
 				dropdownItem.setData(
 					HashMapBuilder.<String, Object>put(
@@ -231,5 +240,6 @@ public class DepotAdminSitesDisplayContext {
 	private final PortletURL _currentURL;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSitesDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSitesDisplayContext.java
@@ -144,6 +144,7 @@ public class DepotAdminSitesDisplayContext {
 		SiteItemSelectorCriterion siteItemSelectorCriterion =
 			new SiteItemSelectorCriterion();
 
+		siteItemSelectorCriterion.setActionId(ActionKeys.UPDATE);
 		siteItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new URLItemSelectorReturnType());
 

--- a/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector Criteria API
 Bundle-SymbolicName: com.liferay.item.selector.criteria.api
-Bundle-Version: 11.5.2
+Bundle-Version: 11.6.0
 Export-Package:\
 	com.liferay.item.selector.criteria,\
 	com.liferay.item.selector.criteria.asset.criterion,\

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/group/criterion/GroupItemSelectorCriterion.java
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/group/criterion/GroupItemSelectorCriterion.java
@@ -6,6 +6,7 @@
 package com.liferay.item.selector.criteria.group.criterion;
 
 import com.liferay.item.selector.BaseItemSelectorCriterion;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 /**
  * @author Adolfo Pérez
@@ -17,6 +18,10 @@ public class GroupItemSelectorCriterion extends BaseItemSelectorCriterion {
 
 	public GroupItemSelectorCriterion(boolean privateLayout) {
 		_privateLayout = privateLayout;
+	}
+
+	public String getActionId() {
+		return _actionId;
 	}
 
 	public int getDepotEntryType() {
@@ -85,6 +90,10 @@ public class GroupItemSelectorCriterion extends BaseItemSelectorCriterion {
 
 	public boolean isPrivateLayout() {
 		return _privateLayout;
+	}
+
+	public void setActionId(String actionId) {
+		_actionId = actionId;
 	}
 
 	public void setAllowNavigation(boolean allowNavigation) {
@@ -159,6 +168,7 @@ public class GroupItemSelectorCriterion extends BaseItemSelectorCriterion {
 		_target = target;
 	}
 
+	private String _actionId = ActionKeys.VIEW;
 	private boolean _allowNavigation = true;
 	private int _depotEntryType;
 	private long[] _excludedGroupIds;

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/group/criterion/packageinfo
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/group/criterion/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.8.0

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/provider/GroupSearchProvider.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/provider/GroupSearchProvider.java
@@ -27,6 +27,7 @@ import com.liferay.site.search.GroupSearch;
 
 import jakarta.portlet.PortletRequest;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -40,6 +41,16 @@ public class GroupSearchProvider {
 			GroupSearch groupSearch, PortletRequest portletRequest)
 		throws PortalException {
 
+		setResultsAndTotal(
+			ActionKeys.VIEW, classNames, excludedGroupIds, groupSearch,
+			portletRequest);
+	}
+
+	public static void setResultsAndTotal(
+			String actionId, List<String> classNames, long[] excludedGroupIds,
+			GroupSearch groupSearch, PortletRequest portletRequest)
+		throws PortalException {
+
 		long parentGroupId = _getParentGroupId(portletRequest);
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
@@ -50,7 +61,7 @@ public class GroupSearchProvider {
 
 			groupSearch.setResultsAndTotal(
 				ListUtil.sort(
-					_getAllGroups(classNames, portletRequest),
+					_getAllGroups(actionId, classNames, portletRequest),
 					groupSearch.getOrderByComparator()));
 		}
 		else if (_isSearch(portletRequest)) {
@@ -62,7 +73,7 @@ public class GroupSearchProvider {
 					themeDisplay.getCompanyId(), classNameIds,
 					_getKeywords(portletRequest),
 					_getGroupParams(
-						classNames, excludedGroupIds, portletRequest,
+						actionId, classNames, excludedGroupIds, portletRequest,
 						parentGroupId),
 					groupSearch.getStart(), groupSearch.getEnd(),
 					groupSearch.getOrderByComparator()),
@@ -70,7 +81,7 @@ public class GroupSearchProvider {
 					themeDisplay.getCompanyId(), classNameIds,
 					_getKeywords(portletRequest),
 					_getGroupParams(
-						classNames, excludedGroupIds, portletRequest,
+						actionId, classNames, excludedGroupIds, portletRequest,
 						parentGroupId)));
 		}
 		else {
@@ -86,7 +97,7 @@ public class GroupSearchProvider {
 					themeDisplay.getCompanyId(), classNameIds, groupId,
 					_getKeywords(portletRequest),
 					_getGroupParams(
-						classNames, excludedGroupIds, portletRequest,
+						actionId, classNames, excludedGroupIds, portletRequest,
 						parentGroupId),
 					groupSearch.getStart(), groupSearch.getEnd(),
 					groupSearch.getOrderByComparator()),
@@ -94,13 +105,14 @@ public class GroupSearchProvider {
 					themeDisplay.getCompanyId(), classNameIds, groupId,
 					_getKeywords(portletRequest),
 					_getGroupParams(
-						classNames, excludedGroupIds, portletRequest,
+						actionId, classNames, excludedGroupIds, portletRequest,
 						parentGroupId)));
 		}
 	}
 
 	private static List<Group> _getAllGroups(
-			List<String> classNames, PortletRequest portletRequest)
+			String actionId, List<String> classNames,
+			PortletRequest portletRequest)
 		throws PortalException {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
@@ -120,17 +132,34 @@ public class GroupSearchProvider {
 			groups.add(GroupLocalServiceUtil.getGroup(groupId));
 		}
 
-		return groups;
+		if (actionId.equals(ActionKeys.VIEW)) {
+			return groups;
+		}
+
+		List<Group> permittedGroups = new ArrayList<>(groups.size());
+
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
+		for (Group group : groups) {
+			if (GroupPermissionUtil.contains(
+					permissionChecker, group, actionId)) {
+
+				permittedGroups.add(group);
+			}
+		}
+
+		return permittedGroups;
 	}
 
 	private static LinkedHashMap<String, Object> _getGroupParams(
-			List<String> classNames, long[] excludedGroupIds,
+			String actionId, List<String> classNames, long[] excludedGroupIds,
 			PortletRequest portletRequest, long parentGroupId)
 		throws PortalException {
 
 		LinkedHashMap<String, Object> groupParams =
 			LinkedHashMapBuilder.<String, Object>put(
-				"actionId", ActionKeys.VIEW
+				"actionId", actionId
 			).put(
 				"excludedGroupIds", ListUtil.fromArray(excludedGroupIds)
 			).put(
@@ -140,7 +169,8 @@ public class GroupSearchProvider {
 		if (_isSearch(portletRequest)) {
 			if (_isFilterManageableGroups(portletRequest)) {
 				groupParams.put(
-					"groupsTree", _getAllGroups(classNames, portletRequest));
+					"groupsTree",
+					_getAllGroups(actionId, classNames, portletRequest));
 			}
 			else if (parentGroupId > 0) {
 				List<Group> groupsTree = ListUtil.fromArray(

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/provider/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/provider/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/MySitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/MySitesItemSelectorViewDisplayContext.java
@@ -94,7 +94,7 @@ public class MySitesItemSelectorViewDisplayContext
 					ctCollectionId)) {
 
 			GroupSearchProvider.setResultsAndTotal(
-				_getClassNames(),
+				groupItemSelectorCriterion.getActionId(), _getClassNames(),
 				groupItemSelectorCriterion.getExcludedGroupIds(), _groupSearch,
 				_portletRequest);
 		}

--- a/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/RecentSitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/RecentSitesItemSelectorViewDisplayContext.java
@@ -11,8 +11,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.site.item.selector.display.context.SitesItemSelectorViewDisplayContext;
 import com.liferay.site.manager.RecentGroupManager;
 import com.liferay.site.search.GroupSearch;
@@ -20,6 +22,9 @@ import com.liferay.site.search.GroupSearch;
 import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Julio Camarero
@@ -66,12 +71,26 @@ public class RecentSitesItemSelectorViewDisplayContext
 		GroupItemSelectorCriterion groupItemSelectorCriterion =
 			getGroupItemSelectorCriterion();
 
-		groupSearch.setResultsAndTotal(
-			ListUtil.filter(
-				_recentGroupManager.getRecentGroups(httpServletRequest),
-				group -> !ArrayUtil.contains(
+		List<Group> groups = new ArrayList<>();
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		for (Group group :
+				_recentGroupManager.getRecentGroups(httpServletRequest)) {
+
+			if (!ArrayUtil.contains(
 					groupItemSelectorCriterion.getExcludedGroupIds(),
-					group.getGroupId())));
+					group.getGroupId()) &&
+				GroupPermissionUtil.contains(
+					permissionChecker, group,
+					groupItemSelectorCriterion.getActionId())) {
+
+				groups.add(group);
+			}
+		}
+
+		groupSearch.setResultsAndTotal(groups);
 
 		return groupSearch;
 	}

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/provider/test/GroupSearchProviderTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/provider/test/GroupSearchProviderTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -75,6 +76,50 @@ public class GroupSearchProviderTest {
 			_originalGroupsComplexSQLClassNames);
 
 		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
+	}
+
+	@Test
+	public void testSearchGroupsWithUpdateActionId() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		User user = UserTestUtil.addGroupUser(group, RoleConstants.SITE_MEMBER);
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(group, user));
+		mockLiferayPortletActionRequest.setParameter(
+			"keywords", group.getGroupKey());
+
+		GroupSearch viewGroupSearch = new GroupSearch(
+			mockLiferayPortletActionRequest, new MockLiferayPortletURL());
+
+		GroupSearchProvider.setResultsAndTotal(
+			ActionKeys.VIEW,
+			Arrays.asList(
+				Company.class.getName(), Group.class.getName(),
+				Organization.class.getName()),
+			null, viewGroupSearch, mockLiferayPortletActionRequest);
+
+		_assertGroupSearch(group, viewGroupSearch);
+
+		GroupSearch updateGroupSearch = new GroupSearch(
+			mockLiferayPortletActionRequest, new MockLiferayPortletURL());
+
+		GroupSearchProvider.setResultsAndTotal(
+			ActionKeys.UPDATE,
+			Arrays.asList(
+				Company.class.getName(), Group.class.getName(),
+				Organization.class.getName()),
+			null, updateGroupSearch, mockLiferayPortletActionRequest);
+
+		List<Group> results = updateGroupSearch.getResults();
+
+		Assert.assertEquals(results.toString(), 0, results.size());
 	}
 
 	@Test
@@ -157,7 +202,7 @@ public class GroupSearchProviderTest {
 	}
 
 	private void _assertGroupSearch(
-		Group childGroup1, GroupSearch groupSearch) {
+		Group expectedGroup, GroupSearch groupSearch) {
 
 		List<Group> results = groupSearch.getResults();
 
@@ -165,7 +210,7 @@ public class GroupSearchProviderTest {
 
 		Group group = results.get(0);
 
-		Assert.assertEquals(childGroup1.getGroupId(), group.getGroupId());
+		Assert.assertEquals(expectedGroup.getGroupId(), group.getGroupId());
 	}
 
 	private ThemeDisplay _getThemeDisplay(Group group, User user)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101914

## What Is Being Fixed

An asset library administrator could connect the library to any site in the instance, including sites they hold no permission on, by calling the connected sites endpoint directly.

`DepotEntryGroupRelServiceImpl.addDepotEntryGroupRel` checked `UPDATE` on the depot entry but performed no check at all against the site being connected. The user interface hides the problem because its item selector only lists sites the caller belongs to, so the gap is only reachable through the REST or JSON web service layer. `deleteDepotEntryGroupRel` had the same gap in the opposite direction, letting the same caller disconnect a site they do not administer.

## How It Is Being Fixed

Both service methods now also check `UPDATE` on the target site group through `GroupPermissionUtil`, in addition to the existing depot entry check. Connecting a library exposes its content to the site and disconnecting withdraws it, so both operations change the site and belong behind the site's own permission rather than the library's alone.

The user interface is brought in line with the service. `GroupSearchProvider` gains an overload that takes the action to check, so the site selector can list only the sites the caller may update, and `GroupItemSelectorCriterion` carries that action through the item selector. The Disconnect action is hidden when the caller lacks site `UPDATE`.

Worth flagging for review: this tightens an existing flow. A library administrator who is only a member of a connected site can no longer disconnect it and now needs site `UPDATE`, so the Disconnect action in the library's Sites screen becomes unavailable for that role.

The integration tests drive both service methods as an asset library administrator against a site they do not administer and assert that each is refused, and cover the site selector filtering. The connect and disconnect cases share one fixture and one test method so the suite pays the asset library administrator setup once.

## PR Check

**pr-check: PASS** — tested on `e8a3179a009e048981b26cc934aa4d0b08d1bcfd`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e8a3179a009e048981b26cc934aa4d0b08d1bcfd"} -->
