### PR TITLE
LPD-103010 Clean up temporary file entries in publications

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
@@ -5,20 +5,26 @@
 
 package com.liferay.document.library.internal.repository.capabilities;
 
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.model.CTCollectionModel;
+import com.liferay.change.tracking.service.CTCollectionLocalServiceUtil;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppHelperLocalServiceUtil;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.repository.DocumentRepository;
 import com.liferay.portal.kernel.repository.capabilities.BulkOperationCapability;
 import com.liferay.portal.kernel.repository.capabilities.ConfigurationCapability;
@@ -31,6 +37,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -104,25 +111,51 @@ public class TemporaryFileEntriesCapabilityImpl
 
 	@Override
 	public void deleteExpiredTemporaryFileEntries() throws PortalException {
-		BulkOperationCapability bulkOperationCapability =
-			_documentRepository.getCapability(BulkOperationCapability.class);
+		Folder folder = _documentRepository.getFolder(
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-		BulkOperationCapability.Filter<Date> bulkFilter =
-			new BulkOperationCapability.Filter<>(
-				BulkOperationCapability.Field.CreateDate.class,
-				BulkOperationCapability.Operator.LT,
-				new Date(
-					System.currentTimeMillis() -
-						getTemporaryFileEntriesTimeout()));
+		List<Long> ctCollectionIds = ListUtil.toList(
+			_getPublicationCTCollections(folder.getCompanyId()),
+			CTCollectionModel::getCtCollectionId);
 
-		_runWithoutSystemEvents(
-			() -> {
-				bulkOperationCapability.execute(
-					bulkFilter,
-					new DeleteExpiredTemporaryFilesRepositoryModelOperation());
+		ctCollectionIds.add(
+			CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION);
 
-				return null;
-			});
+		for (long ctCollectionId : ctCollectionIds) {
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						ctCollectionId)) {
+
+				BulkOperationCapability bulkOperationCapability =
+					_documentRepository.getCapability(
+						BulkOperationCapability.class);
+
+				BulkOperationCapability.Filter<Date> bulkFilter =
+					new BulkOperationCapability.Filter<>(
+						BulkOperationCapability.Field.CreateDate.class,
+						BulkOperationCapability.Operator.LT,
+						new Date(
+							System.currentTimeMillis() -
+								getTemporaryFileEntriesTimeout()));
+
+				_runWithoutSystemEvents(
+					() -> {
+						bulkOperationCapability.execute(
+							bulkFilter,
+							new DeleteExpiredTemporaryFilesRepositoryModelOperation());
+
+						return null;
+					});
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to delete expired temporary file entries in " +
+							"change tracking collection " + ctCollectionId,
+						portalException);
+				}
+			}
+		}
 	}
 
 	@Override
@@ -297,6 +330,16 @@ public class TemporaryFileEntriesCapabilityImpl
 			temporaryFileEntriesScope.getFolderPath());
 	}
 
