### PR TITLE
LPD-103006 Store identical upload field values from the UI and API

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -117,6 +117,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -6412,7 +6413,13 @@ public class JournalArticleLocalServiceImpl
 
 				if (Objects.equals(
 						ddmFormFieldValue.getType(),
-						DDMFormFieldTypeConstants.IMAGE)) {
+						DDMFormFieldTypeConstants.DOCUMENT_LIBRARY)) {
+
+					content = _toDocumentLibraryJSON(content);
+				}
+				else if (Objects.equals(
+							ddmFormFieldValue.getType(),
+							DDMFormFieldTypeConstants.IMAGE)) {
 
 					content = addImageFileEntries(article, content);
 				}
@@ -8574,6 +8581,85 @@ public class JournalArticleLocalServiceImpl
 
 				return null;
 			});
+	}
+
+	private String _toDocumentLibraryJSON(String content)
+		throws PortalException {
+
+		if (ExportImportThreadLocal.isImportInProcess()) {
+			return content;
+		}
+
+		JSONObject valueJSONObject = null;
+
+		try {
+			valueJSONObject = _jsonFactory.createJSONObject(content);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonException);
+			}
+
+			return content;
+		}
+
+		FileEntry fileEntry = _getFileEntry(valueJSONObject);
+
+		if (fileEntry == null) {
+			return content;
+		}
+
+		Group group = _groupLocalService.fetchGroup(fileEntry.getGroupId());
+
+		String previewURL = _dlURLHelper.getPreviewURL(
+			fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+			false, true);
+
+		JSONObject jsonObject = JSONUtil.put(
+			"alt", valueJSONObject.getString("alt")
+		).put(
+			"classNameId",
+			_classNameLocalService.getClassNameId(FileEntry.class)
+		).put(
+			"classPK", fileEntry.getFileEntryId()
+		).put(
+			"description", valueJSONObject.getString("description")
+		).put(
+			"extension", fileEntry.getExtension()
+		).put(
+			"externalReferenceCode", fileEntry.getExternalReferenceCode()
+		).put(
+			"fileEntryId", fileEntry.getFileEntryId()
+		).put(
+			"groupExternalReferenceCode",
+			() -> {
+				if (group == null) {
+					return StringPool.BLANK;
+				}
+
+				return group.getExternalReferenceCode();
+			}
+		).put(
+			"groupId", fileEntry.getGroupId()
+		).put(
+			"name", fileEntry.getFileName()
+		).put(
+			"resourcePrimKey", fileEntry.getPrimaryKey()
+		).put(
+			"size", fileEntry.getSize()
+		).put(
+			"title", fileEntry.getTitle()
+		).put(
+			"type", "document"
+		).put(
+			"url", previewURL
+		).put(
+			"uuid", fileEntry.getUuid()
+		);
+
+		jsonObject = JSONUtil.merge(valueJSONObject, jsonObject);
+
+		return jsonObject.toString();
 	}
 
 	private String _toJSON(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -313,6 +313,155 @@ public class JournalArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testAddArticleWithDocumentLibraryFieldNormalizesValue()
+		throws Exception {
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			FileUtil.getBytes(getClass(), "dependencies/image.jpg"), null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Group group = _groupLocalService.getGroup(fileEntry.getGroupId());
+
+		String itemSelectorValue = _addArticleWithDocumentLibraryFieldValue(
+			JSONUtil.put(
+				"classNameId",
+				PortalUtil.getClassNameId(FileEntry.class.getName())
+			).put(
+				"extension", fileEntry.getExtension()
+			).put(
+				"externalReferenceCode", fileEntry.getExternalReferenceCode()
+			).put(
+				"fileEntryId", String.valueOf(fileEntry.getFileEntryId())
+			).put(
+				"groupExternalReferenceCode", group.getExternalReferenceCode()
+			).put(
+				"groupId", String.valueOf(fileEntry.getGroupId())
+			).put(
+				"size", fileEntry.getSize()
+			).put(
+				"title", fileEntry.getTitle()
+			).put(
+				"type", "document"
+			).put(
+				"url", "/documents/d/image.jpg?t=1700000000000&imagePreview=1"
+			).put(
+				"uuid", fileEntry.getUuid()
+			).toString());
+
+		String headlessValue = _addArticleWithDocumentLibraryFieldValue(
+			JSONUtil.put(
+				"alt", StringPool.BLANK
+			).put(
+				"classPK", fileEntry.getFileEntryId()
+			).put(
+				"description", StringPool.BLANK
+			).put(
+				"extension", fileEntry.getExtension()
+			).put(
+				"fileEntryId", fileEntry.getFileEntryId()
+			).put(
+				"groupId", fileEntry.getGroupId()
+			).put(
+				"name", fileEntry.getFileName()
+			).put(
+				"resourcePrimKey", fileEntry.getPrimaryKey()
+			).put(
+				"size", fileEntry.getSize()
+			).put(
+				"title", fileEntry.getTitle()
+			).put(
+				"type", "document"
+			).put(
+				"url", "/documents/d/image.jpg?version=1.0"
+			).put(
+				"uuid", fileEntry.getUuid()
+			).toString());
+
+		JSONObject headlessJSONObject = _jsonFactory.createJSONObject(
+			headlessValue);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			itemSelectorValue);
+
+		Assert.assertEquals(headlessJSONObject.toMap(), jsonObject.toMap());
+
+		Assert.assertEquals(
+			PortalUtil.getClassNameId(FileEntry.class.getName()),
+			jsonObject.getLong("classNameId"));
+		Assert.assertEquals(
+			fileEntry.getFileEntryId(), jsonObject.getLong("classPK"));
+		Assert.assertEquals(
+			fileEntry.getExtension(), jsonObject.getString("extension"));
+		Assert.assertEquals(
+			fileEntry.getExternalReferenceCode(),
+			jsonObject.getString("externalReferenceCode"));
+		Assert.assertEquals(
+			fileEntry.getFileEntryId(), jsonObject.getLong("fileEntryId"));
+		Assert.assertEquals(
+			group.getExternalReferenceCode(),
+			jsonObject.getString("groupExternalReferenceCode"));
+		Assert.assertEquals(
+			fileEntry.getGroupId(), jsonObject.getLong("groupId"));
+		Assert.assertEquals(
+			fileEntry.getFileName(), jsonObject.getString("name"));
+		Assert.assertEquals(fileEntry.getSize(), jsonObject.getLong("size"));
+		Assert.assertEquals(
+			fileEntry.getTitle(), jsonObject.getString("title"));
+		Assert.assertEquals("document", jsonObject.getString("type"));
+		Assert.assertEquals(fileEntry.getUuid(), jsonObject.getString("uuid"));
+	}
+
+	@Test
+	public void testAddArticleWithDocumentLibraryFieldPreservesUnknownKeys()
+		throws Exception {
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			FileUtil.getBytes(getClass(), "dependencies/image.jpg"), null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			_addArticleWithDocumentLibraryFieldValue(
+				JSONUtil.put(
+					"groupId", fileEntry.getGroupId()
+				).put(
+					"html", "<video></video>"
+				).put(
+					"title", "Stale Title"
+				).put(
+					"uuid", fileEntry.getUuid()
+				).toString()));
+
+		Assert.assertEquals("<video></video>", jsonObject.getString("html"));
+		Assert.assertEquals(
+			fileEntry.getTitle(), jsonObject.getString("title"));
+	}
+
+	@Test
+	public void testAddArticleWithDocumentLibraryFieldWhenFileEntryIsMissing()
+		throws Exception {
+
+		String documentLibraryJSON = JSONUtil.put(
+			"groupId", _group.getGroupId()
+		).put(
+			"title", "Deleted Document"
+		).put(
+			"uuid", RandomTestUtil.randomString()
+		).toString();
+
+		Assert.assertEquals(
+			documentLibraryJSON,
+			_addArticleWithDocumentLibraryFieldValue(documentLibraryJSON));
+	}
+
+	@Test
 	public void testAddArticleWithEmptyDefaultLanguageIdFriendlyURLWithAnotherLanguageIdFriendlyURL()
 		throws Exception {
 
@@ -2653,6 +2802,42 @@ public class JournalArticleLocalServiceTest {
 
 		Assert.assertEquals(
 			"Predefined Value", field.getValue(unavailableLocale));
+	}
+
+	private String _addArticleWithDocumentLibraryFieldValue(
+			String documentLibraryJSON)
+		throws Exception {
+
+		DataDefinition dataDefinition =
+			DataDefinitionTestUtil.addDataDefinition(
+				"journal", _dataDefinitionResourceFactory, _group.getGroupId(),
+				_readFileToString("ddm_form_with_document_library.json"),
+				TestPropsValues.getUser());
+
+		JournalArticle journalArticle =
+			JournalTestUtil.addArticleWithXMLContent(
+				_group.getGroupId(),
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+				StringUtil.replace(
+					_readFileToString(
+						"journal_article_content_with_document_library.xml"),
+					"[$DOCUMENT_JSON$]", documentLibraryJSON),
+				dataDefinition.getDataDefinitionKey(), null, LocaleUtil.US);
+
+		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(true);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"Document47928126");
+
+		DDMFormFieldValue ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		Value value = ddmFormFieldValue.getValue();
+
+		return value.getString(LocaleUtil.US);
 	}
 
 	private FileEntry _addTempFileEntry(String fileName) throws Exception {

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/ddm_form_with_document_library.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/ddm_form_with_document_library.json
@@ -1,0 +1,82 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"dataType": "document-library",
+				"fieldNamespace": "",
+				"fieldReference": "Document47928126",
+				"objectFieldName": "",
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": {
+				}
+			},
+			"fieldType": "document_library",
+			"indexType": "text",
+			"indexable": true,
+			"label": {
+				"en_US": "Document"
+			},
+			"localizable": true,
+			"name": "Document47928126",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		}
+	],
+	"defaultDataLayout": {
+		"dataLayoutFields": {
+		},
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Document47928126"
+								]
+							}
+						]
+					}
+				],
+				"description": {
+					"en_US": ""
+				},
+				"title": {
+					"en_US": ""
+				}
+			}
+		],
+		"dataRules": [
+		],
+		"description": {
+		},
+		"name": {
+			"en_US": "Document"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"description": {
+	},
+	"name": {
+		"en_US": "Document"
+	},
+	"storageType": "default"
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/journal_article_content_with_document_library.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/journal_article_content_with_document_library.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element field-reference="Document47928126" index-type="text" instance-id="a4NC7xMP" name="Document47928126" type="document_library">
+		<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_JSON$]]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103006

