### PR TITLE
LPD-102138 Prevent deleting a relationship of an unauthorized object

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -18,13 +18,23 @@ import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -170,7 +180,8 @@ public class UpdateStructureStrutsActionTest {
 		String name = StringUtil.randomId();
 
 		MockHttpServletRequest mockHttpServletRequest =
-			_getMockHttpServletRequest(_objectDefinition3);
+			_getMockHttpServletRequest(
+				_objectDefinition3, TestPropsValues.getUser());
 
 		mockHttpServletRequest.setParameter(
 			"objectRelationships",
@@ -239,7 +250,8 @@ public class UpdateStructureStrutsActionTest {
 			new MockHttpServletResponse();
 
 		_updateStructureStrutsAction.execute(
-			_getMockHttpServletRequest(_objectDefinition1),
+			_getMockHttpServletRequest(
+				_objectDefinition1, TestPropsValues.getUser()),
 			mockHttpServletResponse);
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
@@ -253,6 +265,72 @@ public class UpdateStructureStrutsActionTest {
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
 				objectRelationship.getObjectRelationshipId()));
+	}
+
+	@Test
+	@TestInfo("LPD-102138")
+	public void testExecuteDoesNotDeleteUnauthorizedObjectRelationships()
+		throws Exception {
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			_addEdgeObjectRelationship(_objectDefinition2, _objectDefinition3);
+
+		_user = UserTestUtil.addUser();
+
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(),
+			com.liferay.object.model.ObjectDefinition.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_objectDefinition1.getObjectDefinitionId()),
+			_role.getRoleId(),
+			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW});
+
+		_userLocalService.addRoleUser(_role.getRoleId(), _user.getUserId());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(_objectDefinition1, _user);
+
+		mockHttpServletRequest.setParameter(
+			"deletedObjectRelationships",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"objectDefinitionERC",
+					_objectDefinition2.getExternalReferenceCode()
+				).put(
+					"objectRelationshipERC",
+					objectRelationship.getExternalReferenceCode()
+				)
+			).toString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user)) {
+
+			_updateStructureStrutsAction.execute(
+				mockHttpServletRequest, mockHttpServletResponse);
+		}
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(
+			jsonObject.toString(), "PrincipalException.MustHavePermission",
+			jsonObject.getString("type"));
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+
+		_deleteEdgeObjectRelationship(objectRelationship);
 	}
 
 	private com.liferay.object.model.ObjectRelationship