+	private List<CTCollection> _getPublicationCTCollections(long companyId) {
+		return CTCollectionLocalServiceUtil.getCTCollections(
+			companyId,
+			new int[] {
+				WorkflowConstants.STATUS_DRAFT,
+				WorkflowConstants.STATUS_SCHEDULED
+			},
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
 	private Folder _getTempFolder(
 			TemporaryFileEntriesScope temporaryFileEntriesScope)
 		throws PortalException {
@@ -309,6 +352,17 @@ public class TemporaryFileEntriesCapabilityImpl
 		return _getDeepestFolder(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			_getFolderPath(temporaryFileEntriesScope));
+	}
+
+	private boolean _isOwnedByCurrentCTCollection(Object model) {
+		if (!(model instanceof CTModel<?> ctModel) ||
+			(ctModel.getCtCollectionId() ==
+				CTCollectionThreadLocal.getCTCollectionId())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _runWithoutSystemEvents(
@@ -343,6 +397,10 @@ public class TemporaryFileEntriesCapabilityImpl
 
 		@Override
 		public void execute(FileEntry fileEntry) throws PortalException {
+			if (!_isOwnedByCurrentCTCollection(fileEntry.getModel())) {
+				return;
+			}
+
 			DLAppHelperLocalServiceUtil.deleteFileEntry(fileEntry);
 
 			_documentRepository.deleteFileEntry(fileEntry.getFileEntryId());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
@@ -354,6 +354,28 @@ public class TemporaryFileEntriesCapabilityImpl
 			_getFolderPath(temporaryFileEntriesScope));
 	}
 
+	private boolean _hasPublicationFileEntries(long companyId, long folderId)
+		throws PortalException {
+
+		for (CTCollection ctCollection :
+				_getPublicationCTCollections(companyId)) {
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						ctCollection.getCtCollectionId())) {
+
+				int count = _documentRepository.getFileEntriesCount(
+					folderId, WorkflowConstants.STATUS_ANY);
+
+				if (count != 0) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	private boolean _isOwnedByCurrentCTCollection(Object model) {
 		if (!(model instanceof CTModel<?> ctModel) ||
 			(ctModel.getCtCollectionId() ==
@@ -417,6 +439,17 @@ public class TemporaryFileEntriesCapabilityImpl
 					folderId, WorkflowConstants.STATUS_ANY);
 
 				if (count != 0) {
+					break;
+				}
+
+				if (CTCollectionThreadLocal.isProductionMode()) {
+					if (_hasPublicationFileEntries(
+							folder.getCompanyId(), folderId)) {
+
+						break;
+					}
+				}
+				else if (!_isOwnedByCurrentCTCollection(folder.getModel())) {
 					break;
 				}
 

--- a/modules/apps/repository/repository-test/build.gradle
+++ b/modules/apps/repository/repository-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-db-partition-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/capabilities/test/TemporaryFileEntriesCapabilityTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/capabilities/test/TemporaryFileEntriesCapabilityTest.java
@@ -6,9 +6,13 @@
 package com.liferay.repository.capabilities.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.User;
@@ -21,15 +25,18 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.InputStream;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import org.junit.Assert;
@@ -58,41 +65,102 @@ public class TemporaryFileEntriesCapabilityTest {
 
 	@Test
 	public void testDeleteExpiredTemporaryFileEntries() throws Exception {
-		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
-			_group.getGroupId(), _user.getUserId(),
-			RandomTestUtil.randomString(), "image.jpg", getInputStream(),
-			ContentTypes.IMAGE_JPEG);
+		_addExpiredTempFileEntry(RandomTestUtil.randomString(), "image.jpg");
 
-		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
-			fileEntry.getFileEntryId());
-
-		dlFileEntry.setCreateDate(
-			new Date(System.currentTimeMillis() - Time.WEEK));
-
-		DLFileEntryLocalServiceUtil.updateDLFileEntry(dlFileEntry);
-
-		Repository repository = RepositoryLocalServiceUtil.fetchRepository(
-			_group.getGroupId(), TempFileEntryUtil.class.getName(),
-			TempFileEntryUtil.class.getName());
-
-		LocalRepository localRepository =
-			RepositoryProviderUtil.getLocalRepository(
-				repository.getRepositoryId());
+		LocalRepository localRepository = _getLocalRepository();
 
 		int foldersAndFileEntriesAndFileShortcutsCount =
 			getFoldersAndFileEntriesAndFileShortcutsCount(localRepository);
 
 		Assert.assertTrue(foldersAndFileEntriesAndFileShortcutsCount > 0);
 
-		TemporaryFileEntriesCapability temporaryFileEntriesCapability =
-			localRepository.getCapability(TemporaryFileEntriesCapability.class);
-
-		temporaryFileEntriesCapability.setTemporaryFileEntriesTimeout(Time.DAY);
-
-		temporaryFileEntriesCapability.deleteExpiredTemporaryFileEntries();
+		_deleteExpiredTemporaryFileEntries(localRepository);
 
 		Assert.assertEquals(
 			0, getFoldersAndFileEntriesAndFileShortcutsCount(localRepository));
+	}
+
+	@Test
+	public void testDeleteExpiredTemporaryFileEntriesInPublication()
+		throws Exception {
+
+		String folderName = RandomTestUtil.randomString();
+
+		_addExpiredTempFileEntry(folderName, "image1.jpg");
+
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), _user.getUserId(), 0,
+			TemporaryFileEntriesCapabilityTest.class.getName(), null);
+
+		FileEntry fileEntry = null;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			fileEntry = _addExpiredTempFileEntry(folderName, "image2.jpg");
+		}
+
+		LocalRepository localRepository = _getLocalRepository();
+
+		_deleteExpiredTemporaryFileEntries(localRepository);
+
+		Assert.assertEquals(
+			0, getFoldersAndFileEntriesAndFileShortcutsCount(localRepository));
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			Assert.assertNull(
+				DLFileEntryLocalServiceUtil.fetchDLFileEntry(
+					fileEntry.getFileEntryId()));
+			Assert.assertEquals(
+				0,
+				getFoldersAndFileEntriesAndFileShortcutsCount(localRepository));
+		}
+	}
+
+	@Test
+	public void testDeleteExpiredTemporaryFileEntriesWhenPublicationFileEntryIsNotExpired()
+		throws Exception {
+
+		String folderName = RandomTestUtil.randomString();
+
+		_addExpiredTempFileEntry(folderName, "image1.jpg");
+
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), _user.getUserId(), 0,
+			TemporaryFileEntriesCapabilityTest.class.getName(), null);
+
+		String fileName = "image2.jpg";
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			TempFileEntryUtil.addTempFileEntry(
+				_group.getGroupId(), _user.getUserId(), folderName, fileName,
+				getInputStream(), ContentTypes.IMAGE_JPEG);
+		}
+
+		_deleteExpiredTemporaryFileEntries(_getLocalRepository());
+
+		String[] tempFileNames = TempFileEntryUtil.getTempFileNames(
+			_group.getGroupId(), _user.getUserId(), folderName);
+
+		Assert.assertEquals(
+			Arrays.toString(tempFileNames), 0, tempFileNames.length);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			FileEntry fileEntry = TempFileEntryUtil.getTempFileEntry(
+				_group.getGroupId(), _user.getUserId(), folderName, fileName);
+
+			Assert.assertEquals(fileName, fileEntry.getFileName());
+		}
 	}
 
 	protected int getFoldersAndFileEntriesAndFileShortcutsCount(
@@ -120,6 +188,52 @@ public class TemporaryFileEntriesCapabilityTest {
 		return classLoader.getResourceAsStream(
 			"com/liferay/portal/util/dependencies/test.jpg");
 	}
+
+	private FileEntry _addExpiredTempFileEntry(
+			String folderName, String fileName)
+		throws Exception {
+
+		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
+			_group.getGroupId(), _user.getUserId(), folderName, fileName,
+			getInputStream(), ContentTypes.IMAGE_JPEG);
+
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		dlFileEntry.setCreateDate(
+			new Date(System.currentTimeMillis() - Time.WEEK));
+
+		DLFileEntryLocalServiceUtil.updateDLFileEntry(dlFileEntry);
+
+		return fileEntry;
+	}
+
+	private void _deleteExpiredTemporaryFileEntries(
+			LocalRepository localRepository)
+		throws Exception {
+
+		TemporaryFileEntriesCapability temporaryFileEntriesCapability =
+			localRepository.getCapability(TemporaryFileEntriesCapability.class);
+
+		temporaryFileEntriesCapability.setTemporaryFileEntriesTimeout(Time.DAY);
+
+		temporaryFileEntriesCapability.deleteExpiredTemporaryFileEntries();
+	}
+
+	private LocalRepository _getLocalRepository() throws Exception {
+		Repository repository = RepositoryLocalServiceUtil.fetchRepository(
+			_group.getGroupId(), TempFileEntryUtil.class.getName(),
+			TempFileEntryUtil.class.getName());
+
+		return RepositoryProviderUtil.getLocalRepository(
+			repository.getRepositoryId());
+	}
+
+	@DeleteAfterTestRun
+	private CTCollection _ctCollection;
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103010