Continues liferay-stability-team/liferay-portal#179. Three review comments from that thread are incorporated here and are not otherwise reviewed on this pull request: @Shakir-Shamim caught that `_toDocumentLibraryJSON` was missing the `ExportImportThreadLocal.isImportInProcess()` guard that the sibling `addImageFileEntries` has, and that the parity assertion compared serialized JSON strings when `org.json.JSONObject` is backed by a `HashMap` and so does not preserve key order; @ak-ragnor suggested replacing the manual key merge loop with `JSONUtil.merge(valueJSONObject, jsonObject)`. All three are in this branch.

## What Is Being Fixed

A web content upload field stored different data depending on how the content was created. Through the UI, the item selector serialized the chosen document into JSON carrying `classNameId`, `externalReferenceCode`, `groupExternalReferenceCode`, `extension`, `size`, and stringified ids. Through `postSiteStructuredContent`, `DDMValueUtil` built its own JSON instead, carrying `alt`, `classPK`, `description`, `name`, `resourcePrimKey`, and numeric ids, and taking `title` from the file name rather than the document title.

Custom templates are what surfaced the difference. `JournalTransformer` iterates every key of the stored value and copies it verbatim into the FreeMarker `TemplateNode` attribute map, so any key one path omitted showed up as missing information on content created through the other. The same divergence also reached the search index, which reads document library fields by `title`.