@@ -293,7 +371,8 @@ public class UpdateStructureStrutsActionTest {
 	}
 
 	private MockHttpServletRequest _getMockHttpServletRequest(
-			com.liferay.object.model.ObjectDefinition objectDefinition)
+			com.liferay.object.model.ObjectDefinition objectDefinition,
+			User user)
 		throws Exception {
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -304,7 +383,7 @@ public class UpdateStructureStrutsActionTest {
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
 		themeDisplay.setLocale(LocaleUtil.US);
-		themeDisplay.setUser(TestPropsValues.getUser());
+		themeDisplay.setUser(user);
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -380,7 +459,19 @@ public class UpdateStructureStrutsActionTest {
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@DeleteAfterTestRun
+	private Role _role;
+
 	@Inject(filter = "path=/cms/update-structure")
 	private StrutsAction _updateStructureStrutsAction;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -150,38 +150,49 @@ public class UpdateStructureStrutsActionTest {
 	@Test
 	@TestInfo("LPD-99742")
 	public void testExecuteDeletesObjectRelationships() throws Exception {
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
 
-		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition3 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
 
-		com.liferay.object.model.ObjectRelationship objectRelationship1 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, _objectDefinition1,
-				_objectDefinition3,
-				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship1 =
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService,
+					_serviceBuilderObjectDefinition1,
+					_serviceBuilderObjectDefinition3,
+					ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
+					StringUtil.randomId(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		com.liferay.object.model.ObjectRelationship objectRelationship2 =
-			_addEdgeObjectRelationship(_objectDefinition1, _objectDefinition3);
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship2 = _addEdgeObjectRelationship(
+				_serviceBuilderObjectDefinition1,
+				_serviceBuilderObjectDefinition3);
 
-		com.liferay.object.model.ObjectRelationship objectRelationship3 =
-			_addEdgeObjectRelationship(_objectDefinition3, _objectDefinition2);
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship3 = _addEdgeObjectRelationship(
+				_serviceBuilderObjectDefinition3,
+				_serviceBuilderObjectDefinition2);
 
-		com.liferay.object.model.ObjectRelationship objectRelationship4 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, _objectDefinition1,
-				_objectDefinition3,
-				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship4 =
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService,
+					_serviceBuilderObjectDefinition1,
+					_serviceBuilderObjectDefinition3,
+					ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
+					StringUtil.randomId(),
+					ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		String name = StringUtil.randomId();
 
 		MockHttpServletRequest mockHttpServletRequest =
 			_getMockHttpServletRequest(
-				_objectDefinition3, TestPropsValues.getUser());
+				_serviceBuilderObjectDefinition3, TestPropsValues.getUser());
 
 		mockHttpServletRequest.setParameter(
 			"objectRelationships",
@@ -193,10 +204,10 @@ public class UpdateStructureStrutsActionTest {
 					"name", name
 				).put(
 					"objectDefinitionExternalReferenceCode1",
-					_objectDefinition2.getExternalReferenceCode()
+					_serviceBuilderObjectDefinition2.getExternalReferenceCode()
 				).put(
 					"objectDefinitionExternalReferenceCode2",
-					_objectDefinition3.getExternalReferenceCode()
+					_serviceBuilderObjectDefinition3.getExternalReferenceCode()
 				).put(
 					"type", ObjectRelationshipConstants.TYPE_ONE_TO_MANY
 				)
@@ -215,43 +226,48 @@ public class UpdateStructureStrutsActionTest {
 
 		Assert.assertNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship1.getObjectRelationshipId()));
+				serviceBuilderObjectRelationship1.getObjectRelationshipId()));
 
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.
 				fetchObjectRelationshipByObjectDefinitionId(
-					_objectDefinition3.getObjectDefinitionId(), name));
+					_serviceBuilderObjectDefinition3.getObjectDefinitionId(),
+					name));
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship2.getObjectRelationshipId()));
+				serviceBuilderObjectRelationship2.getObjectRelationshipId()));
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship4.getObjectRelationshipId()));
+				serviceBuilderObjectRelationship4.getObjectRelationshipId()));
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship3.getObjectRelationshipId()));
+				serviceBuilderObjectRelationship3.getObjectRelationshipId()));
 
-		_deleteEdgeObjectRelationship(objectRelationship2);
-		_deleteEdgeObjectRelationship(objectRelationship3);
+		_deleteEdgeObjectRelationship(serviceBuilderObjectRelationship2);
+		_deleteEdgeObjectRelationship(serviceBuilderObjectRelationship3);
 	}
 
 	@Test
 	@TestInfo("LPD-92696")
 	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
 
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, _objectDefinition1,
-				_objectDefinition2);
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship =
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService,
+					_serviceBuilderObjectDefinition1,
+					_serviceBuilderObjectDefinition2);
 
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();
 
 		_updateStructureStrutsAction.execute(
 			_getMockHttpServletRequest(
-				_objectDefinition1, TestPropsValues.getUser()),
+				_serviceBuilderObjectDefinition1, TestPropsValues.getUser()),
 			mockHttpServletResponse);
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
@@ -261,10 +277,10 @@ public class UpdateStructureStrutsActionTest {
 
 		Assert.assertNotNull(
 			_objectFieldLocalService.fetchObjectField(
-				objectRelationship.getObjectFieldId2()));
+				serviceBuilderObjectRelationship.getObjectFieldId2()));
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
+				serviceBuilderObjectRelationship.getObjectRelationshipId()));
 	}
 
 	@Test
