### PR TITLE
LPD-99972 Fix the 500 when patching an asset library friendly URL

### DIFF
--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BulkActionResourceTest.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BulkActionResourceTest.java
@@ -214,6 +214,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
 		return _depotEntryLocalService.updateDepotEntry(
 			depotEntry.getDepotEntryId(), nameMap, null, Collections.emptyMap(),
+			null,
 			UnicodePropertiesBuilder.put(
 				"trashEnabled", trashEnabled
 			).build(),

--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 12.0.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
@@ -380,7 +380,7 @@ public interface DepotEntryLocalService
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
-			Map<String, Boolean> depotAppCustomizationMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
@@ -401,4 +401,4 @@ public interface DepotEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:60896067
+// LIFERAY-SERVICE-BUILDER-HASH:-1578473779

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
@@ -443,7 +443,7 @@ public class DepotEntryLocalServiceUtil {
 	public static DepotEntry updateDepotEntry(
 			long depotEntryId, Map<java.util.Locale, String> nameMap,
 			Map<java.util.Locale, String> descriptionMap,
-			Map<String, Boolean> depotAppCustomizationMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -451,7 +451,7 @@ public class DepotEntryLocalServiceUtil {
 
 		return getService().updateDepotEntry(
 			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
-			typeSettingsUnicodeProperties, serviceContext);
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	public static DepotEntryLocalService getService() {
@@ -463,4 +463,4 @@ public class DepotEntryLocalServiceUtil {
 			DepotEntryLocalServiceUtil.class, DepotEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:239845251
+// LIFERAY-SERVICE-BUILDER-HASH:-719857016

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
@@ -496,6 +496,7 @@ public class DepotEntryLocalServiceWrapper
 			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,
+			String friendlyURL,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -503,7 +504,7 @@ public class DepotEntryLocalServiceWrapper
 
 		return _depotEntryLocalService.updateDepotEntry(
 			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
-			typeSettingsUnicodeProperties, serviceContext);
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override
@@ -546,4 +547,4 @@ public class DepotEntryLocalServiceWrapper
 	private DepotEntryLocalService _depotEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2008945564
+// LIFERAY-SERVICE-BUILDER-HASH:-4632591

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
@@ -98,10 +98,10 @@ public interface DepotEntryService extends BaseService {
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
-			Map<String, Boolean> depotAppCustomizationMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2012305632
+// LIFERAY-SERVICE-BUILDER-HASH:1881212834

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
@@ -113,7 +113,7 @@ public class DepotEntryServiceUtil {
 	public static DepotEntry updateDepotEntry(
 			long depotEntryId, Map<java.util.Locale, String> nameMap,
 			Map<java.util.Locale, String> descriptionMap,
-			Map<String, Boolean> depotAppCustomizationMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -121,7 +121,7 @@ public class DepotEntryServiceUtil {
 
 		return getService().updateDepotEntry(
 			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
-			typeSettingsUnicodeProperties, serviceContext);
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	public static DepotEntryService getService() {
@@ -132,4 +132,4 @@ public class DepotEntryServiceUtil {
 		new Snapshot<>(DepotEntryServiceUtil.class, DepotEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1376930221
+// LIFERAY-SERVICE-BUILDER-HASH:-1117226626

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
@@ -123,6 +123,7 @@ public class DepotEntryServiceWrapper
 			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,
+			String friendlyURL,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -130,7 +131,7 @@ public class DepotEntryServiceWrapper
 
 		return _depotEntryService.updateDepotEntry(
 			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
-			typeSettingsUnicodeProperties, serviceContext);
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override
@@ -146,4 +147,4 @@ public class DepotEntryServiceWrapper
 	private DepotEntryService _depotEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1245536009
+// LIFERAY-SERVICE-BUILDER-HASH:-598259630

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.4.0
+version 4.0.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
@@ -450,6 +450,7 @@ public class DepotEntryServiceHttp {
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,
+			String friendlyURL,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -462,8 +463,8 @@ public class DepotEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, depotEntryId, nameMap, descriptionMap,
-				depotAppCustomizationMap, typeSettingsUnicodeProperties,
-				serviceContext);
+				depotAppCustomizationMap, friendlyURL,
+				typeSettingsUnicodeProperties, serviceContext);
 
 			Object returnObj = null;
 
@@ -530,10 +531,10 @@ public class DepotEntryServiceHttp {
 	private static final Class<?>[] _updateDepotEntryParameterTypes10 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
-			java.util.Map.class,
+			java.util.Map.class, String.class,
 			com.liferay.portal.kernel.util.UnicodeProperties.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-851994723
+// LIFERAY-SERVICE-BUILDER-HASH:-1871780588

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -379,7 +379,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
-			Map<String, Boolean> depotAppCustomizationMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
@@ -436,10 +436,14 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 			nameMap.put(locale, defaultName);
 		}
 
+		if (Validator.isNull(friendlyURL)) {
+			friendlyURL = group.getFriendlyURL();
+		}
+
 		group = _groupLocalService.updateGroup(
 			depotEntry.getGroupId(), group.getParentGroupId(), nameMap,
 			descriptionMap, group.getType(), null, group.isManualMembership(),
-			group.getMembershipRestriction(), group.getFriendlyURL(),
+			group.getMembershipRestriction(), friendlyURL,
 			group.isInheritContent(), group.isActive(), serviceContext);
 
 		_groupLocalService.updateGroup(

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -225,7 +225,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 	public DepotEntry updateDepotEntry(
 			long depotEntryId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap,
-			Map<String, Boolean> depotAppCustomizationMap,
+			Map<String, Boolean> depotAppCustomizationMap, String friendlyURL,
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
@@ -235,7 +235,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 
 		return depotEntryLocalService.updateDepotEntry(
 			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
-			typeSettingsUnicodeProperties, serviceContext);
+			friendlyURL, typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -307,7 +307,7 @@ public class DepotEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "newDescription"
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), null,
 			UnicodePropertiesBuilder.put(
 				PropsKeys.LOCALES,
 				LocaleUtil.toLanguageId(LocaleUtil.getDefault())
@@ -342,7 +342,7 @@ public class DepotEntryLocalServiceTest {
 			).put(
 				LocaleUtil.fromLanguageId("es_ES"), "nuevaDescripcion"
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), null,
 			UnicodePropertiesBuilder.put(
 				PropsKeys.LOCALES,
 				StringUtil.merge(LocaleUtil.toLanguageIds(availableLocales))
@@ -370,7 +370,7 @@ public class DepotEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "newDescription"
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), null,
 			UnicodePropertiesBuilder.put(
 				"inheritLocales", "true"
 			).build(),
@@ -399,7 +399,7 @@ public class DepotEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "newName"
 			).build(),
-			Collections.emptyMap(), Collections.emptyMap(),
+			Collections.emptyMap(), Collections.emptyMap(), null,
 			UnicodePropertiesBuilder.put(
 				PropsKeys.LOCALES,
 				LocaleUtil.toLanguageId(LocaleUtil.getDefault())
@@ -419,7 +419,7 @@ public class DepotEntryLocalServiceTest {
 
 		_depotEntryLocalService.updateDepotEntry(
 			depotEntry.getDepotEntryId(), new HashMap<>(),
-			Collections.emptyMap(), Collections.emptyMap(),
+			Collections.emptyMap(), Collections.emptyMap(), null,
 			new UnicodeProperties(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -445,7 +445,7 @@ public class DepotEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "description"
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), null,
 			UnicodePropertiesBuilder.put(
 				PropsKeys.LOCALES,
 				LocaleUtil.toLanguageId(LocaleUtil.getDefault())
@@ -475,7 +475,7 @@ public class DepotEntryLocalServiceTest {
 			).put(
 				LocaleUtil.fromLanguageId("es_ES"), "descripcion"
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), null,
 			UnicodePropertiesBuilder.put(
 				"inheritLocales", "false"
 			).build(),

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryServiceTest.java
@@ -201,7 +201,7 @@ public class DepotEntryServiceTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			Collections.emptyMap(), new UnicodeProperties(),
+			Collections.emptyMap(), null, new UnicodeProperties(),
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), user.getUserId()));
 	}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/EditDepotEntryMVCActionCommand.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/EditDepotEntryMVCActionCommand.java
@@ -75,6 +75,7 @@ public class EditDepotEntryMVCActionCommand extends BaseMVCActionCommand {
 				_localization.getLocalizationMap(
 					actionRequest, "description", group.getDescriptionMap()),
 				_toStringBooleanMap(depotAppCustomizationUnicodeProperties),
+				null,
 				PropertiesParamUtil.getProperties(
 					actionRequest, "TypeSettingsProperties--"),
 				ServiceContextFactory.getInstance(

--- a/modules/apps/export-import/export-import-test-util/bnd.bnd
+++ b/modules/apps/export-import/export-import-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import Test Utilities
 Bundle-SymbolicName: com.liferay.exportimport.test.util
-Bundle-Version: 12.0.1
+Bundle-Version: 12.1.0
 Export-Package:\
 	com.liferay.exportimport.test.rule,\
 	com.liferay.exportimport.test.util,\

--- a/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/packageinfo
+++ b/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -369,14 +369,13 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				depotEntry.getDepotEntryId(), nameMap, descriptionMap,
 				_getDepotAppCustomizationMap(
 					depotEntry.getCompanyId(), externalReferenceCode),
+				assetLibrary.getFriendlyURL(),
 				UnicodePropertiesBuilder.create(
 					group.getTypeSettingsProperties(), true
 				).putAll(
 					unicodeProperties
 				).build(),
 				serviceContext);
-
-			_updateFriendlyURL(assetLibrary, group.getGroupId());
 
 			_updateDLSizeLimitConfiguration(
 				assetLibrary, group.getGroupId(), mimeTypeSizeLimits);

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -169,15 +169,20 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo("LPD-102154")
+	@TestInfo({"LPD-99972", "LPD-102154"})
 	public void testPatchAssetLibrary() throws Exception {
 		super.testPatchAssetLibrary();
 
 		_testPatchAssetLibraryPermissions();
 		_testPatchAssetLibrarySettings();
-		_testPatchAssetLibraryFriendlyURL();
 		_testPatchAssetLibraryFriendlyURLValidation();
 		_testPatchAssetLibraryWithoutUpdatePermission();
+		_testPatchAssetLibraryName();
+		_testPatchAssetLibraryFriendlyURLUnchanged();
+		_testPatchAssetLibraryFriendlyURLChanged();
+		_testPatchAssetLibraryNameAndFriendlyURLUnchanged();
+		_testPatchAssetLibraryNameAndFriendlyURLChanged();
+		_testPatchAssetLibraryExternalReferenceCodeAndFriendlyURL();
 	}
 
 	@Override
@@ -196,6 +201,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 				}
 			});
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
+		_testPostAssetLibraryFriendlyURL();
 		_testPostAssetLibraryWithDuplicateExternalReferenceCode();
 		_testPostAssetLibraryWithExternalReferenceCode();
 		_testPostAssetLibraryWithMissingTrashEntriesMaxAge();
@@ -435,6 +441,28 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		return assetLibraryResource.postAssetLibrary(randomAssetLibrary());
 	}
 
+	private void _assertFriendlyURLAndName(
+			AssetLibrary assetLibrary, String expectedFriendlyURL,
+			String expectedName, AssetLibrary patchAssetLibrary)
+		throws Exception {
+
+		AssetLibrary patchedAssetLibrary =
+			assetLibraryResource.patchAssetLibrary(
+				assetLibrary.getExternalReferenceCode(), patchAssetLibrary);
+
+		Assert.assertEquals(
+			expectedFriendlyURL, patchedAssetLibrary.getFriendlyURL());
+		Assert.assertEquals(expectedName, patchedAssetLibrary.getName());
+
+		AssetLibrary persistedAssetLibrary =
+			assetLibraryResource.getAssetLibrary(
+				assetLibrary.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			expectedFriendlyURL, persistedAssetLibrary.getFriendlyURL());
+		Assert.assertEquals(expectedName, persistedAssetLibrary.getName());
+	}
+
 	private void _assertFriendlyURLValidationFailure(
 			String friendlyURL, String expectedType)
 		throws Exception {
@@ -580,22 +608,67 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		return assetLibrary;
 	}
 
-	private void _testPatchAssetLibraryFriendlyURL() throws Exception {
+	private String _randomFriendlyURL() {
+		return StringUtil.toLowerCase("/" + RandomTestUtil.randomString());
+	}
+
+	private void _testPatchAssetLibraryExternalReferenceCodeAndFriendlyURL()
+		throws Exception {
+
 		AssetLibrary assetLibrary = _addAssetLibrary();
 
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String friendlyURL = _randomFriendlyURL();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setExternalReferenceCode(externalReferenceCode);
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+
+		AssetLibrary patchedAssetLibrary =
+			assetLibraryResource.patchAssetLibrary(
+				assetLibrary.getExternalReferenceCode(), patchAssetLibrary);
+
 		Assert.assertEquals(
-			"/asset-library-" + assetLibrary.getId(),
-			assetLibrary.getFriendlyURL());
+			externalReferenceCode,
+			patchedAssetLibrary.getExternalReferenceCode());
+		Assert.assertEquals(friendlyURL, patchedAssetLibrary.getFriendlyURL());
 
-		String customFriendlyURL = StringUtil.toLowerCase(
-			"/cms-friendly-url-" + RandomTestUtil.randomString());
+		AssetLibrary persistedAssetLibrary =
+			assetLibraryResource.getAssetLibrary(externalReferenceCode);
 
-		assetLibrary.setFriendlyURL(customFriendlyURL);
+		Assert.assertEquals(
+			friendlyURL, persistedAssetLibrary.getFriendlyURL());
+		Assert.assertEquals(
+			assetLibrary.getName(), persistedAssetLibrary.getName());
+	}
 
-		assetLibrary = assetLibraryResource.patchAssetLibrary(
-			assetLibrary.getExternalReferenceCode(), assetLibrary);
+	private void _testPatchAssetLibraryFriendlyURLChanged() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
 
-		Assert.assertEquals(customFriendlyURL, assetLibrary.getFriendlyURL());
+		String friendlyURL = _randomFriendlyURL();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, assetLibrary.getName(),
+			patchAssetLibrary);
+	}
+
+	private void _testPatchAssetLibraryFriendlyURLUnchanged() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String friendlyURL = assetLibrary.getFriendlyURL();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, assetLibrary.getName(),
+			patchAssetLibrary);
 	}
 
 	private void _testPatchAssetLibraryFriendlyURLValidation()
@@ -622,6 +695,55 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 		_assertFriendlyURLValidationFailure(
 			existingFriendlyURL, "FRIENDLY_URL_DUPLICATE");
+	}
+
+	private void _testPatchAssetLibraryName() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String name = RandomTestUtil.randomString();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setName(name);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, assetLibrary.getFriendlyURL(), name,
+			patchAssetLibrary);
+	}
+
+	private void _testPatchAssetLibraryNameAndFriendlyURLChanged()
+		throws Exception {
+
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String friendlyURL = _randomFriendlyURL();
+		String name = RandomTestUtil.randomString();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+		patchAssetLibrary.setName(name);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, name, patchAssetLibrary);
+	}
+
+	private void _testPatchAssetLibraryNameAndFriendlyURLUnchanged()
+		throws Exception {
+
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		String friendlyURL = assetLibrary.getFriendlyURL();
+
+		String name = RandomTestUtil.randomString();
+
+		AssetLibrary patchAssetLibrary = new AssetLibrary();
+
+		patchAssetLibrary.setFriendlyURL(friendlyURL);
+		patchAssetLibrary.setName(name);
+
+		_assertFriendlyURLAndName(
+			assetLibrary, friendlyURL, name, patchAssetLibrary);
 	}
 
 	private void _testPatchAssetLibraryPermissions() throws Exception {
@@ -826,6 +948,14 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			trashEnabled, trashEntriesMaxAge, useCustomLanguages);
 
 		_assertGroupDepotEntryType(assetLibrary);
+	}
+
+	private void _testPostAssetLibraryFriendlyURL() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		Assert.assertEquals(
+			"/asset-library-" + assetLibrary.getId(),
+			assetLibrary.getFriendlyURL());
 	}
 
 	private void _testPostAssetLibraryWithDuplicateExternalReferenceCode()

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -2214,7 +2214,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 							PortletKeys.TRANSLATION),
 						true)
 				).build(),