The two producers are not the whole story: the guest upload path in `DefaultUploadResponseHandler` writes a third shape into the same hidden input, so reconciling the item selector against `DDMValueUtil` would still have left a gap.

## How It Is Being Fixed

Rather than patch each producer, the value is normalized at the point every producer already passes through. `JournalArticleLocalServiceImpl.format()` is reached from `addArticle`, `updateArticle`, and `updateArticleTranslation`, so the UI, the headless API, and the guest upload path all converge there. It already normalizes image field values the same way, so a `DOCUMENT_LIBRARY` branch alongside the existing `IMAGE` branch follows established precedent in that method.

The new `_toDocumentLibraryJSON` resolves the file entry by `uuid` and `groupId` — the pair every consumer in the codebase already uses to resolve it — and rebuilds the canonical key set from that entry, so the stored values are derived rather than trusted. Keys the incoming value carries that are not part of the canonical set are merged back afterward, which keeps `html` for video documents and the editor's upload keys intact instead of stripping them. A value whose file entry cannot be resolved is returned untouched, so a deleted document does not lose its stored data.

Because `format()` runs on update as well as add, existing articles are repaired the next time they are saved.

One related gap is deliberately left out of scope, and it reaches further than a LAR. `DDMFormValuesExportImportContentProcessor.FileEntryImportDDMFormFieldValueTransformer.toJSON` rebuilds a document library value as `classPK`, `groupId`, `title`, `type` and `uuid` only. The path into it is `JournalArticleStagedModelDataHandler` to `JournalArticleExportImportContentProcessor.replaceImportContentReferences` to that transformer, so publishing a site from staging to live travels it as well as a LAR import, and the value on live ends up with fewer keys than either original producer wrote. Because `_toDocumentLibraryJSON` returns early on `ExportImportThreadLocal.isImportInProcess()`, `format()` does not repair it on the way in: normalization is skipped during import rather than undone by it. Closing the gap means promoting the canonical builder out of `JournalArticleLocalServiceImpl`, which is better done as its own change. It is tracked as LPD-103771 (https://liferay.atlassian.net/browse/LPD-103771).

## PR Check

**pr-check: FAIL** — tested on `9857ee96928ea9eed7850867778411c4460a50a4`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | FAIL |
| Java Unit Tests | PASS |

Baseline is the only failure, and it is not caused by this branch.

```
PACKAGE_NAME                            DELTA      CUR_VER  BASE_VER  REC_VER  WARNINGS
com.liferay.headless.cms.resource.v1_0  UNCHANGED  3.1.0    3.0.0     3.0.0    EXCESSIVE VERSION INCREASE
```

The finding is in `modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo`. This branch changes four files, all under `journal`, and touches no `headless-cms` file. The tracked `3.1.0` is already present at the rebase target `76ef70b`, set by upstream commit `aed5313 LPD-97871 Semantic versioning`, and bnd reports `DELTA UNCHANGED` for the package, so the bump is unjustified upstream and baseline recommends lowering it to `3.0.0`. It reproduces on plain `upstream/master` and cannot be cleared from this branch. Per the Baseline rule a lowered version is never autocommitted, so nothing was committed for it.

Baseline is deliberately repository-wide rather than scoped to the branch diff, because the comparison target is resolved from Nexus on every run and a module the branch never touched can begin failing between one run and the next. That is what happened here.

Verified beyond the table: the document library parity integration test (`JournalArticleLocalServiceTest.testAddArticleWithDocumentLibraryFieldNormalizesValue`) passes on this commit, and the full `JournalArticleLocalServiceTest` class was green earlier in the change's development.

<!-- pr-check {"result": "failure", "sha": "9857ee96928ea9eed7850867778411c4460a50a4"} -->