@@ -272,13 +288,18 @@ public class UpdateStructureStrutsActionTest {
 	public void testExecuteDoesNotDeleteUnauthorizedObjectRelationships()
 		throws Exception {
 
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
 
-		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_serviceBuilderObjectDefinition3 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
 
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			_addEdgeObjectRelationship(_objectDefinition2, _objectDefinition3);
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship = _addEdgeObjectRelationship(
+				_serviceBuilderObjectDefinition2,
+				_serviceBuilderObjectDefinition3);
 
 		_user = UserTestUtil.addUser();
 
@@ -288,24 +309,25 @@ public class UpdateStructureStrutsActionTest {
 			TestPropsValues.getCompanyId(),
 			com.liferay.object.model.ObjectDefinition.class.getName(),
 			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(_objectDefinition1.getObjectDefinitionId()),
+			String.valueOf(
+				_serviceBuilderObjectDefinition1.getObjectDefinitionId()),
 			_role.getRoleId(),
 			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW});
 
 		_userLocalService.addRoleUser(_role.getRoleId(), _user.getUserId());
 
 		MockHttpServletRequest mockHttpServletRequest =
-			_getMockHttpServletRequest(_objectDefinition1, _user);
+			_getMockHttpServletRequest(_serviceBuilderObjectDefinition1, _user);
 
 		mockHttpServletRequest.setParameter(
 			"deletedObjectRelationships",
 			JSONUtil.putAll(
 				JSONUtil.put(
 					"objectDefinitionERC",
-					_objectDefinition2.getExternalReferenceCode()
+					_serviceBuilderObjectDefinition2.getExternalReferenceCode()
 				).put(
 					"objectRelationshipERC",
-					objectRelationship.getExternalReferenceCode()
+					serviceBuilderObjectRelationship.getExternalReferenceCode()
 				)
 			).toString());
 
@@ -328,50 +350,58 @@ public class UpdateStructureStrutsActionTest {
 
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
+				serviceBuilderObjectRelationship.getObjectRelationshipId()));
 
-		_deleteEdgeObjectRelationship(objectRelationship);
+		_deleteEdgeObjectRelationship(serviceBuilderObjectRelationship);
 	}
 
 	private com.liferay.object.model.ObjectRelationship
 			_addEdgeObjectRelationship(
-				com.liferay.object.model.ObjectDefinition objectDefinition1,
-				com.liferay.object.model.ObjectDefinition objectDefinition2)
+				com.liferay.object.model.ObjectDefinition
+					serviceBuilderObjectDefinition1,
+				com.liferay.object.model.ObjectDefinition
+					serviceBuilderObjectDefinition2)
 		throws Exception {
 
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				objectDefinition1.getObjectDefinitionId(),
-				objectDefinition2.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship =
+				_objectRelationshipLocalService.addObjectRelationship(
+					null, TestPropsValues.getUserId(),
+					serviceBuilderObjectDefinition1.getObjectDefinitionId(),
+					serviceBuilderObjectDefinition2.getObjectDefinitionId(), 0,
+					ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString()),
+					StringUtil.randomId(), false,
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
 
-		Assert.assertTrue(objectRelationship.isEdge());
+		Assert.assertTrue(serviceBuilderObjectRelationship.isEdge());
 
-		return objectRelationship;
+		return serviceBuilderObjectRelationship;
 	}
 
 	private void _deleteEdgeObjectRelationship(
-			com.liferay.object.model.ObjectRelationship objectRelationship)
+			com.liferay.object.model.ObjectRelationship
+				serviceBuilderObjectRelationship)
 		throws Exception {
 
-		com.liferay.object.model.ObjectRelationship updatedObjectRelationship =
-			_objectRelationshipLocalService.updateObjectRelationship(
-				objectRelationship.getExternalReferenceCode(),
-				objectRelationship.getObjectRelationshipId(),
-				objectRelationship.getParameterObjectFieldId(),
-				objectRelationship.getDeletionType(), false,
-				objectRelationship.getLabelMap(), null);
+		com.liferay.object.model.ObjectRelationship
+			updatedServiceBuilderObjectRelationship =
+				_objectRelationshipLocalService.updateObjectRelationship(
+					serviceBuilderObjectRelationship.getExternalReferenceCode(),
+					serviceBuilderObjectRelationship.getObjectRelationshipId(),
+					serviceBuilderObjectRelationship.
+						getParameterObjectFieldId(),
+					serviceBuilderObjectRelationship.getDeletionType(), false,
+					serviceBuilderObjectRelationship.getLabelMap(), null);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
-			updatedObjectRelationship);
+			updatedServiceBuilderObjectRelationship);
 	}
 
 	private MockHttpServletRequest _getMockHttpServletRequest(
-			com.liferay.object.model.ObjectDefinition objectDefinition,
+			com.liferay.object.model.ObjectDefinition
+				serviceBuilderObjectDefinition,
 			User user)
 		throws Exception {
 
@@ -390,7 +420,8 @@ public class UpdateStructureStrutsActionTest {
 
 		mockHttpServletRequest.setParameter(
 			"objectDefinition",
-			_getObjectDefinitionJSON(objectDefinition.getObjectDefinitionId()));
+			_getObjectDefinitionJSON(
+				serviceBuilderObjectDefinition.getObjectDefinitionId()));
 
 		return mockHttpServletRequest;
 	}