-				unicodeProperties, serviceContext);
+				null, unicodeProperties, serviceContext);
 
 			Group scopeGroup = serviceContext.getScopeGroup();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99972

## What Is Being Fixed

Patching an asset library returns HTTP 500 whenever the request carries a genuine friendly URL change, so editing a Space friendly URL is broken in the standalone CMS.

`AssetLibraryResourceImpl._addOrUpdateDepotEntry` wrote the group more than once per request, each write in its own transaction. `GroupLocalServiceImpl.updateFriendlyURL` then merged a group whose `mvccVersion` was already behind the row, and Hibernate raised a `StaleObjectStateException`. Hibernate only issues the versioned UPDATE when the merged entity is actually dirty, which is why the failure looked input dependent: it appeared only when the second write carried a real field change.

That is also why the earlier attempt under LPD-98285 did not work. Reordering the two writes only chose which payload was the dirty one, so it fixed a changed friendly URL and broke every Space rename instead. It was reverted, which returned this defect to master.

LPD-102886 reports the same defect from the log side, where the stale group error fails `AssetLibraryResourceTest` instead of surfacing as the 500. It is closed as a duplicate of this ticket, and the run recorded below logs none of those errors.

## How It Is Being Fixed

The extra write is removed rather than reordered. `DepotEntryLocalServiceImpl.updateDepotEntry` already forwarded a friendly URL into `GroupLocalServiceImpl.updateGroup`, but it forwarded the group's current value. It now takes the caller's value instead, so the friendly URL rides the group write that already happens and `_updateFriendlyURL` leaves the patch path entirely.

