### PR TITLE
LPD-102190 Limit the depot role permission to assigning members

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -318,6 +318,10 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 						return true;
 					}
 
+					if (!_supportedRoleActionIds.contains(actionId)) {
+						return null;
+					}
+
 					if (_isDepotGroupAdmin(groupId)) {
 						String subtype = _getSubtype(
 							_groupLocalService.fetchGroup(groupId));
@@ -557,6 +561,8 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			ActionKeys.DELETE, ActionKeys.PUBLISH_STAGING, ActionKeys.UPDATE,
 			ActionKeys.VIEW, ActionKeys.VIEW_MEMBERS,
 			ActionKeys.VIEW_SITE_ADMINISTRATION, ActionKeys.VIEW_STAGING));
+	private static final Set<String> _supportedRoleActionIds = new HashSet<>(
+		Arrays.asList(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
 
 	private final ModelResourcePermission<DepotEntry>
 		_depotEntryModelResourcePermission;

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -287,6 +287,38 @@ public class DepotPermissionCheckerWrapperTest {
 	}
 
 	@Test
+	public void testHasPermissionWithRoleAndAssetLibraryAdministrator()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		DepotTestUtil.withAssetLibraryAdministrator(
+			depotEntry,
+			user -> {
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Role role = _roleLocalService.getRole(
+					TestPropsValues.getCompanyId(),
+					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+				Assert.assertTrue(
+					permissionChecker.hasPermission(
+						depotEntry.getGroupId(), Role.class.getName(),
+						role.getRoleId(), ActionKeys.ASSIGN_MEMBERS));
+
+				Assert.assertFalse(
+					permissionChecker.hasPermission(
+						0, Role.class.getName(), role.getRoleId(),
+						ActionKeys.DELETE));
+				Assert.assertFalse(
+					permissionChecker.hasPermission(
+						0, Role.class.getName(), role.getRoleId(),
+						ActionKeys.UPDATE));
+			});
+	}
+
+	@Test
 	public void testHasPermissionWithUserAndAssetLibraryAdministrator()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102190

## What Is Being Fixed

The role branch of `DepotPermissionCheckerWrapper._hasPermission` — the one that handles checks on `Role` resources of type depot — was not scoped to an action set. `ASSIGN_MEMBERS` and `VIEW` are the actions it exists for, and the ones LPD-97807 relies on.

## How It Is Being Fixed

The branch now answers only those two actions, through a second whitelist beside the existing `_supportedActionIds`. Every other action returns `null`, so it falls through to the ordinary permission check rather than being decided here.

A depot role is company scoped rather than tied to one library, so the action set rather than the group scope is what this branch can meaningfully narrow. `_isDepotGroupAdmin(0)`, which walks the caller's `UserGroupRole` entries, is deliberately left as it is.

The test asserts that assigning members still works and denies the two actions the branch no longer answers; both denials exercise the wrapper without a group scope, which is how a check on a company scoped role arrives. Each assertion was confirmed to fail with the production commit reverted.

## PR Check

**pr-check: PASS** — tested on `3bf77e405169870d769f8adb71ea3a4574129cb9`

| Validation | Result |
| --- | --- |
| Transaction Usage | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3bf77e405169870d769f8adb71ea3a4574129cb9"} -->
