### PR TITLE
LPD-103206 Fix connectSite hang on the already-selected Sites option

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -258,11 +258,9 @@ export class SpaceSummaryPage {
 	async connectSite(siteName: string) {
 		await this.openConnectSitesDialog();
 
-		await this.page.getByLabel('Sites', {exact: true}).click();
-
-		await this.page
-			.getByRole('option', {exact: true, name: 'Sites'})
-			.click();
+		await expect(this.page.getByLabel('Sites', {exact: true})).toHaveText(
+			'Sites'
+		);
 
 		await this.page
 			.getByPlaceholder('Select a Site', {exact: true})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103206

## What Is Being Fixed

Since LPD-92565 converted the CMS theme to Clay's atlas-custom-properties flavor, `.dropdown-item.active` carries `pointer-events: none`, so the already-selected option of a Clay Picker no longer receives clicks. `SpaceSummaryPage#connectSite` opened the connect-sites kind picker and clicked "Sites", the option that is always preselected, so the click never landed and Playwright retried it until the 90 second test timeout. Every test going through the helper failed deterministically, among them "Preview a content from the preview modal in mobile view" and "Preview a content" in `contentEditorPreview.spec.ts`.

## How It Is Being Fixed

The method no longer reselects the default kind. The dialog always mounts with "Sites" preselected, so the two clicks are replaced with an assertion that the picker trigger shows "Sites"; if the default ever changes, the assertion fails with a clear message instead of a locator timeout. `connectSiteTemplate` keeps its selection flow since it clicks "Site Templates", an option that is not active and therefore still clickable.

## Why Are There No Tests?

The change is itself test code: it repairs existing Playwright coverage that a product theme change broke, so there is no product behavior to add coverage for. Both affected tests were run locally from `modules/test/playwright`: `contentEditorPreview.spec.ts` passes for @LPD-85583 and @LPD-85584, and @LPD-85583 stays green with `--repeat-each=2 --workers=1`.

## PR Check

**pr-check: PASS** — tested on `7abb4d00ef422be4e257bbac8abcc732166163fe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

Baseline ran as the validation's local version check: the diff only touches `modules/test/playwright`, which is not part of any OSGi bundle, so no exported API changed and the Nexus comparison was skipped. Per-Module Compile and JavaScript Unit Tests matched the diff mechanically but do not apply here, because the Playwright module is outside the modules Gradle build and its `test` script is the e2e suite, which pr-check declares out of scope.

<!-- pr-check {"result": "success", "sha": "7abb4d00ef422be4e257bbac8abcc732166163fe"} -->
