### PR TITLE
LPD-102710 Stop applying filters hidden by an item type change

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
@@ -65,7 +65,7 @@
 				/>
 			</div>
 
-			<div id="<portlet:namespace />assetFilterBuilderWrapper">
+			<fieldset id="<portlet:namespace />assetFilterBuilderWrapper">
 				<react:component
 					module="{AssetFilterBuilder} from asset-list-web"
 					props='<%=
@@ -86,7 +86,7 @@
 						).build()
 					%>'
 				/>
-			</div>
+			</fieldset>
 
 			<liferay-frontend:component
 				context='<%=

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
@@ -38,15 +38,27 @@ export default function ({namespace}) {
 		// empty value to clear the stored filters.
 
 		assetWrapper.disabled = showCollection;
+
+		return showCollection;
 	};
 
 	updateVisibility();
 
-	Liferay.on(namespace + 'sourceChange', updateVisibility);
+	// The collection filter builder cannot tell on its own whether it is the one
+	// in use, and it has to keep submitting to clear what it stored. Announce
+	// the outcome only for a source change: nothing should discard a stored
+	// filter merely because the collection was opened.
+
+	const onSourceChange = () =>
+		Liferay.fire(`${namespace}filterVisibilityChange`, {
+			showCollection: updateVisibility(),
+		});
+
+	Liferay.on(namespace + 'sourceChange', onSourceChange);
 
 	return {
 		destroy() {
-			Liferay.detach(namespace + 'sourceChange', updateVisibility);
+			Liferay.detach(namespace + 'sourceChange', onSourceChange);
 		},
 	};
 }

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
@@ -30,6 +30,14 @@ export default function ({namespace}) {
 
 		assetWrapper.classList.toggle('hide', showCollection);
 		collectionWrapper.classList.toggle('hide', !showCollection);
+
+		// A hidden wrapper still submits its fields, so keep the asset filter
+		// builder out of the form while the collection filter builder is in
+		// use. Never do the same to the collection filter builder: type
+		// settings are merged on save, so its input has to keep submitting an
+		// empty value to clear the stored filters.
+
+		assetWrapper.disabled = showCollection;
 	};
 
 	updateVisibility();

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
 
 import useTypeProperties from '../../hooks/useTypeProperties';
@@ -31,6 +31,22 @@ function normalizeDateTime(value: string) {
 	const date = new Date(normalized.replace(' ', 'T'));
 
 	return Number.isNaN(date.getTime()) ? '' : normalized;
+}
+
+function createEmptyConditions(): FilterCondition[] {
+	return [{id: uuidv4()}];
+}
+
+/**
+ * A condition on a field of a specific item type only exists for that item
+ * type. Conditions on the asset fields and on the common fields apply to every
+ * item type, so they are worth keeping when the source changes.
+ */
+function isTypeSpecificCondition(condition: FilterCondition): boolean {
+	return (
+		condition.classNameId !== undefined &&
+		condition.classTypeId !== undefined
+	);
 }
 
 function serializeValue(
@@ -88,7 +104,7 @@ export default function CollectionFilterBuilder({
 					...condition,
 					id: uuidv4(),
 				}))
-			: [{id: uuidv4()}]
+			: createEmptyConditions()
 	);
 
 	const properties = useTypeProperties(initialProperties);
@@ -162,11 +178,54 @@ export default function CollectionFilterBuilder({
 				return true;
 			});
 
