### PR TITLE
LPD-103198 Search a CMS folder subtree instead of its direct children

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -11,6 +11,7 @@ import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
@@ -42,7 +43,10 @@ public class ObjectEntryFolderModelDocumentContributor
 		String[] parts = StringUtil.split(
 			objectEntryFolder.getTreePath(), CharPool.SLASH);
 
-		document.addKeyword(Field.TREE_PATH, parts);
+		if (parts.length > 1) {
+			document.addKeyword(
+				Field.TREE_PATH, ArrayUtil.subset(parts, 0, parts.length - 1));
+		}
 
 		String cmsSection = _getCMSSection(parts);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -640,6 +640,10 @@ public class ObjectEntryModelDocumentContributor
 			return;
 		}
 
+		document.addKeyword(
+			Field.TREE_PATH,
+			StringUtil.split(objectEntryFolder.getTreePath(), CharPool.SLASH));
+
 		ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
 			objectEntryFolder);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryFolderModelDocumentContributorTest.java
@@ -129,6 +129,15 @@ public class ObjectEntryFolderModelDocumentContributorTest {
 		Assert.assertEquals(
 			objectEntryFolder.getName(), document.get(Field.NAME));
 
+		Field treePathField = document.getField(Field.TREE_PATH);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				StringPool.BLANK,
+				String.valueOf(parentObjectEntryFolder.getObjectEntryFolderId())
+			},
+			treePathField.getValues());
+
 		for (Map.Entry<String, String> entry : attributes.entrySet()) {
 			Assert.assertEquals(entry.getValue(), document.get(entry.getKey()));
 		}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -19,11 +19,13 @@ import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectEntryFolderTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Role;
@@ -454,6 +456,48 @@ public class ObjectEntryModelDocumentContributorTest {
 		Assert.assertNull(
 			document.getField(
 				Field.getLocalizedName(LocaleUtil.US, "objectEntryContent")));
+	}
+
+	@Test
+	public void testContributeWithObjectEntryFolder() throws Exception {
+		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			_addModifiableSystemObjectDefinition(false, objectFieldName);
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		Document document = new DocumentImpl();
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			ObjectEntryFolderTestUtil.addObjectEntryFolder();
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderTestUtil.addObjectEntryFolder(
+				TestPropsValues.getGroupId(),
+				parentObjectEntryFolder.getObjectEntryFolderId());
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			objectEntryFolder.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, RandomTestUtil.randomString()
+			).build());
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		Field field = document.getField(Field.TREE_PATH);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				StringPool.BLANK,
+				String.valueOf(
+					parentObjectEntryFolder.getObjectEntryFolderId()),
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId())
+			},
+			field.getValues());
 	}
 
 	private ObjectDefinition _addModifiableSystemObjectDefinition(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -62,6 +62,8 @@ public class SearchResultEntityModel implements EntityModel {
 				new StringEntityField(
 					"objectFolderExternalReferenceCode",
 					locale -> "objectFolderExternalReferenceCode")),
+			new CollectionEntityField(
+				new StringEntityField("treePath", locale -> Field.TREE_PATH)),
 			new DateTimeEntityField(
 				"cmpDueDate", locale -> "cmpDueDate", locale -> "cmpDueDate"),
 			new DateTimeEntityField(

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -1702,7 +1702,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		"extension", "dateDisplay", "dateExpiration", "datePublish",
 		"dateReview", "dueDate", "folderId",
 		"objectDefinitionExternalReferenceCode",
-		"objectFolderExternalReferenceCode", "rootDescendantNode"
+		"objectFolderExternalReferenceCode", "rootDescendantNode", "treePath"
 	};
 
 	private AssetCategory _assetCategory;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -81,22 +81,12 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 			getRootObjectEntryFolderExternalReferenceCode(),
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS);
 