The `friendlyURL` argument was added to the existing `updateDepotEntry` on both `DepotEntryLocalService` and `DepotEntryService` rather than introduced as a new overload, so there is one signature to maintain. A caller with no friendly URL to supply passes null, and the service resolves null to the group's current value inside the write transaction, immediately before the single group write. `EditDepotEntryMVCActionCommand` and `BundleSiteInitializer` take that path.

`AssetLibraryResourceImpl` forwards the payload's friendly URL straight through rather than filling the argument itself, so a patch that omits it forwards null and the resolution happens in the service. Forwarding the group instance the resource read earlier would turn every name only patch into a friendly URL write, and open a window where a concurrent rename is reverted without an error. Resolving null in the service also matters because `GroupLocalServiceImpl.getFriendlyURL` treats a blank friendly URL as a request to generate a default one, so forwarding a blank value from the resource would silently rewrite the URL rather than leave it alone.

Removing the previous signature makes this a breaking change. `com.liferay.depot.service` goes to 4.0.0 and `depot-api` to 13.0.0, both set by the baseline tooling, and the `Baseline` commit message carries the `# breaking` block that `PackageinfoBreakingChangeCommitMessageCheck` requires. Deployed consumers still resolve, because Liferay generates unbounded import ranges: consumer jars import `com.liferay.depot.service;version="3.4"`, which 4.0.0 satisfies.