## What is this trying to solve?

The temporary file entry cleanup job runs pinned to production mode, so it never sees temporary file entries created inside publications — they accumulate forever. Worse, once production held no entries, the job hard-deleted the shared temporary folders while publications still had temporary file entries inside them. Publishing such a publication then fails with "Missing Requirement Conflict: Cannot be added because a required Documents Folder has been deleted.", even though Review Changes shows no changes at all (customer issue LPP-65228).

## How am I fixing it?

`TemporaryFileEntriesCapabilityImpl.deleteExpiredTemporaryFileEntries` now runs the existing cleanup once per draft or scheduled change tracking collection before the production pass. A publication pass reads the merged view, so entries not owned by the current collection are skipped — deleting a production row from a publication would only record a change tracking deletion. The folder walk gets two guards: the production pass keeps a folder while any draft or scheduled publication still has file entries in it, and a publication pass only deletes folders the publication itself owns. As a trade-off, a production-owned temporary folder can linger empty when a publication blocked its deletion, until a later production pass cleans it. The change tracking service is resolved lazily through `CTCollectionLocalServiceUtil` because a service component reference on `PortalCapabilityLocatorImpl` deadlocks the OSGi component graph at startup.

## How can you verify that it works?

Run `gradlew testIntegration --tests TemporaryFileEntriesCapabilityTest` in `modules/apps/repository/repository-test`. The two new tests fail without the fix: `testDeleteExpiredTemporaryFileEntriesInPublication` (the publication's expired entry is never deleted) and `testDeleteExpiredTemporaryFileEntriesWhenPublicationFileEntryIsNotExpired` (the folder chain is hard-deleted from under a live publication entry). The bug and the fix were also reproduced manually end to end: multi-file uploads abandoned inside a publication and in production, the scheduled job executed in production mode, and the publish screen going from four missing-requirement conflicts (unfixed) to "No unresolved conflicts, ready to publish" (fixed).

## PR Check

**pr-check: PASS** — tested on `b67d93e8d974a769c11bf4db8859c1284b3b4e95`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b67d93e8d974a769c11bf4db8859c1284b3b4e95"} -->