@@ -438,15 +469,6 @@ public class UpdateStructureStrutsActionTest {
 	@Inject
 	private JSONFactory _jsonFactory;
 
-	@DeleteAfterTestRun
-	private com.liferay.object.model.ObjectDefinition _objectDefinition1;
-
-	@DeleteAfterTestRun
-	private com.liferay.object.model.ObjectDefinition _objectDefinition2;
-
-	@DeleteAfterTestRun
-	private com.liferay.object.model.ObjectDefinition _objectDefinition3;
-
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
@@ -464,6 +486,18 @@ public class UpdateStructureStrutsActionTest {
 
 	@DeleteAfterTestRun
 	private Role _role;
+
+	@DeleteAfterTestRun
+	private com.liferay.object.model.ObjectDefinition
+		_serviceBuilderObjectDefinition1;
+
+	@DeleteAfterTestRun
+	private com.liferay.object.model.ObjectDefinition
+		_serviceBuilderObjectDefinition2;
+
+	@DeleteAfterTestRun
+	private com.liferay.object.model.ObjectDefinition
+		_serviceBuilderObjectDefinition3;
 
 	@Inject(filter = "path=/cms/update-structure")
 	private StrutsAction _updateStructureStrutsAction;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -13,6 +13,7 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -301,6 +302,9 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 	private ObjectRelationshipResource.Factory
 		_objectRelationshipResourceFactory;
 
+	@Reference
+	private ObjectRelationshipService _objectRelationshipService;
+
 	private class UpdateStructureCallable implements Callable<Void> {
 
 		@Override
@@ -334,25 +338,22 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 									objectDefinition.getObjectDefinitionId());
 
 					if (serviceBuilderObjectRelationship.isEdge()) {
-						serviceBuilderObjectRelationship =
-							_objectRelationshipLocalService.
-								updateObjectRelationship(
-									serviceBuilderObjectRelationship.
-										getExternalReferenceCode(),
-									serviceBuilderObjectRelationship.
-										getObjectRelationshipId(),
-									serviceBuilderObjectRelationship.
-										getParameterObjectFieldId(),
-									serviceBuilderObjectRelationship.
-										getDeletionType(),
-									false,
-									serviceBuilderObjectRelationship.
-										getLabelMap(),
-									null);
+						_objectRelationshipService.updateObjectRelationship(
+							serviceBuilderObjectRelationship.
+								getExternalReferenceCode(),
+							serviceBuilderObjectRelationship.
+								getObjectRelationshipId(),
+							serviceBuilderObjectRelationship.
+								getParameterObjectFieldId(),
+							serviceBuilderObjectRelationship.getDeletionType(),
+							false,
+							serviceBuilderObjectRelationship.getLabelMap(),
+							null);
 					}
 
-					_objectRelationshipLocalService.deleteObjectRelationship(
-						serviceBuilderObjectRelationship);
+					_objectRelationshipService.deleteObjectRelationship(
+						serviceBuilderObjectRelationship.
+							getObjectRelationshipId());
 				}
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102138

## What Is Being Fixed

`/c/cms/update-structure` deleted and updated object relationships through `ObjectRelationshipLocalService`, using an object definition identifier taken from the request body, so no permission was checked on the definition the request named. Both calls now go through the permission-checking remote service. The ticket carries the details.

## How It Is Being Fixed

Validating that the named definition is the one being updated is not viable. `StructureService.ts` sends one entry per relationship with `objectDefinitionERC` set to `relationship.structureERC`, and `updateHistory.ts` shows that value is legitimately the main structure, a child node's external reference code, or `child.relatedStructureERC`. There is no single owner to compare the request against.

Both mutating calls in the loop move instead to `ObjectRelationshipService`, the permission-checking remote layer. `deleteObjectRelationship` and `updateObjectRelationship` each check UPDATE on `objectRelationship.getObjectDefinitionId1()`, and the relationship is looked up with `findByERC_C_ODI1`, so that side is exactly the definition the request named. The check therefore lands on the named target itself rather than on a proxy for it.

The remote signatures line up with what the loop already passed: `updateObjectRelationship` takes the same seven arguments, and `deleteObjectRelationship` takes the relationship id where the local call passed the relationship. The permission checker is available where the loop runs — the same method already deletes repeatable groups through `ObjectDefinitionService`, and `TransactionInvokerUtil.invoke` runs the callable on the caller's thread.

One call in the same class deliberately stays on the local service. `_deleteRelationships` deletes the inbound one-to-many relationships of the structure being updated, and its object definition id comes from that structure's own external reference code rather than from the request. Migrating it would also change the action's effective permission: those relationships are found by `objectDefinitionId2`, so the remote check would test UPDATE on the other side of each relationship — a different definition than the one being updated — and could reject a user who can legitimately update their own structure.

The test grants the acting user UPDATE and VIEW on the structure it legitimately updates and nothing on a second object definition, then has the request name the second definition's relationship. Granting the legitimate half is what makes the test meaningful. The callable is configured with `rollbackFor = Exception.class`, so a caller holding no permission at all would have the change undone by the rollback and the test would pass with the defect still present. Verified by reverting the fix and re-running, where the test fails. The three pre-existing tests in the class cover the legitimate path and still pass, which is what shows the migration does not reject a caller who owns the structure. Beyond them, `DeleteStructureStrutsActionTest`, `GetObjectEntriesValuesStrutsActionTest`, `UpdateObjectValuesBulkSelectionActionTest` and `CMSObjectRelationshipEdgeUpgradeProcessTest` pass, the last covering the edge relationships the migrated update branch handles, and the Playwright specs `relatedContent.spec.ts`, `referencedStructures.spec.ts` and `repeatableGroups.spec.ts` pass, walking the same deletion through the UI as an administrator.

## What Changed Since The Previous Pull Request

`brianchandotcom#180401` was closed with "we have a pattern for this" over the `ObjectRelationship` local in the new test. The file imports the object admin REST DTOs `ObjectDefinition` and `ObjectRelationship`, so a local holding the ServiceBuilder model of the same simple name carries a `serviceBuilder` lead — which `testExecute` has done since LPD-77022, while the tests added after it use the bare name. The third commit applies that name across the file rather than to the new test alone, so the file is left with one form. It is a rename only: every string literal is byte identical to the previous head, and `gw compileTestIntegrationJava` passes.

## PR Check

**pr-check: PASS** — tested on `bd7647779ad597bc06ccf08d4db3e0b0bd458a24`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline reported four version changes and none belong to this branch: `export-import-test-util` and two lowered `portal-kernel` packageinfos. This branch changes two files under `site-cms-site-initializer`, which cannot alter those packages, so they are master drift and were not committed here.

<!-- pr-check {"result": "success", "sha": "bd7647779ad597bc06ccf08d4db3e0b0bd458a24"} -->