### PR TITLE
LPD-103025 Add the broken link assets endpoint

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/BrokenLinkAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/BrokenLinkAsset.java
@@ -1,0 +1,514 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName("BrokenLinkAsset")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "BrokenLinkAsset")
+public class BrokenLinkAsset implements Serializable {
+
+	public static BrokenLinkAsset toDTO(String json) {
+		return ObjectMapperUtil.readValue(BrokenLinkAsset.class, json);
+	}
+
+	public static BrokenLinkAsset unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(BrokenLinkAsset.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getBrokenLinkTitle() {
+		if (_brokenLinkTitleSupplier != null) {
+			brokenLinkTitle = _brokenLinkTitleSupplier.get();
+
+			_brokenLinkTitleSupplier = null;
+		}
+
+		return brokenLinkTitle;
+	}
+
+	public void setBrokenLinkTitle(String brokenLinkTitle) {
+		this.brokenLinkTitle = brokenLinkTitle;
+
+		_brokenLinkTitleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setBrokenLinkTitle(
+		UnsafeSupplier<String, Exception> brokenLinkTitleUnsafeSupplier) {
+
+		_brokenLinkTitleSupplier = () -> {
+			try {
+				return brokenLinkTitleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String brokenLinkTitle;
+
+	@JsonIgnore
+	private Supplier<String> _brokenLinkTitleSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getBrokenLinksCount() {
+		if (_brokenLinksCountSupplier != null) {
+			brokenLinksCount = _brokenLinksCountSupplier.get();
+
+			_brokenLinksCountSupplier = null;
+		}
+
+		return brokenLinksCount;
+	}
+
+	public void setBrokenLinksCount(Long brokenLinksCount) {
+		this.brokenLinksCount = brokenLinksCount;
+
+		_brokenLinksCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setBrokenLinksCount(
+		UnsafeSupplier<Long, Exception> brokenLinksCountUnsafeSupplier) {
+
+		_brokenLinksCountSupplier = () -> {
+			try {
+				return brokenLinksCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long brokenLinksCount;
+
+	@JsonIgnore
+	private Supplier<Long> _brokenLinksCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getHref() {
+		if (_hrefSupplier != null) {
+			href = _hrefSupplier.get();
+
+			_hrefSupplier = null;
+		}
+
+		return href;
+	}
+
+	public void setHref(String href) {
+		this.href = href;
+
+		_hrefSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setHref(UnsafeSupplier<String, Exception> hrefUnsafeSupplier) {
+		_hrefSupplier = () -> {
+			try {
+				return hrefUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String href;
+
+	@JsonIgnore
+	private Supplier<String> _hrefSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getObjectDefinitionExternalReferenceCode() {
+		if (_objectDefinitionExternalReferenceCodeSupplier != null) {
+			objectDefinitionExternalReferenceCode =
+				_objectDefinitionExternalReferenceCodeSupplier.get();
+
+			_objectDefinitionExternalReferenceCodeSupplier = null;
+		}
+
+		return objectDefinitionExternalReferenceCode;
+	}
+
+	public void setObjectDefinitionExternalReferenceCode(
+		String objectDefinitionExternalReferenceCode) {
+
+		this.objectDefinitionExternalReferenceCode =
+			objectDefinitionExternalReferenceCode;
+
+		_objectDefinitionExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setObjectDefinitionExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			objectDefinitionExternalReferenceCodeUnsafeSupplier) {
+
+		_objectDefinitionExternalReferenceCodeSupplier = () -> {
+			try {
+				return objectDefinitionExternalReferenceCodeUnsafeSupplier.
+					get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String objectDefinitionExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _objectDefinitionExternalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof BrokenLinkAsset)) {
+			return false;
+		}
+
+		BrokenLinkAsset brokenLinkAsset = (BrokenLinkAsset)object;
+
+		return Objects.equals(toString(), brokenLinkAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String brokenLinkTitle = getBrokenLinkTitle();
+
+		if (brokenLinkTitle != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"brokenLinkTitle\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(brokenLinkTitle));
+
+			sb.append("\"");
+		}
+
+		Long brokenLinksCount = getBrokenLinksCount();
+
+		if (brokenLinksCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"brokenLinksCount\": ");
+
+			sb.append(brokenLinksCount);
+		}
+
+		String href = getHref();
+
+		if (href != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"href\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(href));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String objectDefinitionExternalReferenceCode =
+			getObjectDefinitionExternalReferenceCode();
+
+		if (objectDefinitionExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"objectDefinitionExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectDefinitionExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:581079945

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/BrokenLinkAssetResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/BrokenLinkAssetResource.java
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-cms/v1.0
+ *
+ * @author Crescenzo Rega
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface BrokenLinkAssetResource {
+
+	public Page<BrokenLinkAsset> getBrokenLinkAssetsPage(
+			Long assetLibraryId, String search, Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public BrokenLinkAssetResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1619757765

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/BrokenLinkAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/BrokenLinkAsset.java
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.BrokenLinkAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class BrokenLinkAsset implements Cloneable, Serializable {
+
+	public static BrokenLinkAsset toDTO(String json) {
+		return BrokenLinkAssetSerDes.toDTO(json);
+	}
+
+	public String getBrokenLinkTitle() {
+		return brokenLinkTitle;
+	}
+
+	public void setBrokenLinkTitle(String brokenLinkTitle) {
+		this.brokenLinkTitle = brokenLinkTitle;
+	}
+
+	public void setBrokenLinkTitle(
+		UnsafeSupplier<String, Exception> brokenLinkTitleUnsafeSupplier) {
+
+		try {
+			brokenLinkTitle = brokenLinkTitleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String brokenLinkTitle;
+
+	public Long getBrokenLinksCount() {
+		return brokenLinksCount;
+	}
+
+	public void setBrokenLinksCount(Long brokenLinksCount) {
+		this.brokenLinksCount = brokenLinksCount;
+	}
+
+	public void setBrokenLinksCount(
+		UnsafeSupplier<Long, Exception> brokenLinksCountUnsafeSupplier) {
+
+		try {
+			brokenLinksCount = brokenLinksCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long brokenLinksCount;
+
+	public String getHref() {
+		return href;
+	}
+
+	public void setHref(String href) {
+		this.href = href;
+	}
+
+	public void setHref(UnsafeSupplier<String, Exception> hrefUnsafeSupplier) {
+		try {
+			href = hrefUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String href;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getObjectDefinitionExternalReferenceCode() {
+		return objectDefinitionExternalReferenceCode;
+	}
+
+	public void setObjectDefinitionExternalReferenceCode(
+		String objectDefinitionExternalReferenceCode) {
+
+		this.objectDefinitionExternalReferenceCode =
+			objectDefinitionExternalReferenceCode;
+	}
+
+	public void setObjectDefinitionExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			objectDefinitionExternalReferenceCodeUnsafeSupplier) {
+
+		try {
+			objectDefinitionExternalReferenceCode =
+				objectDefinitionExternalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String objectDefinitionExternalReferenceCode;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public BrokenLinkAsset clone() throws CloneNotSupportedException {
+		return (BrokenLinkAsset)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof BrokenLinkAsset)) {
+			return false;
+		}
+
+		BrokenLinkAsset brokenLinkAsset = (BrokenLinkAsset)object;
+
+		return Objects.equals(toString(), brokenLinkAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return BrokenLinkAssetSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:834820098

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/BrokenLinkAssetResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/BrokenLinkAssetResource.java
@@ -1,0 +1,295 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.resource.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.headless.cms.client.serdes.v1_0.BrokenLinkAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public interface BrokenLinkAssetResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<BrokenLinkAsset> getBrokenLinkAssetsPage(
+			Long assetLibraryId, String search, Pagination pagination,
+			String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getBrokenLinkAssetsPageHttpResponse(
+			Long assetLibraryId, String search, Pagination pagination,
+			String sortString)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public BrokenLinkAssetResource build() {
+			return new BrokenLinkAssetResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class BrokenLinkAssetResourceImpl
+		implements BrokenLinkAssetResource {
+
+		public Page<BrokenLinkAsset> getBrokenLinkAssetsPage(
+				Long assetLibraryId, String search, Pagination pagination,
+				String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getBrokenLinkAssetsPageHttpResponse(
+					assetLibraryId, search, pagination, sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, BrokenLinkAssetSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getBrokenLinkAssetsPageHttpResponse(
+				Long assetLibraryId, String search, Pagination pagination,
+				String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetLibraryId != null) {
+				httpInvoker.parameter(
+					"assetLibraryId", String.valueOf(assetLibraryId));
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cms/v1.0/broken-link-assets");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private BrokenLinkAssetResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			BrokenLinkAssetResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-372453695

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/BrokenLinkAssetSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/BrokenLinkAssetSerDes.java
@@ -1,0 +1,367 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class BrokenLinkAssetSerDes {
+
+	public static BrokenLinkAsset toDTO(String json) {
+		BrokenLinkAssetJSONParser brokenLinkAssetJSONParser =
+			new BrokenLinkAssetJSONParser();
+
+		return brokenLinkAssetJSONParser.parseToDTO(json);
+	}
+
+	public static BrokenLinkAsset[] toDTOs(String json) {
+		BrokenLinkAssetJSONParser brokenLinkAssetJSONParser =
+			new BrokenLinkAssetJSONParser();
+
+		return brokenLinkAssetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(BrokenLinkAsset brokenLinkAsset) {
+		if (brokenLinkAsset == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (brokenLinkAsset.getBrokenLinkTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"brokenLinkTitle\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(brokenLinkAsset.getBrokenLinkTitle()));
+
+			sb.append("\"");
+		}
+
+		if (brokenLinkAsset.getBrokenLinksCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"brokenLinksCount\": ");
+
+			sb.append(brokenLinkAsset.getBrokenLinksCount());
+		}
+
+		if (brokenLinkAsset.getHref() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"href\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(brokenLinkAsset.getHref()));
+
+			sb.append("\"");
+		}
+
+		if (brokenLinkAsset.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(brokenLinkAsset.getId());
+		}
+
+		if (brokenLinkAsset.getObjectDefinitionExternalReferenceCode() !=
+				null) {
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"objectDefinitionExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(
+					brokenLinkAsset.
+						getObjectDefinitionExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (brokenLinkAsset.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(brokenLinkAsset.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		BrokenLinkAssetJSONParser brokenLinkAssetJSONParser =
+			new BrokenLinkAssetJSONParser();
+
+		return brokenLinkAssetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(BrokenLinkAsset brokenLinkAsset) {
+		if (brokenLinkAsset == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (brokenLinkAsset.getBrokenLinkTitle() == null) {
+			map.put("brokenLinkTitle", null);
+		}
+		else {
+			map.put(
+				"brokenLinkTitle",
+				String.valueOf(brokenLinkAsset.getBrokenLinkTitle()));
+		}
+
+		if (brokenLinkAsset.getBrokenLinksCount() == null) {
+			map.put("brokenLinksCount", null);
+		}
+		else {
+			map.put(
+				"brokenLinksCount",
+				String.valueOf(brokenLinkAsset.getBrokenLinksCount()));
+		}
+
+		if (brokenLinkAsset.getHref() == null) {
+			map.put("href", null);
+		}
+		else {
+			map.put("href", String.valueOf(brokenLinkAsset.getHref()));
+		}
+
+		if (brokenLinkAsset.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(brokenLinkAsset.getId()));
+		}
+
+		if (brokenLinkAsset.getObjectDefinitionExternalReferenceCode() ==
+				null) {
+
+			map.put("objectDefinitionExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"objectDefinitionExternalReferenceCode",
+				String.valueOf(
+					brokenLinkAsset.
+						getObjectDefinitionExternalReferenceCode()));
+		}
+
+		if (brokenLinkAsset.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(brokenLinkAsset.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class BrokenLinkAssetJSONParser
+		extends BaseJSONParser<BrokenLinkAsset> {
+
+		@Override
+		protected BrokenLinkAsset createDTO() {
+			return new BrokenLinkAsset();
+		}
+
+		@Override
+		protected BrokenLinkAsset[] createDTOArray(int size) {
+			return new BrokenLinkAsset[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "brokenLinkTitle")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "brokenLinksCount")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "href")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"objectDefinitionExternalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			BrokenLinkAsset brokenLinkAsset, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "brokenLinkTitle")) {
+				if (jsonParserFieldValue != null) {
+					brokenLinkAsset.setBrokenLinkTitle(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "brokenLinksCount")) {
+				if (jsonParserFieldValue != null) {
+					brokenLinkAsset.setBrokenLinksCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "href")) {
+				if (jsonParserFieldValue != null) {
+					brokenLinkAsset.setHref((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					brokenLinkAsset.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"objectDefinitionExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					brokenLinkAsset.setObjectDefinitionExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					brokenLinkAsset.setTitle((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-792535952

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -65,6 +65,28 @@ components:
                     type: string
                 url:
                     type: string
+        BrokenLinkAsset:
+            properties:
+                brokenLinkTitle:
+                    readOnly: true
+                    type: string
+                brokenLinksCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                href:
+                    readOnly: true
+                    type: string
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                objectDefinitionExternalReferenceCode:
+                    readOnly: true
+                    type: string
+                title:
+                    readOnly: true
+                    type: string
         ResetAssetPermissionAction:
             allOf:
                 -   $ref: "#/components/schemas/AssetPermissionAction"
@@ -158,3 +180,42 @@ paths:
                                     $ref: "#/components/schemas/AssetUsage"
                                 type: array
             tags: ["AssetUsage"]
+    "/broken-link-assets":
+        get:
+            operationId: getBrokenLinkAssetsPage
+            parameters:
+                -   in: query
+                    name: assetLibraryId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/BrokenLinkAsset"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/BrokenLinkAsset"
+                                type: array
+            tags: ["BrokenLinkAsset"]

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -7,8 +7,10 @@ package com.liferay.headless.cms.internal.graphql.query.v1_0;
 
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -58,6 +60,14 @@ public class Query {
 			assetUsageResourceComponentServiceObjects;
 	}
 
+	public static void setBrokenLinkAssetResourceComponentServiceObjects(
+		ComponentServiceObjects<BrokenLinkAssetResource>
+			brokenLinkAssetResourceComponentServiceObjects) {
+
+		_brokenLinkAssetResourceComponentServiceObjects =
+			brokenLinkAssetResourceComponentServiceObjects;
+	}
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -97,6 +107,31 @@ public class Query {
 				assetUsageResource.getAssetUsagesAssetPage(
 					assetId, search, Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(assetUsageResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {brokenLinkAssets(assetLibraryId: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public BrokenLinkAssetPage brokenLinkAssets(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("search") String search,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_brokenLinkAssetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			brokenLinkAssetResource -> new BrokenLinkAssetPage(
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					Long.valueOf(assetLibraryId), search,
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(
+						brokenLinkAssetResource, sortsString))));
 	}
 
 	@GraphQLName("AssetStatisticsPage")
@@ -150,6 +185,39 @@ public class Query {
 
 		@GraphQLField
 		protected java.util.Collection<AssetUsage> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("BrokenLinkAssetPage")
+	public class BrokenLinkAssetPage {
+
+		public BrokenLinkAssetPage(Page brokenLinkAssetPage) {
+			actions = brokenLinkAssetPage.getActions();
+
+			items = brokenLinkAssetPage.getItems();
+			lastPage = brokenLinkAssetPage.getLastPage();
+			page = brokenLinkAssetPage.getPage();
+			pageSize = brokenLinkAssetPage.getPageSize();
+			totalCount = brokenLinkAssetPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<BrokenLinkAsset> items;
 
 		@GraphQLField
 		protected long lastPage;
@@ -221,10 +289,32 @@ public class Query {
 		assetUsageResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private void _populateResourceContext(
+			BrokenLinkAssetResource brokenLinkAssetResource)
+		throws Exception {
+
+		brokenLinkAssetResource.setContextAcceptLanguage(_acceptLanguage);
+		brokenLinkAssetResource.setContextCompany(_company);
+		brokenLinkAssetResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		brokenLinkAssetResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		brokenLinkAssetResource.setContextUriInfo(_uriInfo);
+		brokenLinkAssetResource.setContextUser(_user);
+		brokenLinkAssetResource.setGroupLocalService(_groupLocalService);
+		brokenLinkAssetResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		brokenLinkAssetResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		brokenLinkAssetResource.setRoleLocalService(_roleLocalService);
+	}
+
 	private static ComponentServiceObjects<AssetStatisticsResource>
 		_assetStatisticsResourceComponentServiceObjects;
 	private static ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
+	private static ComponentServiceObjects<BrokenLinkAssetResource>
+		_brokenLinkAssetResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
 	private com.liferay.portal.kernel.model.Company _company;
@@ -243,4 +333,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1836156125
+// LIFERAY-REST-BUILDER-HASH:-802839611

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -10,9 +10,11 @@ import com.liferay.headless.cms.internal.graphql.query.v1_0.Query;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetPermissionActionResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetStatisticsResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetUsageResourceImpl;
+import com.liferay.headless.cms.internal.resource.v1_0.BrokenLinkAssetResourceImpl;
 import com.liferay.headless.cms.resource.v1_0.AssetPermissionActionResource;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 
@@ -45,6 +47,8 @@ public class ServletDataImpl implements ServletData {
 			_assetStatisticsResourceComponentServiceObjects);
 		Query.setAssetUsageResourceComponentServiceObjects(
 			_assetUsageResourceComponentServiceObjects);
+		Query.setBrokenLinkAssetResourceComponentServiceObjects(
+			_brokenLinkAssetResourceComponentServiceObjects);
 	}
 
 	public String getApplicationName() {
@@ -97,6 +101,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							AssetUsageResourceImpl.class,
 							"getAssetUsagesAssetPage"));
+					put(
+						"query#brokenLinkAssets",
+						new ObjectValuePair<>(
+							BrokenLinkAssetResourceImpl.class,
+							"getBrokenLinkAssetsPage"));
 				}
 			};
 
@@ -112,5 +121,9 @@ public class ServletDataImpl implements ServletData {
 	private ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
 
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<BrokenLinkAssetResource>
+		_brokenLinkAssetResourceComponentServiceObjects;
+
 }
-// LIFERAY-REST-BUILDER-HASH:-1043047869
+// LIFERAY-REST-BUILDER-HASH:1309969940

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
@@ -9,20 +9,25 @@ import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
 import com.liferay.site.cms.site.initializer.util.CMSOutboundLinksUtil;
 
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Jürgen Kappler
@@ -39,40 +44,20 @@ public class BrokenLinkAssetSearcher {
 	}
 
 	public long getCount(
-		long companyId, Long[] groupIds, List<String> outboundLinkTokens) {
-
-		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
-
-		booleanQuery.addFilterQueryClauses(
-			_getOutboundLinksBooleanQuery(outboundLinkTokens),
-			_getTermsQuery("cms_section", "contents", "files"),
-			_getTermsQuery(
-				Field.STATUS,
-				ArrayUtil.toStringArray(CMSWorkflowConstants.STATUSES)),
-			QueriesUtil.term("rootDescendantNode", false));
+		long companyId, Long[] groupIds, Set<String> outboundLinkTokens) {
 
 		SearchResponse searchResponse = _searcher.search(
-			_searchRequestBuilderFactory.builder(
-			).companyId(
-				companyId
-			).emptySearchEnabled(
-				true
-			).groupIds(
-				ArrayUtil.toArray(groupIds)
-			).query(
-				booleanQuery
-			).withSearchContext(
-				searchContext -> searchContext.setAttribute(
-					Field.STATUS, WorkflowConstants.STATUS_ANY)
+			_getSearchRequestBuilder(
+				companyId, groupIds, outboundLinkTokens
 			).build());
 
 		return searchResponse.getCount();
 	}
 
-	public List<String> getExpiredAssetTokens(
+	public Map<String, Long> getExpiredAssetObjectEntryIds(
 		long companyId, Long[] objectDefinitionIds) {
 
-		List<String> expiredAssetTokens = new ArrayList<>();
+		Map<String, Long> objectEntryIds = new LinkedHashMap<>();
 
 		List<Object[]> results = _objectEntryLocalService.dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -93,19 +78,56 @@ public class BrokenLinkAssetSearcher {
 			));
 
 		for (Object[] objects : results) {
-			expiredAssetTokens.add(
+			long objectEntryId = GetterUtil.getLong(objects[1]);
+
+			objectEntryIds.put(
 				CMSOutboundLinksUtil.getObjectEntryExternalReferenceCodeToken(
-					GetterUtil.getString(objects[0])));
-			expiredAssetTokens.add(
-				CMSOutboundLinksUtil.getObjectEntryIdToken(
-					GetterUtil.getLong(objects[1])));
+					GetterUtil.getString(objects[0])),
+				objectEntryId);
+			objectEntryIds.put(
+				CMSOutboundLinksUtil.getObjectEntryIdToken(objectEntryId),
+				objectEntryId);
 		}
 
-		return expiredAssetTokens;
+		return objectEntryIds;
+	}
+
+	public SearchResponse search(
+		long companyId, Long[] groupIds, String languageId,
+		Set<String> outboundLinkTokens, Pagination pagination, String search,
+		Sort[] sorts) {
+
+		SearchRequestBuilder searchRequestBuilder = _getSearchRequestBuilder(
+			companyId, groupIds, outboundLinkTokens);
+
+		int startPosition = Math.min(
+			pagination.getStartPosition(), _MAX_RESULT_WINDOW);
+
+		searchRequestBuilder.addSelectedFieldNames(
+			"outboundLinks", Field.ENTRY_CLASS_PK, "objectDefinitionId",
+			"objectEntryTitle",
+			Field.getLocalizedName(languageId, "objectEntryTitle")
+		).from(
+			startPosition
+		).size(
+			Math.min(
+				pagination.getPageSize(), _MAX_RESULT_WINDOW - startPosition)
+		);
+
+		if (ArrayUtil.isNotEmpty(sorts)) {
+			searchRequestBuilder.withSearchContext(
+				searchContext -> searchContext.setSorts(sorts));
+		}
+
+		if (search != null) {
+			searchRequestBuilder.queryString(search);
+		}
+
+		return _searcher.search(searchRequestBuilder.build());
 	}
 
 	private BooleanQuery _getOutboundLinksBooleanQuery(
-		List<String> outboundLinkTokens) {
+		Set<String> outboundLinkTokens) {
 
 		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
 
@@ -125,6 +147,34 @@ public class BrokenLinkAssetSearcher {
 		return booleanQuery;
 	}
 
+	private SearchRequestBuilder _getSearchRequestBuilder(
+		long companyId, Long[] groupIds, Set<String> outboundLinkTokens) {
+
+		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+		booleanQuery.addFilterQueryClauses(
+			_getOutboundLinksBooleanQuery(outboundLinkTokens),
+			_getTermsQuery("cms_section", "contents", "files"),
+			_getTermsQuery(
+				Field.STATUS,
+				ArrayUtil.toStringArray(CMSWorkflowConstants.STATUSES)),
+			QueriesUtil.term("rootDescendantNode", false));
+
+		return _searchRequestBuilderFactory.builder(
+		).companyId(
+			companyId
+		).emptySearchEnabled(
+			true
+		).groupIds(
+			ArrayUtil.toArray(groupIds)
+		).query(
+			booleanQuery
+		).withSearchContext(
+			searchContext -> searchContext.setAttribute(
+				Field.STATUS, WorkflowConstants.STATUS_ANY)
+		);
+	}
+
 	private TermsQuery _getTermsQuery(String fieldName, String... values) {
 		TermsQuery termsQuery = QueriesUtil.terms(fieldName);
 
@@ -132,6 +182,8 @@ public class BrokenLinkAssetSearcher {
 
 		return termsQuery;
 	}
+
+	private static final int _MAX_RESULT_WINDOW = 10000;
 
 	private static final int _TERMS_QUERY_CHUNK_SIZE = 4096;
 

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -29,7 +29,7 @@ import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
 
 import java.util.Date;
-import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -163,16 +163,17 @@ public class AssetStatisticsResourceImpl
 					_objectEntryLocalService, _searcher,
 					_searchRequestBuilderFactory);
 
-			List<String> expiredAssetTokens =
-				brokenLinkAssetSearcher.getExpiredAssetTokens(
+			Map<String, Long> expiredAssetObjectEntryIds =
+				brokenLinkAssetSearcher.getExpiredAssetObjectEntryIds(
 					contextCompany.getCompanyId(), objectDefinitionIds);
 
-			if (expiredAssetTokens.isEmpty()) {
+			if (expiredAssetObjectEntryIds.isEmpty()) {
 				return 0;
 			}
 
 			return brokenLinkAssetSearcher.getCount(
-				contextCompany.getCompanyId(), groupIds, expiredAssetTokens);
+				contextCompany.getCompanyId(), groupIds,
+				expiredAssetObjectEntryIds.keySet());
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -5,11 +5,11 @@
 
 package com.liferay.headless.cms.internal.resource.v1_0;
 
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.internal.links.BrokenLinkAssetSearcher;
+import com.liferay.headless.cms.internal.util.CMSGroupUtil;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
-import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
 
 import java.util.Date;
@@ -50,7 +49,12 @@ public class AssetStatisticsResourceImpl
 	public AssetStatistics getAssetStatistics(Long assetLibraryId)
 		throws Exception {
 
-		Long[] groupIds = _getGroupIds(assetLibraryId);
+		Long[] groupIds = CMSGroupUtil.getSelectedSpaceGroupIds(
+			assetLibraryId, contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService,
+			CMSGroupUtil.getSpaceGroupIds(
+				contextCompany.getCompanyId(), _depotEntryService,
+				contextUser.getUserId()));
 
 		if (ArrayUtil.isEmpty(groupIds)) {
 			return _toAssetStatistics();
@@ -194,27 +198,6 @@ public class AssetStatisticsResourceImpl
 
 			return 0;
 		}
-	}
-
-	private Long[] _getGroupIds(Long assetLibraryId) {
-		List<Long> depotEntryGroupIds =
-			_depotEntryService.getDepotEntryGroupIds(
-				contextCompany.getCompanyId(), contextUser.getUserId(),
-				DepotConstants.TYPE_SPACE);
-
-		if (assetLibraryId == null) {
-			return depotEntryGroupIds.toArray(new Long[0]);
-		}
-
-		Long groupId = GroupUtil.getDepotGroupId(
-			String.valueOf(assetLibraryId), contextCompany.getCompanyId(),
-			_depotEntryLocalService, groupLocalService);
-
-		if ((groupId == null) || !depotEntryGroupIds.contains(groupId)) {
-			return new Long[0];
-		}
-
-		return new Long[] {groupId};
 	}
 
 	private AssetStatistics _toAssetStatistics() {

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseBrokenLinkAssetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseBrokenLinkAssetResourceImpl.java
@@ -1,0 +1,556 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseBrokenLinkAssetResourceImpl
+	implements BrokenLinkAssetResource, EntityModelResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-cms/v1.0/broken-link-assets'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "BrokenLinkAsset")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/broken-link-assets")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<BrokenLinkAsset> getBrokenLinkAssetsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-cms";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseBrokenLinkAssetResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:-419457898

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
@@ -5,13 +5,52 @@
 
 package com.liferay.headless.cms.internal.resource.v1_0;
 
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.internal.links.BrokenLinkAssetSearcher;
+import com.liferay.headless.cms.internal.util.CMSGroupUtil;
 import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.entity.StringEntityField;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
- * @author Crescenzo Rega
+ * @author Jürgen Kappler
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/broken-link-asset.properties",
@@ -19,4 +58,185 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class BrokenLinkAssetResourceImpl
 	extends BaseBrokenLinkAssetResourceImpl {
+
+	@Override
+	public Page<BrokenLinkAsset> getBrokenLinkAssetsPage(
+			Long assetLibraryId, String search, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-82226")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		Long[] selectedSpaceGroupIds = CMSGroupUtil.getSelectedSpaceGroupIds(
+			assetLibraryId, contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService,
+			CMSGroupUtil.getSpaceGroupIds(
+				contextCompany.getCompanyId(), _depotEntryService,
+				contextUser.getUserId()));
+
+		if (ArrayUtil.isEmpty(selectedSpaceGroupIds)) {
+			return Page.of(Collections.emptyList());
+		}
+
+		List<ObjectDefinition> objectDefinitions =
+			_objectDefinitionService.getCMSObjectDefinitions(
+				contextCompany.getCompanyId(),
+				new String[] {
+					ObjectFolderConstants.
+						EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+					ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+				});
+
+		Long[] objectDefinitionIds = transformToArray(
+			objectDefinitions, ObjectDefinition::getObjectDefinitionId,
+			Long.class);
+
+		if (ArrayUtil.isEmpty(objectDefinitionIds)) {
+			return Page.of(Collections.emptyList());
+		}
+
+		BrokenLinkAssetSearcher brokenLinkAssetSearcher =
+			new BrokenLinkAssetSearcher(
+				_objectEntryLocalService, _searcher,
+				_searchRequestBuilderFactory);
+
+		Map<String, Long> expiredAssetObjectEntryIds =
+			brokenLinkAssetSearcher.getExpiredAssetObjectEntryIds(
+				contextCompany.getCompanyId(), objectDefinitionIds);
+
+		if (expiredAssetObjectEntryIds.isEmpty()) {
+			return Page.of(Collections.emptyList());
+		}
+
+		SearchResponse searchResponse = brokenLinkAssetSearcher.search(
+			contextCompany.getCompanyId(), selectedSpaceGroupIds,
+			contextAcceptLanguage.getPreferredLanguageId(),
+			expiredAssetObjectEntryIds.keySet(), pagination, search, sorts);
+
+		Map<Long, String> externalReferenceCodes = new HashMap<>();
+
+		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			externalReferenceCodes.put(
+				objectDefinition.getObjectDefinitionId(),
+				objectDefinition.getExternalReferenceCode());
+		}
+
+		return Page.of(
+			transform(
+				searchResponse.getDocuments(),
+				document -> _toBrokenLinkAsset(
+					document, expiredAssetObjectEntryIds,
+					externalReferenceCodes)),
+			pagination, searchResponse.getCount());
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	private String _getBrokenLinkTitle(Set<Long> brokenLinkObjectEntryIds)
+		throws PortalException {
+
+		for (long brokenLinkObjectEntryId : brokenLinkObjectEntryIds) {
+			ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+				brokenLinkObjectEntryId);
+
+			if (objectEntry == null) {
+				continue;
+			}
+
+			return objectEntry.getTitleValue(
+				contextAcceptLanguage.getPreferredLanguageId(), true);
+		}
+
+		return null;
+	}
+
+	private String _getTitle(Document document) {
+		String title = document.getString(
+			Field.getLocalizedName(
+				contextAcceptLanguage.getPreferredLocale(),
+				"objectEntryTitle"));
+
+		if (Validator.isNotNull(title)) {
+			return title;
+		}
+
+		return document.getString("objectEntryTitle");
+	}
+
+	private BrokenLinkAsset _toBrokenLinkAsset(
+		Document document, Map<String, Long> expiredAssetObjectEntryIds,
+		Map<Long, String> externalReferenceCodes) {
+
+		Set<Long> brokenLinkObjectEntryIds = new LinkedHashSet<>();
+
+		for (String outboundLink : document.getStrings("outboundLinks")) {
+			Long brokenLinkObjectEntryId = expiredAssetObjectEntryIds.get(
+				outboundLink);
+
+			if (brokenLinkObjectEntryId != null) {
+				brokenLinkObjectEntryIds.add(brokenLinkObjectEntryId);
+			}
+		}
+
+		long objectEntryId = GetterUtil.getLong(
+			document.getString(Field.ENTRY_CLASS_PK));
+
+		return new BrokenLinkAsset() {
+			{
+				setBrokenLinksCount(
+					() -> (long)brokenLinkObjectEntryIds.size());
+				setBrokenLinkTitle(
+					() -> _getBrokenLinkTitle(brokenLinkObjectEntryIds));
+				setHref(
+					() -> StringBundler.concat(
+						_portal.getPortalURL(contextHttpServletRequest),
+						_portal.getPathMain(), GroupConstants.CMS_FRIENDLY_URL,
+						"/edit_content_item?p_l_mode=read&p_p_state=",
+						LiferayWindowState.POP_UP, "&objectEntryId=",
+						objectEntryId));
+				setId(() -> objectEntryId);
+				setObjectDefinitionExternalReferenceCode(
+					() -> externalReferenceCodes.get(
+						GetterUtil.getLong(
+							document.getString("objectDefinitionId"))));
+				setTitle(() -> _getTitle(document));
+			}
+		};
+	}
+
+	private static final EntityModel _entityModel =
+		() -> EntityModel.toEntityFieldsMap(
+			new StringEntityField(
+				"title",
+				locale -> Field.getSortableFieldName(
+					Field.getLocalizedName(locale, "localized_title"))));
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private DepotEntryService _depotEntryService;
+
+	@Reference
+	private ObjectDefinitionService _objectDefinitionService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
 }

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Crescenzo Rega
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/broken-link-asset.properties",
+	scope = ServiceScope.PROTOTYPE, service = BrokenLinkAssetResource.class
+)
+public class BrokenLinkAssetResourceImpl
+	extends BaseBrokenLinkAssetResourceImpl {
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -91,9 +91,11 @@ public class OpenAPIResourceImpl {
 
 			add(AssetUsageResourceImpl.class);
 
+			add(BrokenLinkAssetResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1867425424
+// LIFERAY-REST-BUILDER-HASH:-529876021

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/BrokenLinkAssetResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/BrokenLinkAssetResourceFactoryImpl.java
@@ -1,0 +1,335 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0.factory;
+
+import com.liferay.headless.cms.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-cms/v1.0/BrokenLinkAsset",
+	service = BrokenLinkAssetResource.Factory.class
+)
+@Generated("")
+public class BrokenLinkAssetResourceFactoryImpl
+	implements BrokenLinkAssetResource.Factory {
+
+	@Override
+	public BrokenLinkAssetResource.Builder create() {
+		return new BrokenLinkAssetResource.Builder() {
+
+			@Override
+			public BrokenLinkAssetResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, BrokenLinkAssetResource>
+					brokenLinkAssetResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_brokenLinkAssetResourceProxyProviderFunction;
+
+				return brokenLinkAssetResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public BrokenLinkAssetResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public BrokenLinkAssetResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public BrokenLinkAssetResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public BrokenLinkAssetResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public BrokenLinkAssetResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public BrokenLinkAssetResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, BrokenLinkAssetResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			BrokenLinkAssetResource.class.getClassLoader(),
+			BrokenLinkAssetResource.class);
+
+		try {
+			Constructor<BrokenLinkAssetResource> constructor =
+				(Constructor<BrokenLinkAssetResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		BrokenLinkAssetResource brokenLinkAssetResource =
+			_componentServiceObjects.getService();
+
+		brokenLinkAssetResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		brokenLinkAssetResource.setContextCompany(company);
+
+		brokenLinkAssetResource.setContextHttpServletRequest(
+			httpServletRequest);
+		brokenLinkAssetResource.setContextHttpServletResponse(
+			httpServletResponse);
+		brokenLinkAssetResource.setContextUriInfo(uriInfo);
+		brokenLinkAssetResource.setContextUser(user);
+		brokenLinkAssetResource.setExpressionConvert(_expressionConvert);
+		brokenLinkAssetResource.setFilterParserProvider(_filterParserProvider);
+		brokenLinkAssetResource.setGroupLocalService(_groupLocalService);
+		brokenLinkAssetResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		brokenLinkAssetResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		brokenLinkAssetResource.setRoleLocalService(_roleLocalService);
+		brokenLinkAssetResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(brokenLinkAssetResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(brokenLinkAssetResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<BrokenLinkAssetResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, BrokenLinkAssetResource>
+				_brokenLinkAssetResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1513477086

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/util/CMSGroupUtil.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/util/CMSGroupUtil.java
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.util;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.vulcan.util.GroupUtil;
+
+import java.util.List;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class CMSGroupUtil {
+
+	public static Long[] getSelectedSpaceGroupIds(
+		Long assetLibraryId, long companyId,
+		DepotEntryLocalService depotEntryLocalService,
+		GroupLocalService groupLocalService, Long[] spaceGroupIds) {
+
+		if (assetLibraryId == null) {
+			return spaceGroupIds;
+		}
+
+		Long groupId = GroupUtil.getDepotGroupId(
+			String.valueOf(assetLibraryId), companyId, depotEntryLocalService,
+			groupLocalService);
+
+		if ((groupId == null) || !ArrayUtil.contains(spaceGroupIds, groupId)) {
+			return new Long[0];
+		}
+
+		return new Long[] {groupId};
+	}
+
+	public static Long[] getSpaceGroupIds(
+		long companyId, DepotEntryService depotEntryService, long userId) {
+
+		List<Long> depotEntryGroupIds = depotEntryService.getDepotEntryGroupIds(
+			companyId, userId, DepotConstants.TYPE_SPACE);
+
+		return depotEntryGroupIds.toArray(new Long[0]);
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/broken-link-asset.properties
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/broken-link-asset.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.CMS)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -11,6 +11,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.cms.client.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.client.resource.v1_0.AssetStatisticsResource;
+import com.liferay.headless.cms.resource.v1_0.test.util.CMSOutboundLinkTestUtil;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
@@ -21,7 +22,6 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -387,15 +387,6 @@ public class AssetStatisticsResourceTest
 				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
 	}
 
-	private String _getImageHTML(String externalReferenceCode) {
-		return StringBundler.concat(
-			"<img src=\"/documents/20125/0/image.jpg/", StringUtil.randomId(),
-			"?download=true&amp;objectDefinitionExternalReferenceCode=",
-			"L_CMS_BASIC_DOCUMENT&amp;objectEntryExternalReferenceCode=",
-			externalReferenceCode,
-			"&amp;objectFieldExternalReferenceCode=FILE\">");
-	}
-
 	private void _testGetAssetStatisticsBrokenLinksCount() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
@@ -410,7 +401,8 @@ public class AssetStatisticsResourceTest
 				depotEntry, objectDefinition);
 
 			_addObjectEntry(
-				_getImageHTML(targetObjectEntry.getExternalReferenceCode()),
+				CMSOutboundLinkTestUtil.getImageHTML(
+					targetObjectEntry.getExternalReferenceCode()),
 				depotEntry, objectDefinition);
 
 			_assertBrokenLinksCount(depotEntry.getGroupId(), 0);
@@ -423,7 +415,8 @@ public class AssetStatisticsResourceTest
 			_assertBrokenLinksCount(depotEntry.getGroupId(), 1);
 
 			_addObjectEntry(
-				_getImageHTML(targetObjectEntry.getExternalReferenceCode()),
+				CMSOutboundLinkTestUtil.getImageHTML(
+					targetObjectEntry.getExternalReferenceCode()),
 				depotEntry, objectDefinition);
 
 			_assertBrokenLinksCount(depotEntry.getGroupId(), 2);
@@ -436,9 +429,9 @@ public class AssetStatisticsResourceTest
 				otherTargetObjectEntry.getObjectEntryId(),
 				WorkflowConstants.STATUS_EXPIRED, serviceContext);
 
-			String imageHTML = _getImageHTML(
+			String imageHTML = CMSOutboundLinkTestUtil.getImageHTML(
 				targetObjectEntry.getExternalReferenceCode());
-			String otherImageHTML = _getImageHTML(
+			String otherImageHTML = CMSOutboundLinkTestUtil.getImageHTML(
 				otherTargetObjectEntry.getExternalReferenceCode());
 
 			_addObjectEntry(

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseBrokenLinkAssetResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseBrokenLinkAssetResourceTestCase.java
@@ -1,0 +1,1383 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.cms.client.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.headless.cms.client.serdes.v1_0.BrokenLinkAssetSerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.JAXRSWhiteboardTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public abstract class BaseBrokenLinkAssetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		JAXRSWhiteboardTestUtil.ensureReady();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_brokenLinkAssetResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		brokenLinkAssetResource = BrokenLinkAssetResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		BrokenLinkAsset brokenLinkAsset1 = randomBrokenLinkAsset();
+
+		String json = objectMapper.writeValueAsString(brokenLinkAsset1);
+
+		BrokenLinkAsset brokenLinkAsset2 = BrokenLinkAssetSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(brokenLinkAsset1, brokenLinkAsset2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		BrokenLinkAsset brokenLinkAsset = randomBrokenLinkAsset();
+
+		String json1 = objectMapper.writeValueAsString(brokenLinkAsset);
+		String json2 = BrokenLinkAssetSerDes.toJSON(brokenLinkAsset);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		BrokenLinkAsset brokenLinkAsset = randomBrokenLinkAsset();
+
+		brokenLinkAsset.setBrokenLinkTitle(regex);
+		brokenLinkAsset.setHref(regex);
+		brokenLinkAsset.setObjectDefinitionExternalReferenceCode(regex);
+		brokenLinkAsset.setTitle(regex);
+
+		String json = BrokenLinkAssetSerDes.toJSON(brokenLinkAsset);
+
+		Assert.assertFalse(json.contains(regex));
+
+		brokenLinkAsset = BrokenLinkAssetSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, brokenLinkAsset.getBrokenLinkTitle());
+		Assert.assertEquals(regex, brokenLinkAsset.getHref());
+		Assert.assertEquals(
+			regex, brokenLinkAsset.getObjectDefinitionExternalReferenceCode());
+		Assert.assertEquals(regex, brokenLinkAsset.getTitle());
+	}
+
+	@Test
+	public void testGetBrokenLinkAssetsPage() throws Exception {
+		Page<BrokenLinkAsset> page =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		BrokenLinkAsset brokenLinkAsset1 =
+			testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+				randomBrokenLinkAsset());
+
+		BrokenLinkAsset brokenLinkAsset2 =
+			testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+				randomBrokenLinkAsset());
+
+		page = brokenLinkAssetResource.getBrokenLinkAssetsPage(
+			null, null, Pagination.of(1, (int)totalCount + 2), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(
+			brokenLinkAsset1, (List<BrokenLinkAsset>)page.getItems());
+		assertContains(
+			brokenLinkAsset2, (List<BrokenLinkAsset>)page.getItems());
+		assertValid(page, testGetBrokenLinkAssetsPage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetBrokenLinkAssetsPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetBrokenLinkAssetsPageWithPagination() throws Exception {
+		Page<BrokenLinkAsset> brokenLinkAssetsPage =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			brokenLinkAssetsPage.getTotalCount());
+
+		BrokenLinkAsset brokenLinkAsset1 =
+			testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+				randomBrokenLinkAsset());
+
+		BrokenLinkAsset brokenLinkAsset2 =
+			testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+				randomBrokenLinkAsset());
+
+		BrokenLinkAsset brokenLinkAsset3 =
+			testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+				randomBrokenLinkAsset());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<BrokenLinkAsset> page1 =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				brokenLinkAsset1, (List<BrokenLinkAsset>)page1.getItems());
+
+			Page<BrokenLinkAsset> page2 =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				brokenLinkAsset2, (List<BrokenLinkAsset>)page2.getItems());
+
+			Page<BrokenLinkAsset> page3 =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				brokenLinkAsset3, (List<BrokenLinkAsset>)page3.getItems());
+		}
+		else {
+			Page<BrokenLinkAsset> page1 =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null, Pagination.of(1, totalCount + 2), null);
+
+			List<BrokenLinkAsset> brokenLinkAssets1 =
+				(List<BrokenLinkAsset>)page1.getItems();
+
+			Assert.assertEquals(
+				brokenLinkAssets1.toString(), totalCount + 2,
+				brokenLinkAssets1.size());
+
+			Page<BrokenLinkAsset> page2 =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null, Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<BrokenLinkAsset> brokenLinkAssets2 =
+				(List<BrokenLinkAsset>)page2.getItems();
+
+			Assert.assertEquals(
+				brokenLinkAssets2.toString(), 1, brokenLinkAssets2.size());
+
+			Page<BrokenLinkAsset> page3 =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null, Pagination.of(1, (int)totalCount + 3), null);
+
+			assertContains(
+				brokenLinkAsset1, (List<BrokenLinkAsset>)page3.getItems());
+			assertContains(
+				brokenLinkAsset2, (List<BrokenLinkAsset>)page3.getItems());
+			assertContains(
+				brokenLinkAsset3, (List<BrokenLinkAsset>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortDateTime() throws Exception {
+		testGetBrokenLinkAssetsPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, brokenLinkAsset1, brokenLinkAsset2) -> {
+				BeanTestUtil.setProperty(
+					brokenLinkAsset1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortDouble() throws Exception {
+		testGetBrokenLinkAssetsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, brokenLinkAsset1, brokenLinkAsset2) -> {
+				BeanTestUtil.setProperty(
+					brokenLinkAsset1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					brokenLinkAsset2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortInteger() throws Exception {
+		testGetBrokenLinkAssetsPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, brokenLinkAsset1, brokenLinkAsset2) -> {
+				BeanTestUtil.setProperty(
+					brokenLinkAsset1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					brokenLinkAsset2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortString() throws Exception {
+		testGetBrokenLinkAssetsPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, brokenLinkAsset1, brokenLinkAsset2) -> {
+				Class<?> clazz = brokenLinkAsset1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						brokenLinkAsset1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						brokenLinkAsset2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						brokenLinkAsset1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						brokenLinkAsset2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						brokenLinkAsset1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						brokenLinkAsset2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetBrokenLinkAssetsPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, BrokenLinkAsset, BrokenLinkAsset, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		BrokenLinkAsset brokenLinkAsset1 = randomBrokenLinkAsset();
+		BrokenLinkAsset brokenLinkAsset2 = randomBrokenLinkAsset();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, brokenLinkAsset1, brokenLinkAsset2);
+		}
+
+		brokenLinkAsset1 = testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+			brokenLinkAsset1);
+
+		brokenLinkAsset2 = testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+			brokenLinkAsset2);
+
+		Page<BrokenLinkAsset> page =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<BrokenLinkAsset> ascPage =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null, Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(
+				brokenLinkAsset1, (List<BrokenLinkAsset>)ascPage.getItems());
+			assertContains(
+				brokenLinkAsset2, (List<BrokenLinkAsset>)ascPage.getItems());
+
+			Page<BrokenLinkAsset> descPage =
+				brokenLinkAssetResource.getBrokenLinkAssetsPage(
+					null, null, Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(
+				brokenLinkAsset2, (List<BrokenLinkAsset>)descPage.getItems());
+			assertContains(
+				brokenLinkAsset1, (List<BrokenLinkAsset>)descPage.getItems());
+		}
+	}
+
+	protected BrokenLinkAsset testGetBrokenLinkAssetsPage_addBrokenLinkAsset(
+			BrokenLinkAsset brokenLinkAsset)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertContains(
+		BrokenLinkAsset brokenLinkAsset,
+		List<BrokenLinkAsset> brokenLinkAssets) {
+
+		boolean contains = false;
+
+		for (BrokenLinkAsset item : brokenLinkAssets) {
+			if (equals(brokenLinkAsset, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			brokenLinkAssets + " does not contain " + brokenLinkAsset,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		BrokenLinkAsset brokenLinkAsset1, BrokenLinkAsset brokenLinkAsset2) {
+
+		Assert.assertTrue(
+			brokenLinkAsset1 + " does not equal " + brokenLinkAsset2,
+			equals(brokenLinkAsset1, brokenLinkAsset2));
+	}
+
+	protected void assertEquals(
+		List<BrokenLinkAsset> brokenLinkAssets1,
+		List<BrokenLinkAsset> brokenLinkAssets2) {
+
+		Assert.assertEquals(brokenLinkAssets1.size(), brokenLinkAssets2.size());
+
+		for (int i = 0; i < brokenLinkAssets1.size(); i++) {
+			BrokenLinkAsset brokenLinkAsset1 = brokenLinkAssets1.get(i);
+			BrokenLinkAsset brokenLinkAsset2 = brokenLinkAssets2.get(i);
+
+			assertEquals(brokenLinkAsset1, brokenLinkAsset2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<BrokenLinkAsset> brokenLinkAssets1,
+		List<BrokenLinkAsset> brokenLinkAssets2) {
+
+		Assert.assertEquals(brokenLinkAssets1.size(), brokenLinkAssets2.size());
+
+		for (BrokenLinkAsset brokenLinkAsset1 : brokenLinkAssets1) {
+			boolean contains = false;
+
+			for (BrokenLinkAsset brokenLinkAsset2 : brokenLinkAssets2) {
+				if (equals(brokenLinkAsset1, brokenLinkAsset2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				brokenLinkAssets2 + " does not contain " + brokenLinkAsset1,
+				contains);
+		}
+	}
+
+	protected void assertValid(BrokenLinkAsset brokenLinkAsset)
+		throws Exception {
+
+		boolean valid = true;
+
+		if (brokenLinkAsset.getId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("brokenLinkTitle", additionalAssertFieldName)) {
+				if (brokenLinkAsset.getBrokenLinkTitle() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("brokenLinksCount", additionalAssertFieldName)) {
+				if (brokenLinkAsset.getBrokenLinksCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("href", additionalAssertFieldName)) {
+				if (brokenLinkAsset.getHref() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"objectDefinitionExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (brokenLinkAsset.
+						getObjectDefinitionExternalReferenceCode() == null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (brokenLinkAsset.getTitle() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<BrokenLinkAsset> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<BrokenLinkAsset> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<BrokenLinkAsset> brokenLinkAssets =
+			page.getItems();
+
+		int size = brokenLinkAssets.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		BrokenLinkAsset brokenLinkAsset1, BrokenLinkAsset brokenLinkAsset2) {
+
+		if (brokenLinkAsset1 == brokenLinkAsset2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("brokenLinkTitle", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						brokenLinkAsset1.getBrokenLinkTitle(),
+						brokenLinkAsset2.getBrokenLinkTitle())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("brokenLinksCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						brokenLinkAsset1.getBrokenLinksCount(),
+						brokenLinkAsset2.getBrokenLinksCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("href", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						brokenLinkAsset1.getHref(),
+						brokenLinkAsset2.getHref())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						brokenLinkAsset1.getId(), brokenLinkAsset2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"objectDefinitionExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						brokenLinkAsset1.
+							getObjectDefinitionExternalReferenceCode(),
+						brokenLinkAsset2.
+							getObjectDefinitionExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						brokenLinkAsset1.getTitle(),
+						brokenLinkAsset2.getTitle())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_brokenLinkAssetResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_brokenLinkAssetResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		BrokenLinkAsset brokenLinkAsset) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("brokenLinkTitle")) {
+			Object object = brokenLinkAsset.getBrokenLinkTitle();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("brokenLinksCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("href")) {
+			Object object = brokenLinkAsset.getHref();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("objectDefinitionExternalReferenceCode")) {
+			Object object =
+				brokenLinkAsset.getObjectDefinitionExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("title")) {
+			Object object = brokenLinkAsset.getTitle();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected BrokenLinkAsset randomBrokenLinkAsset() throws Exception {
+		return new BrokenLinkAsset() {
+			{
+				brokenLinkTitle = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				brokenLinksCount = RandomTestUtil.randomLong();
+				href = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
+				objectDefinitionExternalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected BrokenLinkAsset randomIrrelevantBrokenLinkAsset()
+		throws Exception {
+
+		BrokenLinkAsset randomIrrelevantBrokenLinkAsset =
+			randomBrokenLinkAsset();
+
+		return randomIrrelevantBrokenLinkAsset;
+	}
+
+	protected BrokenLinkAsset randomPatchBrokenLinkAsset() throws Exception {
+		return randomBrokenLinkAsset();
+	}
+
+	protected BrokenLinkAssetResource brokenLinkAssetResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseBrokenLinkAssetResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource
+		_brokenLinkAssetResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-955489855

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Crescenzo Rega
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class BrokenLinkAssetResourceTest
+	extends BaseBrokenLinkAssetResourceTestCase {
+}

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
@@ -6,15 +6,341 @@
 package com.liferay.headless.cms.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.headless.cms.client.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.resource.v1_0.test.util.CMSOutboundLinkTestUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import org.junit.Ignore;
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Crescenzo Rega
+ * @author Jürgen Kappler
  */
-@Ignore
+@FeatureFlag("LPD-82226")
 @RunWith(Arquillian.class)
 public class BrokenLinkAssetResourceTest
 	extends BaseBrokenLinkAssetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testGetBrokenLinkAssetsPage() throws Exception {
+		_testGetBrokenLinkAssetsPage(RandomTestUtil.randomString());
+		_testGetBrokenLinkAssetsPage(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		_testGetBrokenLinkAssetsPageWithDuplicateTitles();
+	}
+
+	@Override
+	@Test
+	public void testGetBrokenLinkAssetsPageWithPagination() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		ObjectEntry expiredObjectEntry = _addExpiredObjectEntry(
+			depotEntry, objectDefinition, serviceContext);
+
+		String imageHTML = CMSOutboundLinkTestUtil.getImageHTML(
+			expiredObjectEntry.getExternalReferenceCode());
+
+		for (int i = 0; i < 3; i++) {
+			_addObjectEntry(
+				imageHTML, depotEntry, objectDefinition,
+				RandomTestUtil.randomString());
+		}
+
+		Page<BrokenLinkAsset> brokenLinkAssetsPage =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				depotEntry.getDepotEntryId(), null, Pagination.of(1, 2), null);
+
+		Assert.assertEquals(3, brokenLinkAssetsPage.getTotalCount());
+
+		List<BrokenLinkAsset> brokenLinkAssets =
+			(List<BrokenLinkAsset>)brokenLinkAssetsPage.getItems();
+
+		Assert.assertEquals(
+			brokenLinkAssets.toString(), 2, brokenLinkAssets.size());
+
+		brokenLinkAssetsPage = brokenLinkAssetResource.getBrokenLinkAssetsPage(
+			depotEntry.getDepotEntryId(), null, Pagination.of(2, 2), null);
+
+		Assert.assertEquals(3, brokenLinkAssetsPage.getTotalCount());
+
+		brokenLinkAssets =
+			(List<BrokenLinkAsset>)brokenLinkAssetsPage.getItems();
+
+		Assert.assertEquals(
+			brokenLinkAssets.toString(), 1, brokenLinkAssets.size());
+	}
+
+	@Override
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortDateTime() throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortDouble() throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortInteger() throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testGetBrokenLinkAssetsPageWithSortString() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		ObjectEntry expiredObjectEntry = _addExpiredObjectEntry(
+			depotEntry, objectDefinition, serviceContext);
+
+		String imageHTML = CMSOutboundLinkTestUtil.getImageHTML(
+			expiredObjectEntry.getExternalReferenceCode());
+
+		_addObjectEntry(imageHTML, depotEntry, objectDefinition, "aaa");
+		_addObjectEntry(imageHTML, depotEntry, objectDefinition, "bbb");
+
+		_assertTitleOrder(depotEntry, "aaa", "bbb", "title:asc");
+		_assertTitleOrder(depotEntry, "bbb", "aaa", "title:desc");
+	}
+
+	private ObjectEntry _addExpiredObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			RandomTestUtil.randomString(), depotEntry, objectDefinition,
+			RandomTestUtil.randomString());
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			WorkflowConstants.STATUS_EXPIRED, serviceContext);
+
+		return objectEntry;
+	}
+
+	private ObjectEntry _addObjectEntry(
+			String content, DepotEntry depotEntry,
+			ObjectDefinition objectDefinition, String title)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", content
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", title
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private DepotEntry _addSpaceDepotEntry(ServiceContext serviceContext)
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private void _assertTitleOrder(
+			DepotEntry depotEntry, String expectedFirstTitle,
+			String expectedSecondTitle, String sortString)
+		throws Exception {
+
+		Page<BrokenLinkAsset> brokenLinkAssetsPage =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				depotEntry.getDepotEntryId(), null, null, sortString);
+
+		List<BrokenLinkAsset> brokenLinkAssets =
+			(List<BrokenLinkAsset>)brokenLinkAssetsPage.getItems();
+
+		Assert.assertEquals(
+			brokenLinkAssets.toString(), 2, brokenLinkAssets.size());
+
+		BrokenLinkAsset firstBrokenLinkAsset = brokenLinkAssets.get(0);
+
+		Assert.assertEquals(
+			expectedFirstTitle, firstBrokenLinkAsset.getTitle());
+
+		BrokenLinkAsset secondBrokenLinkAsset = brokenLinkAssets.get(1);
+
+		Assert.assertEquals(
+			expectedSecondTitle, secondBrokenLinkAsset.getTitle());
+	}
+
+	private ObjectDefinition _getBasicWebContentObjectDefinition()
+		throws Exception {
+
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
+	}
+
+	private void _testGetBrokenLinkAssetsPage(String... targetTitles)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		StringBundler sb = new StringBundler(targetTitles.length);
+
+		for (String targetTitle : targetTitles) {
+			ObjectEntry targetObjectEntry = _addObjectEntry(
+				RandomTestUtil.randomString(), depotEntry, objectDefinition,
+				targetTitle);
+
+			sb.append(
+				CMSOutboundLinkTestUtil.getImageHTML(
+					targetObjectEntry.getExternalReferenceCode()));
+
+			_objectEntryLocalService.updateStatus(
+				TestPropsValues.getUserId(),
+				targetObjectEntry.getObjectEntryId(),
+				WorkflowConstants.STATUS_EXPIRED, serviceContext);
+		}
+
+		String referencingTitle = RandomTestUtil.randomString();
+
+		_addObjectEntry(
+			sb.toString(), depotEntry, objectDefinition, referencingTitle);
+
+		Page<BrokenLinkAsset> brokenLinkAssetsPage =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				depotEntry.getDepotEntryId(), null, null, null);
+
+		Assert.assertEquals(1, brokenLinkAssetsPage.getTotalCount());
+
+		List<BrokenLinkAsset> brokenLinkAssets =
+			(List<BrokenLinkAsset>)brokenLinkAssetsPage.getItems();
+
+		BrokenLinkAsset brokenLinkAsset = brokenLinkAssets.get(0);
+
+		Assert.assertEquals(
+			targetTitles.length,
+			GetterUtil.getInteger(brokenLinkAsset.getBrokenLinksCount()));
+		Assert.assertEquals(
+			"L_CMS_BASIC_WEB_CONTENT",
+			brokenLinkAsset.getObjectDefinitionExternalReferenceCode());
+		Assert.assertEquals(referencingTitle, brokenLinkAsset.getTitle());
+
+		if (targetTitles.length == 1) {
+			Assert.assertEquals(
+				targetTitles[0], brokenLinkAsset.getBrokenLinkTitle());
+		}
+	}
+
+	private void _testGetBrokenLinkAssetsPageWithDuplicateTitles()
+		throws Exception {
+
+		String targetTitle = RandomTestUtil.randomString();
+
+		_testGetBrokenLinkAssetsPage(targetTitle, targetTitle);
+	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
 }

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/util/CMSOutboundLinkTestUtil.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/util/CMSOutboundLinkTestUtil.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class CMSOutboundLinkTestUtil {
+
+	public static String getImageHTML(String externalReferenceCode) {
+		return StringBundler.concat(
+			"<img src=\"/documents/", RandomTestUtil.randomLong(),
+			"/0/image.jpg/", StringUtil.randomId(),
+			"?download=true&amp;objectDefinitionExternalReferenceCode=",
+			"L_CMS_BASIC_DOCUMENT&amp;objectEntryExternalReferenceCode=",
+			externalReferenceCode,
+			"&amp;objectFieldExternalReferenceCode=FILE\">");
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103025

Second of four pull requests that replace #8808, split into smaller pieces at Brian's request. The first, #8822, is in master. This one replaces #8826, whose forward Brian closed with two requests, both applied below.

## What Is Being Fixed

The Attention Required card reports how many contents point at an expired asset, but nothing serves that list, so the card has nowhere to send the user and the Broken Links page has no data to render.

## How It Is Being Fixed

A `getBrokenLinkAssetsPage` operation on the headless CMS API enumerates the expired assets in scope, turns each one into its outbound link tokens, and searches for the contents whose indexed `outboundLinks` field matches any of them. Each row carries the referring content's title, its object definition, the number of expired assets it points at, and the title of one of them for the subtitle. Results can be sorted by title and paged.

The searcher extracted in #8822 gains the paged search this needs, and its enumeration now returns each token mapped to its object entry ID, because counting distinct assets and resolving the subtitle both need the ID rather than the token. The card uses the same call and reports the same number as before.

The group resolution the card already performed moves to a `CMSGroupUtil` that both surfaces share, so the endpoint does not grow its own copy.

Brian's two requests are folded into the commits that introduced the code rather than stacked on top, so the property carries one name throughout and the generated output stays in a single `buildREST` commit. The DTO property is now `brokenLinksCount`, matching `AssetStatistics.brokenLinksCount`, and the assertions on the DTO are sorted by getter.

The `Baseline` commit #8826 carried is gone rather than missing: master has since bumped `headless/cms/resource/v1_0` to 3.1.0 under LPD-97871, so the new `BrokenLinkAssetResource` interface rides that bump and `ant baseline-all` reports nothing.

Three related corrections are deliberately left for LPD-103026, since each changes what the shipped card counts: scoping the expired asset enumeration to the Spaces the caller can see, filtering rows by the caller's permissions, and excluding referring contents that are themselves expired.

## How to Execute the Tests

```bash
gradlew -p modules/apps/headless/headless-cms/headless-cms-test testIntegration --tests "com.liferay.headless.cms.resource.v1_0.test.BrokenLinkAssetResourceTest"
```

```bash
gradlew -p modules/apps/headless/headless-cms/headless-cms-test testIntegration --tests "com.liferay.headless.cms.resource.v1_0.test.AssetStatisticsResourceTest"
```

## PR Check

**pr-check: PASS** — tested on `9043d4d6105c1a039842fb13b8a3fec86490bd60`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9043d4d6105c1a039842fb13b8a3fec86490bd60"} -->