Validation behaviour is unchanged. `updateGroup` runs the same `getFriendlyURL` and `validateFriendlyURL` pair that `updateFriendlyURL` ran, so the same `GroupFriendlyURLException` subtypes still surface as `BAD_REQUEST`.

Collapsing the two writes into one also makes the patch atomic. A valid name combined with an invalid friendly URL used to persist the rename and then return `BAD_REQUEST`, because the two writes were two transactions. `validateFriendlyURL` now runs before the single `groupPersistence.update`, so a rejected request leaves nothing behind.

Changing the external reference code and the friendly URL in the same request still performs two group writes, through the external reference code branch added under LPD-98285, and it succeeds. The write that failed was the third one, `_updateFriendlyURL`, and removing it takes that failure with it. Two writes only break when the second merges an instance already behind the row.

## Tests

`AssetLibraryResourceTest` previously exercised only two of the five name and friendly URL payload permutations, which is why the rename regression reached master unnoticed. It now covers all five: name alone, an unchanged friendly URL alone, a changed friendly URL alone, and name combined with each. A sixth case pins the external reference code changing alongside the friendly URL, the permutation that still performs two group writes. Each asserts the patch response and a follow up read, so a write that does not persist cannot pass.

The two combined permutations are the regression guards for this ticket's history. Name with a changed friendly URL is the failure fixed here; name with an unchanged friendly URL is the Space rename that the reverted commit broke.