-		boolean rootFolder = false;
-
-		if (objectEntryFolder != null) {
-			rootFolder = Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				getRootObjectEntryFolderExternalReferenceCode());
-		}
-
 		return new HashMapBuilder<>().putAll(
 			super.getAdditionalProps()
 		).put(
 			"breadcrumbProps", getBreadcrumbProps()
 		).put(
 			"galleryViewEnabled", !contentsFolder
-		).put(
-			"rootFolder", rootFolder
 		).put(
 			"rootObjectEntryFolderExternalReferenceCode",
 			getRootObjectEntryFolderExternalReferenceCode()

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -72,19 +72,16 @@ import transformFDSBulkActions from './utils/transformFDSBulkActions';
 import transformViewsItemsProps from './utils/transformViewsItemProps';
 import GalleryView from './views/GalleryView';
 
-/**
- * Transforms additionalAPIURLParameters to remove folderId filter when searching at root folder.
- * Hoisted outside component to avoid recreation
- */
+const FOLDER_ID_FILTER_REGEX = /^folderId eq (\d+)$/;
+
 export interface AdditionalAPIURLParametersTransformerArgs {
 	additionalAPIURLParameters: string;
-	rootFolder?: boolean;
 	searchParam: string;
 }
 const additionalAPIURLParametersTransformer = (
 	args: AdditionalAPIURLParametersTransformerArgs
 ): string | undefined => {
-	const {additionalAPIURLParameters, rootFolder, searchParam} = args;
+	const {additionalAPIURLParameters, searchParam} = args;
 
 	if (!additionalAPIURLParameters) {
 		return additionalAPIURLParameters;
@@ -112,16 +109,15 @@ const additionalAPIURLParametersTransformer = (
 	const cleanedFilters = filterContent
 		.split(/\s+and\s+/i)
 		.map((part) => part.trim())
-		.filter((part) => {
-			if (part === 'cmsRoot eq true') {
-				return false;
+		.filter((part) => part !== '' && part !== 'cmsRoot eq true')
+		.map((part) => {
+			const matches = part.match(FOLDER_ID_FILTER_REGEX);
+
+			if (matches) {
+				return `treePath/any(t:t eq '${matches[1]}')`;
 			}
 
-			if (rootFolder && part.startsWith('folderId eq')) {
-				return false;
-			}
-
-			return part !== '';
+			return part;
 		});
 
 	if (!cleanedFilters.length) {
@@ -169,7 +165,6 @@ export type AdditionalProps = {
 	objectEntryFolderExternalReferenceCode: string;
 	parentObjectEntryFolderExternalReferenceCode: string;
 	redirect: string;
-	rootFolder?: boolean;
 	rootObjectEntryFolderExternalReferenceCode: string;
 	showAdditionalItemInfo?: boolean;
 	trashEnabled?: boolean;
@@ -231,11 +226,8 @@ export default function AssetsFDSPropsTransformer({
 		mergedViews = [...nonDefaultViews, galleryViewRenderer];
 	}
 
-	const {
-		additionalAPIURLParameters,
-		rootFolder,
-		...remainingAdditionalProps
-	} = additionalProps || {};
+	const {additionalAPIURLParameters, ...remainingAdditionalProps} =
+		additionalProps || {};
 
 	const bulkActionAPIURL =
 		additionalAPIURLParameters && otherProps.apiURL
@@ -252,13 +244,7 @@ export default function AssetsFDSPropsTransformer({
 	return {
 		...otherProps,
 		additionalAPIURLParameters,
-		additionalAPIURLParametersTransformer: (
-			args: AdditionalAPIURLParametersTransformerArgs
-		) =>
-			additionalAPIURLParametersTransformer({
-				...args,
-				rootFolder,
-			}),
+		additionalAPIURLParametersTransformer,
 		additionalProps: remainingAdditionalProps,
 		bulkActions: transformFDSBulkActions(bulkActions),
 		creationMenu: {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformer.test.ts
@@ -261,6 +261,63 @@ describe('AssetsFDSPropsTransformer', () => {
 		expect(folderItem.className).toBeUndefined();
 	});
 
+	describe('additionalAPIURLParametersTransformer', () => {
+		const FOLDER_PARAMETERS =
+			'emptySearch=true&filter=folderId eq 12345 and rootDescendantNode eq false and status in (0, 2, 3)&sort=dateModified:desc';
+
+		const SECTION_PARAMETERS =
+			"emptySearch=true&filter=cmsRoot eq true and cmsSection eq 'files' and rootDescendantNode eq false&sort=dateModified:desc";
+
+		const transform = (
+			additionalAPIURLParameters: string,
+			searchParam: string
+		) => {
+			const {additionalAPIURLParametersTransformer} =
+				AssetsFDSPropsTransformer({
+					additionalProps: {
+						...mockAdditionalProps,
+						additionalAPIURLParameters,
+					},
+					creationMenu: {primaryItems: []},
+					views: [],
+				});
+
+			return additionalAPIURLParametersTransformer({
+				additionalAPIURLParameters,
+				searchParam,
+			});
+		};
+
+		it('keeps the folder scope when there is no search term', () => {
+			expect(transform(FOLDER_PARAMETERS, '')).toBe(FOLDER_PARAMETERS);
+			expect(transform(FOLDER_PARAMETERS, '   ')).toBe(FOLDER_PARAMETERS);
+		});
+
+		it('widens the folder scope to the folder subtree when searching', () => {
+			expect(transform(FOLDER_PARAMETERS, 'bojler')).toBe(
+				"emptySearch=true&filter=treePath/any(t:t eq '12345') and rootDescendantNode eq false and status in (0, 2, 3)&sort=dateModified:desc"
+			);
+		});
+
+		it('drops the CMS root clause when searching in a section', () => {
+			expect(transform(SECTION_PARAMETERS, 'bojler')).toBe(
+				"emptySearch=true&filter=cmsSection eq 'files' and rootDescendantNode eq false&sort=dateModified:desc"
+			);
+		});
+
+		it('drops the filter when no clause survives', () => {
+			expect(
+				transform('emptySearch=true&filter=cmsRoot eq true', 'bojler')
+			).toBe('emptySearch=true');
+		});
+
+		it('keeps parameters without a filter untouched', () => {
+			expect(transform('emptySearch=true', 'bojler')).toBe(
+				'emptySearch=true'
+			);
+		});
+	});
+
 	describe('onActionDropdownItemClick', () => {
 		const mockEvent = {preventDefault: jest.fn()} as any;
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -701,3 +701,62 @@ test(
 		).toBe(true);
 	}
 );
+
+test(
+	'Searching in a folder finds subfolder assets but not the folder itself',
+	{tag: '@LPD-103198'},
+	async ({apiHelpers, assetsPage}) => {
+		const folderTitle = getRandomString();
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			scopeKey: 'Default',
+			title: folderTitle,
+		});
+
+		const subfolder = await apiHelpers.objectFolder.createObjectEntryFolder(
+			{
+				parentObjectEntryFolderExternalReferenceCode:
+					folder.externalReferenceCode,
+				scopeKey: 'Default',
+				title: getRandomString(),
+			}
+		);
+
+		const subfolderContentTitle = getRandomString();
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64:
+						Buffer.from(getRandomString()).toString('base64'),
+					name: `${getRandomString()}.txt`,
+				},
+				objectEntryFolderExternalReferenceCode:
+					subfolder.externalReferenceCode,
+				title: subfolderContentTitle,
+			},
+			'cms/basic-documents',
+			'Default'
+		);
+
+		await assetsPage.gotoFiles();
+
+		await assetsPage.changeVisualizationMode('Table');
+
+		await assetsPage.search(folderTitle);
+
+		await expect(assetsPage.getItem(folderTitle)).toBeVisible();
+
+		await assetsPage.gotoFolder(folder.id, folderTitle);
+
+		await assetsPage.changeVisualizationMode('Table');
+
+		await assetsPage.search(subfolderContentTitle);
+
+		await expect(assetsPage.getItem(subfolderContentTitle)).toBeVisible();
+
+		await assetsPage.search(folderTitle);
+
+		await expect(assetsPage.getItem(folderTitle)).toBeHidden();
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -713,50 +713,56 @@ test(
 			title: folderTitle,
 		});
 
-		const subfolder = await apiHelpers.objectFolder.createObjectEntryFolder(
-			{
-				parentObjectEntryFolderExternalReferenceCode:
-					folder.externalReferenceCode,
-				scopeKey: 'Default',
-				title: getRandomString(),
-			}
-		);
+		try {
+			const subfolder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode:
+						folder.externalReferenceCode,
+					scopeKey: 'Default',
+					title: getRandomString(),
+				});
 
-		const subfolderContentTitle = getRandomString();
+			const subfolderContentTitle = getRandomString();
 
-		await apiHelpers.objectEntry.postObjectEntry(
-			{
-				file: {
-					fileBase64:
-						Buffer.from(getRandomString()).toString('base64'),
-					name: `${getRandomString()}.txt`,
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64:
+							Buffer.from(getRandomString()).toString('base64'),
+						name: `${getRandomString()}.txt`,
+					},
+					objectEntryFolderExternalReferenceCode:
+						subfolder.externalReferenceCode,
+					title: subfolderContentTitle,
 				},
-				objectEntryFolderExternalReferenceCode:
-					subfolder.externalReferenceCode,
-				title: subfolderContentTitle,
-			},
-			'cms/basic-documents',
-			'Default'
-		);
+				'cms/basic-documents',
+				'Default'
+			);
 
-		await assetsPage.gotoFiles();
+			await assetsPage.gotoFiles();
 
-		await assetsPage.changeVisualizationMode('Table');
+			await assetsPage.changeVisualizationMode('Table');
 
-		await assetsPage.search(folderTitle);
+			await assetsPage.search(folderTitle);
 
-		await expect(assetsPage.getItem(folderTitle)).toBeVisible();
+			await expect(assetsPage.getItem(folderTitle)).toBeVisible();
 
-		await assetsPage.gotoFolder(folder.id, folderTitle);
+			await assetsPage.gotoFolder(folder.id, folderTitle);
 
-		await assetsPage.changeVisualizationMode('Table');
+			await assetsPage.changeVisualizationMode('Table');
 
-		await assetsPage.search(subfolderContentTitle);
+			await assetsPage.search(subfolderContentTitle);
 
-		await expect(assetsPage.getItem(subfolderContentTitle)).toBeVisible();
+			await expect(
+				assetsPage.getItem(subfolderContentTitle)
+			).toBeVisible();
 
-		await assetsPage.search(folderTitle);
+			await assetsPage.search(folderTitle);
 
-		await expect(assetsPage.getItem(folderTitle)).toBeHidden();
+			await expect(assetsPage.getItem(folderTitle)).toBeHidden();
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+		}
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103198

## What Is Being Fixed

In the new CMS, a search started inside a folder returned only the items sitting directly in that folder, so anything held in a subfolder was invisible. A customer reported it against 2026.Q1 as LPP-65180.

The asset data set scopes itself with `folderId`, which on an indexed object entry is the entry's immediate folder, so any surviving `folderId eq N` clause confines results to direct children. LPD-84145 covered the section root by stripping `cmsRoot eq true` on search, and its design review subtask LPD-85887 was discarded, so recursion from a nested folder was never implemented.

## How It Is Being Fixed

`Field.TREE_PATH` becomes the scoping term, meaning "the chain of folders containing this item" on every indexed document. Object entry documents start carrying it, matching the semantics `ObjectEntry` already persists in its own `treePath` column, where `ObjectEntryImpl.buildTreePath` returns the containing folder's chain. `SearchResultEntityModel` exposes `treePath` as a filterable collection field, and the CMS props transformer rewrites `folderId eq N` into `treePath/any(t:t eq 'N')` whenever a search term is present. The lambda form is required because a bare `eq` on a collection field is rejected with `Collection not allowed.`, and it matches the `groupIds/any(g:g in (...))` idiom this module already uses.

Folder documents needed the same semantics to make that term safe. `ObjectEntryFolder.buildTreePath` walks from the folder itself, so `ObjectEntryFolderModelDocumentContributor` used to index the folder's own id as the last token while an entry indexes only its containers. Both document types come back from the one `/o/search/v1.0/search` query behind the listing, so folder `N` satisfied `treePath/any(t:t eq 'N')` and appeared as a row inside its own search results, which `folderId eq N` could never do because a folder document's `folderId` is its parent's id. The contributor now indexes the chain minus the folder itself. `cms_section` and `cms_root` still derive from the full split, so the `parts.length == 3` test is unchanged.

The index and the persisted column diverge here by design: `ObjectEntryFolder.treePath` stays self-inclusive, and the `(groupId, companyId, treePath)` finder reads the column, not the index.

Applying the rewrite uniformly also covers the Space root folder, so the `rootFolder` prop and its branch go away. That closes a side effect of the previous approach: at a root folder the `folderId` clause was dropped outright, and the folder filter never adds `cmsSection`, so a search started at the Files root folder could return Contents assets.

One consequence reaches outside CMS. `FolderIdQueryPreFilterContributor` already turns `searchContext` folder ids into a `Field.TREE_PATH` terms filter and is registered without an `indexer.class.name`. Since only object entry folder documents changed, the effect is confined to a search that both sets folder ids and expects an object entry folder document back; no caller in `object`, `site-cms-site-initializer` or `headless-cms` sets them.

Content indexed before this change carries no `treePath`, so a reindex of the Object entries index is required for the fix to take effect on existing data.

## Test Execution

```bash
(cd modules/apps/site/site-cms-site-initializer && yarn test AssetsFDSPropsTransformer)
gradlew -p modules/apps/object/object-test testIntegration --tests ObjectEntryModelDocumentContributorTest --tests ObjectEntryFolderModelDocumentContributorTest
gradlew -p modules/apps/portal-search/portal-search-rest-test testIntegration --tests SearchResultResourceTest
(cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/folders.spec.ts)
```

`ObjectEntryFolderModelDocumentContributorTest` is the regression pin for the self-listing defect: it asserts a folder document's `treePath` excludes the folder's own id. Reverting the contributor fails it with `array lengths differed, expected.length=2 actual.length=3`, the extra element being that id.

The Playwright case searches the folder's title at the Files root and asserts it visible, then searches the same term inside the folder and asserts it hidden, so the negative cannot pass through a query that never matched anything.

## PR Check

**pr-check: PASS** — tested on `22517f7e27268dbd07101390940e48e22947743d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

Baseline: clean, with no `packageinfo` or `bnd.bnd` change. The `com.liferay.headless.cms.resource.v1_0 EXCESSIVE VERSION INCREASE` reported on the previous run has cleared, as that run predicted, now that master carries `version 3.0.0`.

Java Unit Tests: no unit test counterpart exists for any of the four changed Java classes, so the selection was empty and nothing was executed.

JavaScript Unit Tests: the module suite is green at 179 suites and 1021 tests. The `CMSShareModalContent.test.tsx` timeouts seen on the previous run did not recur under bounded workers.

<!-- pr-check {"result": "success", "sha": "22517f7e27268dbd07101390940e48e22947743d"} -->