-	const handleChange = (newConditions: FilterCondition[]) => {
-		setConditions(newConditions);
+	const handleChange = useCallback(
+		(newConditions: FilterCondition[]) => {
+			setConditions(newConditions);
 
-		onChange?.(newConditions);
-	};
+			onChange?.(newConditions);
+		},
+		[onChange]
+	);
+
+	useEffect(() => {
+
+		// An item type that uses the asset filter builder instead displays none
+		// of this, and the type settings are merged rather than replaced on save,
+		// so drop everything and let the empty value clear what was stored.
+		// Otherwise keep the conditions the new item type can still offer rather
+		// than making the user build them again.
+
+		const handleFilterVisibilityChange = ({
+			showCollection,
+		}: {
+			showCollection: boolean;
+		}) =>
+			setConditions((conditions) => {
+				if (!showCollection) {
+					return createEmptyConditions();
+				}
+
+				const keptConditions = conditions.filter(
+					(condition) => !isTypeSpecificCondition(condition)
+				);
+
+				return keptConditions.length
+					? keptConditions
+					: createEmptyConditions();
+			});
+
+		Liferay.on(
+			`${namespace}filterVisibilityChange`,
+			handleFilterVisibilityChange
+		);
+
+		return () => {
+			Liferay.detach(
+				`${namespace}filterVisibilityChange`,
+				handleFilterVisibilityChange
+			);
+		};
+	}, [namespace]);
 
 	return (
 		<>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
 import DropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 import useTypeProperties from '../../hooks/useTypeProperties';
 import {getPropertyKey} from '../CollectionFilterBuilder/types';
@@ -16,6 +16,9 @@ import type {
 	FilterProperty,
 	FilterPropertyGroup,
 } from '../CollectionFilterBuilder/types';
+
+const DEFAULT_ORDER_BY_COLUMN_1 = 'modifiedDate';
+const DEFAULT_ORDER_BY_COLUMN_2 = 'title';
 
 type OrderByType = 'ASC' | 'DESC';
 
@@ -31,8 +34,34 @@ function isGroup(
 	return 'items' in item;
 }
 
+function isTypeSpecificProperty(value: OrderBySelection): boolean {
+	return value.classNameId !== undefined && value.classTypeId !== undefined;
+}
+
+function resetOrderByColumn(defaultPropertyName: string): OrderBySelection {
+	return {
+		classNameId: undefined,
+		classTypeId: undefined,
+		propertyName: defaultPropertyName,
+	};
+}
+
+/**
+ * Common fields are offered for every item type, so a column set to one stays
+ * valid. A column set to a type specific field only exists for the item type it
+ * came from, so fall back to the default rather than submit a column the new
+ * item type does not have.
+ */
+function resetIfTypeSpecific(defaultPropertyName: string) {
+	return (orderByColumn: OrderBySelection): OrderBySelection =>
+		isTypeSpecificProperty(orderByColumn)
+			? resetOrderByColumn(defaultPropertyName)
+			: orderByColumn;
+}
+
 function parseInitialOrderByColumn(
-	value: string | null | undefined
+	value: string | null | undefined,
+	defaultPropertyName: string
 ): OrderBySelection {
 	if (value && value.startsWith('{')) {
 		try {
@@ -53,11 +82,7 @@ function parseInitialOrderByColumn(
 		}
 	}
 
-	return {
-		classNameId: undefined,
-		classTypeId: undefined,
-		propertyName: value || '',
-	};
+	return resetOrderByColumn(value || defaultPropertyName);
 }
 
 interface OrderByFieldProps {
@@ -144,7 +169,7 @@ function OrderByField({
 				name={columnName}
 				type="hidden"
 				value={
-					columnValue.classNameId !== undefined
+					isTypeSpecificProperty(columnValue)
 						? JSON.stringify(columnValue)
 						: columnValue.propertyName
 				}
@@ -189,7 +214,7 @@ function OrderByField({
 								padding: 12,
 							}}
 						>
-							{columnValue.classNameId && columnValue.classTypeId
+							{isTypeSpecificProperty(columnValue)
 								? JSON.stringify(columnValue)
 								: columnValue.propertyName}
 						</pre>
@@ -234,10 +259,16 @@ export default function CollectionOrdering({
 	properties: initialProperties,
 }: CollectionOrderingProps) {
 	const [orderByColumn1, setOrderByColumn1] = useState<OrderBySelection>(() =>
-		parseInitialOrderByColumn(initialOrderByColumn1)
+		parseInitialOrderByColumn(
+			initialOrderByColumn1,
+			DEFAULT_ORDER_BY_COLUMN_1
+		)
 	);
 	const [orderByColumn2, setOrderByColumn2] = useState<OrderBySelection>(() =>
-		parseInitialOrderByColumn(initialOrderByColumn2)
+		parseInitialOrderByColumn(
+			initialOrderByColumn2,
+			DEFAULT_ORDER_BY_COLUMN_2
+		)
 	);
 	const [orderByType1, setOrderByType1] =
 		useState<OrderByType>(initialOrderByType1);
@@ -245,6 +276,19 @@ export default function CollectionOrdering({
 		useState<OrderByType>(initialOrderByType2);
 
 	const properties = useTypeProperties(initialProperties);
+
+	useEffect(() => {
+		const handleSourceChange = () => {
+			setOrderByColumn1(resetIfTypeSpecific(DEFAULT_ORDER_BY_COLUMN_1));
+			setOrderByColumn2(resetIfTypeSpecific(DEFAULT_ORDER_BY_COLUMN_2));
+		};
+
+		Liferay.on(`${namespace}sourceChange`, handleSourceChange);
+
+		return () => {
+			Liferay.detach(`${namespace}sourceChange`, handleSourceChange);
+		};
+	}, [namespace]);
 
 	const items = useMemo<Array<FilterProperty | FilterPropertyGroup>>(() => {
 		return properties

--- a/modules/test/playwright/pages/asset-list-web/CollectionsPage.ts
+++ b/modules/test/playwright/pages/asset-list-web/CollectionsPage.ts
@@ -226,6 +226,173 @@ export class CollectionsPage {
 	}
 
 	/**
+	 * On a collection's edit page, saves the collection.
+	 */
+	async save() {
+		await this.page.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(this.page);
+	}
+
+	/**
+	 * On a collection's edit page, picks one of the two ordering columns. Call
+	 * `save` to persist it. Only available with the LPD-74731 feature flag
+	 * enabled, which replaces the ordering selects with pickers fed by the item
+	 * type's properties.
+	 */
+	async setOrderByColumn({
+		column,
+		field,
+		fieldGroup,
+	}: {
+		column: 'And Then By' | 'Order By';
+		field: string;
+		fieldGroup: string;
+	}) {
+		const picker = this.page.getByLabel(column);
+
+		await clickAndExpectToBeVisible({
+			target: picker,
+			trigger: this.page.getByRole('button', {
+				exact: true,
+				name: 'Ordering',
+			}),
+		});
+
+		await picker.click();
+
+		// As in the filter, a field label only identifies a property within its
+		// group.
+
+		await this.page
+			.getByRole('group', {name: fieldGroup})
+			.getByRole('option', {exact: true, name: field})
+			.click();
+	}
+
+	/**
+	 * On a collection's edit page, adds one condition per entry to the Filter
+	 * section. Call `save` to persist them. Only available with the LPD-74731
+	 * feature flag
+	 * enabled, which replaces the tags and categories rules with the condition
+	 * builder.
+	 */
+	async addFilterConditions(
+		conditions: Array<{
+			field: string;
+			fieldGroup: string;
+			operator: string;
+			quantifier: string;
+			value: string;
+		}>
+	) {
+		const conditionBuilder = this.page.locator('.condition-builder');
+
+		await clickAndExpectToBeVisible({
+			target: conditionBuilder,
+			trigger: this.page.getByRole('button', {
+				exact: true,
+				name: 'Filter',
+			}),
+		});
+
+		for (const [
+			index,
+			{field, fieldGroup, operator, quantifier, value},
+		] of conditions.entries()) {
+			if (index) {
+				await this.page
+					.getByRole('button', {name: 'Add Filter'})
+					.click();
+			}
+
+			// Scope the controls to the row being filled in.
+
+			const row = conditionBuilder
+				.locator('.condition-builder__row')
+				.nth(index);
+
+			// Select Field
+
+			await row.getByLabel('Field').click();
+
+			await this.page
+				.getByRole('group', {name: fieldGroup})
+				.getByRole('option', {exact: true, name: field})
+				.click();
+
+			// Select Operator + Quantifier
+
+			for (const [label, option] of [
+				['Operator', operator],
+				['Quantifier', quantifier],
+			]) {
+				await row.getByLabel(label).click();
+
+				await this.page
+					.getByRole('option', {exact: true, name: option})
+					.click();
+			}
+
+			// Provide Value
+
+			await row.getByLabel('Value').fill(value);
+		}
+	}
+
+	/**
+	 * On a collection's edit page, restricts the collection's scope to a Space
+	 * through the Scope section. Call `save` to persist it.
+	 */
+	async scopeToSpace(spaceName: string) {
+		const selectSiteButton = this.page.getByRole('button', {
+			name: 'Select Site',
+		});
+
+		await clickAndExpectToBeVisible({
+			target: selectSiteButton,
+			trigger: this.page.getByRole('button', {
+				exact: true,
+				name: 'Scope',
+			}),
+		});
+
+		await selectSiteButton.click();
+
+		await this.page
+			.getByRole('menuitem', {name: 'Other Site, Asset Library, or'})
+			.click();
+
+		const scopeFrame = this.page
+			.locator('iframe[title="Scope"]')
+			.contentFrame();
+
+		await scopeFrame.getByRole('link', {name: 'Spaces'}).click();
+
+		await scopeFrame
+			.getByRole('link', {exact: true, name: spaceName})
+			.click();
+	}
+
+	/**
+	 * On a collection's edit page, opens the View Items modal for the default
+	 * variation and returns the frame that lists the resolved items.
+	 */
+	async openViewItems() {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'View Items'}),
+			trigger: this.page.getByRole('button', {name: 'Show Actions'}),
+		});
+
+		const viewItemsIframe = this.page.locator('iframe[title="View Items"]');
+
+		await viewItemsIframe.waitFor();
+
+		return viewItemsIframe.contentFrame();
+	}
+
+	/**
 	 * On a manual collection's edit page, clicks "Select" to open the asset
 	 * entries item selector modal and returns the modal dialog locator.
 	 */

--- a/modules/test/playwright/pages/asset-list-web/CollectionsPage.ts
+++ b/modules/test/playwright/pages/asset-list-web/CollectionsPage.ts
@@ -35,6 +35,8 @@ export class CollectionsPage {
 			itemType: 'Web Content Article',
 		});
 
+		await this.save();
+
 		return {
 			classPK: await this.getCollectionClassPK(name, siteUrl),
 		};
@@ -58,9 +60,7 @@ export class CollectionsPage {
 
 		await this.page.getByPlaceholder('Title').fill(name);
 
-		await this.page.getByRole('button', {name: 'Save'}).click();
-
-		await waitForAlert(this.page);
+		await this.save();
 	}
 
 	/**
@@ -162,14 +162,13 @@ export class CollectionsPage {
 
 		await this.page.getByPlaceholder('Title').fill(newName);
 
-		await this.page.getByRole('button', {name: 'Save'}).click();
-
-		await waitForAlert(this.page);
+		await this.save();
 	}
 
 	/**
 	 * Restricts the collection to multiple item types by choosing "Select
-	 * Types" and moving the given types out of the "In Use" list, then saves.
+	 * Types" and moving the given types out of the "In Use" list. Call `save`
+	 * to persist it.
 	 */
 	async restrictSourceItemTypes(excludedTypes: string[]) {
 		await this.page
@@ -189,15 +188,11 @@ export class CollectionsPage {
 				})
 				.click();
 		}
-
-		await this.page.getByRole('button', {name: 'Save'}).click();
-
-		await waitForAlert(this.page);
 	}
 
 	/**
-	 * Configures the collection to a single item type (and optional subtype),
-	 * then saves.
+	 * Configures the collection to a single item type (and optional subtype).
+	 * Call `save` to persist it.
 	 */
 	async configureSourceItemType({
 		itemSubtype,
@@ -219,14 +214,11 @@ export class CollectionsPage {
 
 			await subtypeSelect.selectOption({label: itemSubtype});
 		}
-
-		await this.page.getByRole('button', {name: 'Save'}).click();
-
-		await waitForAlert(this.page);
 	}
 
 	/**
-	 * On a collection's edit page, saves the collection.
+	 * Saves the collection, from its edit page or from the dialog that creates
+	 * or renames it, and waits for the confirmation alert.
 	 */
 	async save() {
 		await this.page.getByRole('button', {name: 'Save'}).click();

--- a/modules/test/playwright/tests/asset-list-web/main/collections/assetPublisher.spec.ts
+++ b/modules/test/playwright/tests/asset-list-web/main/collections/assetPublisher.spec.ts
@@ -82,6 +82,8 @@ test.describe('Personalized Variation', () => {
 					itemType: 'Web Content Article',
 				});
 
+				await collectionsPage.save();
+
 				await collectionsPage.addPersonalizedVariation(segmentName);
 
 				await collectionsPage.selectAssets([webContentTitle]);
@@ -169,6 +171,8 @@ test.describe('Personalized Variation', () => {
 					itemSubtype: 'All Subtypes',
 					itemType: 'Web Content Article',
 				});
+
+				await collectionsPage.save();
 
 				await collectionsPage.selectAssets([webContentTitle]);
 

--- a/modules/test/playwright/tests/asset-list-web/main/collections/dynamicCollection.spec.ts
+++ b/modules/test/playwright/tests/asset-list-web/main/collections/dynamicCollection.spec.ts
@@ -7,8 +7,10 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {collectionsPagesTest} from '../../../../fixtures/collectionsPagesTest';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {CollectionsPage} from '../../../../pages/asset-list-web/CollectionsPage';
 import getGlobalSite from '../../../../utils/getGlobalSite';
 import getRandomString from '../../../../utils/getRandomString';
 import {
@@ -22,6 +24,364 @@ const test = mergeTests(
 	isolatedSiteTest,
 	dataApiHelpersTest,
 	collectionsPagesTest
+);
+
+const testWithEnhancedFiltering = mergeTests(
+	loginTest(),
+	featureFlagsTest({
+		'LPD-74731': {enabled: true}, // Enhanced Filtering
+		'LPS-178052': {enabled: true}, // CMS Objects
+	}),
+	isolatedSiteTest,
+	dataApiHelpersTest,
+	collectionsPagesTest
+);
+
+const CMS_BASIC_WEB_CONTENT = 'Basic Web Content';
+const CMS_BLOG = 'Blog';
+const CMS_WEB_CONTENT_APPLICATION = 'cms/basic-web-contents';
+
+/**
+ * Reopens the collection and returns the frame listing the items it resolves
+ * to. Every check starts from a fresh page load so no modal state carries over
+ * between retries.
+ */
+async function gotoViewItems(
+	collectionsPage: CollectionsPage,
+	site: {friendlyUrlPath: string},
+	collectionName: string
+) {
+	await collectionsPage.goto(site.friendlyUrlPath);
+
+	await collectionsPage.openCollection(collectionName);
+
+	return await collectionsPage.openViewItems();
+}
+
+testWithEnhancedFiltering.describe(
+	'Enhanced Filtering with CMS Objects',
+	() => {
+		testWithEnhancedFiltering(
+			"Applies a filter for CMS Object based on type's own field",
+			{tag: '@LPD-88609'},
+			async ({apiHelpers, collectionsPage, site}) => {
+				testWithEnhancedFiltering.setTimeout(240000);
+
+				const collectionName = getRandomString();
+				const titles = [
+					`Alpha ${getRandomString()}`,
+					`Beta ${getRandomString()}`,
+				];
+
+				let spaceName: string;
+
+				await testWithEnhancedFiltering.step(
+					'Create a Space holding two basic web contents',
+					async () => {
+						const space =
+							await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+								{
+									name: `Space ${getRandomString()}`,
+									settings: {},
+									type: 'Space',
+								}
+							);
+
+						spaceName = space.name;
+
+						for (const title of titles) {
+							await apiHelpers.objectEntry.postObjectEntry(
+								{
+									content: `<p>${title} body</p>`,
+									objectEntryFolderExternalReferenceCode:
+										'L_CONTENTS',
+									title,
+								},
+								CMS_WEB_CONTENT_APPLICATION,
+								space.name
+							);
+						}
+
+						await apiHelpers.headlessAssetLibrary.connectSite(
+							space.externalReferenceCode,
+							site.externalReferenceCode,
+							{searchable: true}
+						);
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Create a dynamic collection scoped to the Space',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.addNewDynamicCollection(
+							collectionName
+						);
+
+						await collectionsPage.configureSourceItemType({
+							itemType: CMS_BASIC_WEB_CONTENT + ' (CMS)',
+						});
+
+						await collectionsPage.scopeToSpace(spaceName);
+
+						await collectionsPage.save();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Both basic web contents are available before any filter is added',
+					async () => {
+						const viewItemsFrame = await gotoViewItems(
+							collectionsPage,
+							site,
+							collectionName
+						);
+
+						for (const title of titles) {
+							await expect(
+								viewItemsFrame.getByText(title)
+							).toBeVisible({timeout: 5000});
+						}
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Filter the collection by title',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.openCollection(collectionName);
+
+						await collectionsPage.addFilterConditions([
+							{
+								field: 'Title',
+								fieldGroup: CMS_BASIC_WEB_CONTENT,
+								operator: 'Contains',
+								quantifier: 'Any of the Following',
+								value: 'Nothing',
+							},
+						]);
+
+						await collectionsPage.save();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Neither basic web content is available while the filter applies',
+					async () => {
+						const viewItemsFrame = await gotoViewItems(
+							collectionsPage,
+							site,
+							collectionName
+						);
+
+						for (const title of titles) {
+							await expect(
+								viewItemsFrame.getByText(title)
+							).toHaveCount(0);
+						}
+					}
+				);
+			}
+		);
+
+		testWithEnhancedFiltering(
+			'Resets the ordering column that the selected item type does not support',
+			{tag: '@LPD-102710'},
+			async ({collectionsPage, page, site}) => {
+				const collectionName = getRandomString();
+
+				const getOrderByColumn = async (index: number) =>
+					await page
+						.locator(
+							`input[name$="TypeSettingsProperties--orderByColumn${index}--"]`
+						)
+						.inputValue();
+
+				await testWithEnhancedFiltering.step(
+					'Order a collection by a field of its item type, then by a common field',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.addNewDynamicCollection(
+							collectionName
+						);
+
+						await collectionsPage.configureSourceItemType({
+							itemType: CMS_BASIC_WEB_CONTENT + ' (CMS)',
+						});
+
+						await collectionsPage.setOrderByColumn({
+							column: 'Order By',
+							field: 'Title',
+							fieldGroup: CMS_BASIC_WEB_CONTENT,
+						});
+
+						await collectionsPage.setOrderByColumn({
+							column: 'And Then By',
+							field: 'Created Date',
+							fieldGroup: 'Common Fields',
+						});
+
+						await collectionsPage.save();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Both orderings are saved',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.openCollection(collectionName);
+
+						// A column on a field of the item type is saved as JSON
+						// carrying the propertyName, classNameId, classTypeId.
+
+						expect(await getOrderByColumn(1)).toContain(
+							'"propertyName":"title"'
+						);
+						expect(await getOrderByColumn(2)).toBe('createDate');
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Change the item type',
+					async () => {
+						await collectionsPage.configureSourceItemType({
+							itemSubtype: 'Basic Web Content',
+							itemType: 'Web Content Article',
+						});
+
+						await collectionsPage.save();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'The item type specific ordering falls back to the default and the common field is kept',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.openCollection(collectionName);
+
+						expect(await getOrderByColumn(1)).toBe('modifiedDate');
+						expect(await getOrderByColumn(2)).toBe('createDate');
+					}
+				);
+			}
+		);
+
+		testWithEnhancedFiltering(
+			'Discards a filter that the selected item type no longer displays',
+			{tag: '@LPD-102710'},
+			async ({collectionsPage, page, site}) => {
+				const collectionName = getRandomString();
+
+				const getFilters = async () =>
+					JSON.parse(
+						await page
+							.locator(
+								`input[name$="TypeSettingsProperties--filters--"]`
+							)
+							.inputValue()
+					);
+
+				await testWithEnhancedFiltering.step(
+					'Filter a collection by a field of its item type and by a common field',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.addNewDynamicCollection(
+							collectionName
+						);
+
+						await collectionsPage.configureSourceItemType({
+							itemType: CMS_BASIC_WEB_CONTENT + ' (CMS)',
+						});
+
+						await collectionsPage.addFilterConditions([
+							{
+								field: 'Title',
+								fieldGroup: CMS_BASIC_WEB_CONTENT,
+								operator: 'Contains',
+								quantifier: 'Any of the Following',
+								value: 'nothing',
+							},
+							{
+								field: 'Author Name',
+								fieldGroup: 'Common Fields',
+								operator: 'Contains',
+								quantifier: 'Any of the Following',
+								value: 'nobody',
+							},
+						]);
+
+						await collectionsPage.save();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Both filters are saved while they are displayed',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.openCollection(collectionName);
+
+						expect(await getFilters()).toHaveLength(2);
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Change the item type to another CMS object',
+					async () => {
+						await collectionsPage.configureSourceItemType({
+							itemType: CMS_BLOG + ' (CMS)',
+						});
+
+						await collectionsPage.save();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Only the filter on the previous item type field is discarded',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.openCollection(collectionName);
+
+						const filters = await getFilters();
+
+						expect(filters).toHaveLength(1);
+						expect(filters[0].propertyName).toBe('userName');
+						expect(filters[0].classNameId).toBeUndefined();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'Change the item type to one that does not display the enhanced filter',
+					async () => {
+						await collectionsPage.configureSourceItemType({
+							itemSubtype: 'Basic Web Content',
+							itemType: 'Web Content Article',
+						});
+
+						await collectionsPage.save();
+					}
+				);
+
+				await testWithEnhancedFiltering.step(
+					'The filter on the common field is discarded too',
+					async () => {
+						await collectionsPage.goto(site.friendlyUrlPath);
+
+						await collectionsPage.openCollection(collectionName);
+
+						expect(await getFilters()).toEqual([]);
+					}
+				);
+			}
+		);
+	}
 );
 
 test.describe('Source', () => {

--- a/modules/test/playwright/tests/asset-list-web/main/collections/dynamicCollection.spec.ts
+++ b/modules/test/playwright/tests/asset-list-web/main/collections/dynamicCollection.spec.ts
@@ -416,6 +416,8 @@ test.describe('Source', () => {
 					itemSubtype: documentTypeName,
 					itemType: 'Document',
 				});
+
+				await collectionsPage.save();
 			});
 
 			await test.step('Create a user who administers the site', async () => {

--- a/modules/test/playwright/tests/asset-list-web/main/collections/manualCollection.spec.ts
+++ b/modules/test/playwright/tests/asset-list-web/main/collections/manualCollection.spec.ts
@@ -44,6 +44,8 @@ test.describe('Selection and Display', () => {
 
 			await test.step('Restrict the collection to every item type except Blogs Entry and Web Content Article', async () => {
 				await collectionsPage.restrictSourceItemTypes(excludedTypes);
+
+				await collectionsPage.save();
 			});
 
 			await test.step('Open the Type filter in the asset entries item selector', async () => {
@@ -100,6 +102,8 @@ test.describe('Selection and Display', () => {
 					itemSubtype: 'Basic Web Content',
 					itemType: 'Web Content Article',
 				});
+
+				await collectionsPage.save();
 			});
 
 			await test.step('Select the web content article', async () => {
@@ -165,6 +169,8 @@ test.describe('Personalized Variation', () => {
 					itemSubtype: 'All Subtypes',
 					itemType: 'Web Content Article',
 				});
+
+				await collectionsPage.save();
 
 				await collectionsPage.addPersonalizedVariation(segmentName);
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102710

## What Is Being Fixed

A filter set on one item type stayed in the collection after the item type changed, and kept narrowing the results while no longer being shown anywhere in the form. The same held for the legacy tags, categories, and keywords rules, because hiding their wrapper does not stop its fields from being submitted, so they were saved and applied whenever the collection filter builder was the one on screen. An ordering column set to a field of one item type survived the change too, leaving the collection ordered by a column the new item type does not have.

## How It Is Being Fixed

The legacy asset filter builder is taken out of the form while the collection filter builder is in use, by disabling its wrapper rather than only hiding it. Disabling the wrapper also covers the fields React mounts after the toggle runs, which disabling them one by one would miss, and because the action command rebuilds the query logic from queryLogicIndexes, leaving the whole group out of the form clears whatever was stored.

The collection filter builder now discards a condition on a field of a specific item type when the source changes, and discards every condition when the item type uses the asset filter builder instead, where none of them are displayed at all. Conditions on the asset fields and on the common fields are kept, since every item type offers them and rebuilding them by hand is pure loss. Type settings are merged rather than replaced on save, so the builder keeps submitting an empty value to clear what was stored, and FilterVisibility announces the outcome because the builder cannot tell on its own whether it is the one in use. Ordering follows the same rule: a column on a field of a specific item type falls back to the default the editor already shows, while a column on a common field is kept.

Three Playwright tests cover the behavior, and the methods that edit a collection no longer save on their own, so a test can make several changes in one submission and the save itself lives in one place that the creation and rename dialogs reuse.

## PR Check

**pr-check: PASS** — tested on `f7691cac52d35dd834cb8117cefba3279cb6f9e4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

Baseline reported three failures, all pre-existing on master and none in a module this branch touches: the dynamic-data-mapping-form-taglib and data-engine-taglib JSP builds, and a headless-cms-api EXCESSIVE VERSION INCREASE from master's 3.1.0 against the released 3.0.0. Nothing landed in the tree, so there was no version change to classify.

<!-- pr-check {"result": "success", "sha": "f7691cac52d35dd834cb8117cefba3279cb6f9e4"} -->