The assertion that a new asset library receives the generated `/asset-library-<id>` moved to `testPostAssetLibrary`, where the behaviour it describes belongs.

The branch rebases over LPD-102154, which added its own scenarios to the same `testPatchAssetLibrary` dispatcher. The dispatcher carries both sets, and that ticket's friendly URL validation case passes against the collapsed write, so the two fixes hold together.

## Test Execution

```bash
gradlew -p modules/apps/headless/headless-asset-library/headless-asset-library-test \
	testIntegration --tests AssetLibraryResourceTest

gradlew -p modules/apps/depot/depot-test testIntegration --tests DepotEntryLocalServiceTest

gradlew -p modules/apps/depot/depot-test testIntegration --tests DepotEntryServiceTest
```

The Space rename path was also verified through Playwright:

```bash
cd modules/test/playwright && yarn test \
	tests/e2e-cms-dxp/main/space-configuration/spaceConfiguration.spec.ts \
	--project=e2e-cms-dxp.main -g "rename a Space"
```

## PR Check

**pr-check: PASS** — tested on `eea1dc18230730edf4dda0ab54cdad602758be45`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Baseline: the run reported a bump owed by `export-import-test-util`, a module this branch does not touch. `com.liferay.exportimport.test.util` goes to 2.1.0 and its bundle to 12.1.0, owed since LPD-100541 added six public methods to the exported package without one. Both are minor, so they are carried here as `LPD-99972 Semantic versioning` rather than left to fail the check.

Cross-Module Compile: the symbol expansion exceeded the eight module cap, at 50 testIntegration consumers of `DepotEntryLocalService`, so a full `ant all` over this tree stood in for it and compiled every one of them rather than a sampled subset.

Java Unit Tests: no changed class has a counterpart unit test, so there was nothing to run.

<!-- pr-check {"result": "success", "sha": "eea1dc18230730edf4dda0ab54cdad602758be45"} -->
