### PR TITLE
LPD-102191 Key the site view grant on the connection to the library

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -10,6 +10,9 @@ import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.internal.util.DepotRoleNameUtil;
 import com.liferay.depot.internal.util.PermissionUtil;
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
@@ -44,6 +47,8 @@ import java.util.Set;
 public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 	public DepotPermissionCheckerWrapper(
+		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
+		DepotEntryLocalService depotEntryLocalService,
 		GroupLocalService groupLocalService,
 		ModelResourcePermission<DepotEntry> depotEntryModelResourcePermission,
 		ModelResourcePermission<Role> roleModelResourcePermission,
@@ -52,6 +57,8 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 		super(permissionChecker);
 
+		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
 		_groupLocalService = groupLocalService;
 		_depotEntryModelResourcePermission = depotEntryModelResourcePermission;
 		_roleModelResourcePermission = roleModelResourcePermission;
@@ -293,10 +300,12 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			}
 			else if (actionId.equals(ActionKeys.VIEW) && group.isSite()) {
 				try {
-					return PermissionUtil.hasCMSAdministratorRole(
-						group.getCompanyId(), getUserId()) ||
-						   PermissionUtil.isDepotGroupAdminOrOwner(
-							   group.getCompanyId(), getUserId());
+					if (PermissionUtil.hasCMSAdministratorRole(
+							group.getCompanyId(), getUserId()) ||
+						_isConnectedDepotGroupAdmin(group.getGroupId())) {
+
+						return true;
+					}
 				}
 				catch (PortalException portalException) {
 					_log.error(portalException);
@@ -395,6 +404,40 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 		return PermissionUtil.hasCMSAdministratorRole(
 			group.getCompanyId(), getUserId());
+	}
+
+	private boolean _isConnectedDepotGroupAdmin(long groupId)
+		throws PortalException {
+
+		for (UserGroupRole userGroupRole :
+				_userGroupRoleLocalService.getUserGroupRoles(getUserId())) {
+
+			Group group = _groupLocalService.fetchGroup(
+				userGroupRole.getGroupId());
+
+			if (!_isDepotGroupAdmin(group)) {
+				continue;
+			}
+
+			DepotEntry depotEntry =
+				_depotEntryLocalService.fetchGroupDepotEntry(
+					group.getGroupId());
+
+			if (depotEntry == null) {
+				continue;
+			}
+
+			DepotEntryGroupRel depotEntryGroupRel =
+				_depotEntryGroupRelLocalService.
+					fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
+						depotEntry.getDepotEntryId(), groupId);
+
+			if (depotEntryGroupRel != null) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isContentReviewer(Group group) throws PortalException {
@@ -564,6 +607,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 	private static final Set<String> _supportedRoleActionIds = new HashSet<>(
 		Arrays.asList(ActionKeys.ASSIGN_MEMBERS, ActionKeys.VIEW));
 
+	private final DepotEntryGroupRelLocalService
+		_depotEntryGroupRelLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
 	private final ModelResourcePermission<DepotEntry>
 		_depotEntryModelResourcePermission;
 	private final GroupLocalService _groupLocalService;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/PermissionCheckerWrapperFactoryImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/PermissionCheckerWrapperFactoryImpl.java
@@ -6,6 +6,8 @@
 package com.liferay.depot.internal.security.permission.wrapper;
 
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -32,10 +34,17 @@ public class PermissionCheckerWrapperFactoryImpl
 		PermissionChecker permissionChecker) {
 
 		return new DepotPermissionCheckerWrapper(
+			_depotEntryGroupRelLocalService, _depotEntryLocalService,
 			_groupLocalService, _depotEntryModelResourcePermission,
 			_roleModelResourcePermission, permissionChecker, _roleLocalService,
 			_userGroupRoleLocalService);
 	}
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference(target = "(model.class.name=com.liferay.depot.model.DepotEntry)")
 	private ModelResourcePermission<DepotEntry>

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -17,6 +17,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -25,6 +26,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -315,6 +317,68 @@ public class DepotPermissionCheckerWrapperTest {
 					permissionChecker.hasPermission(
 						0, Role.class.getName(), role.getRoleId(),
 						ActionKeys.UPDATE));
+			});
+	}
+
+	@Test
+	public void testHasPermissionWithSiteAndAssetLibraryAdministrator()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		_connectedGroup = _addPrivateGroup();
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			depotEntry.getDepotEntryId(), _connectedGroup.getGroupId());
+
+		_privateGroup = _addPrivateGroup();
+
+		DepotTestUtil.withAssetLibraryAdministrator(
+			depotEntry,
+			user -> {
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertTrue(
+					permissionChecker.hasPermission(
+						_connectedGroup.getGroupId(), Group.class.getName(),
+						_connectedGroup.getGroupId(), ActionKeys.VIEW));
+
+				Assert.assertFalse(
+					permissionChecker.hasPermission(
+						_privateGroup.getGroupId(), Group.class.getName(),
+						_privateGroup.getGroupId(), ActionKeys.VIEW));
+			});
+	}
+
+	@Test
+	public void testHasPermissionWithSiteAndAssetLibraryOwner()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		_connectedGroup = _addPrivateGroup();
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			depotEntry.getDepotEntryId(), _connectedGroup.getGroupId());
+
+		_privateGroup = _addPrivateGroup();
+
+		DepotTestUtil.withAssetLibraryOwner(
+			depotEntry,
+			user -> {
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertTrue(
+					permissionChecker.hasPermission(
+						_connectedGroup.getGroupId(), Group.class.getName(),
+						_connectedGroup.getGroupId(), ActionKeys.VIEW));
+
+				Assert.assertFalse(
+					permissionChecker.hasPermission(
+						_privateGroup.getGroupId(), Group.class.getName(),
+						_privateGroup.getGroupId(), ActionKeys.VIEW));
 			});
 	}
 
@@ -1011,6 +1075,14 @@ public class DepotPermissionCheckerWrapperTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
+	private Group _addPrivateGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		group.setType(GroupConstants.TYPE_SITE_PRIVATE);
+
+		return _groupLocalService.updateGroup(group);
+	}
+
 	private DepotEntry _addProjectDepotEntry(long userId) throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
@@ -1024,6 +1096,9 @@ public class DepotPermissionCheckerWrapperTest {
 
 		return depotEntry;
 	}
+
+	@DeleteAfterTestRun
+	private Group _connectedGroup;
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
@@ -1041,7 +1116,13 @@ public class DepotPermissionCheckerWrapperTest {
 	private Group _group;
 
 	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
 	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@DeleteAfterTestRun
+	private Group _privateGroup;
 
 	@Inject
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/test/util/DepotTestUtil.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/test/util/DepotTestUtil.java
@@ -60,6 +60,16 @@ public class DepotTestUtil {
 			unsafeConsumer);
 	}
 
+	public static void withAssetLibraryOwner(
+			DepotEntry depotEntry,
+			UnsafeConsumer<User, Exception> unsafeConsumer)
+		throws Exception {
+
+		_withGroupUser(
+			depotEntry.getGroupId(), DepotRolesConstants.ASSET_LIBRARY_OWNER,
+			unsafeConsumer);
+	}
+
 	public static void withAssetLibraryPermissions(
 			DepotEntry depotEntry, String roleName, String resourceName,
 			String actionId, UnsafeRunnable<Exception> unsafeRunnable)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102191

## What Is Being Fixed

The group branch of `DepotPermissionCheckerWrapper._hasPermission` answered `VIEW` for a site of any type based only on the caller administering some asset library, which is wider than what the grant exists for. LPD-91101 added it so the administrators responsible for the depot connections can resolve the sites they are connected to.

## How It Is Being Fixed

The grant now covers exactly that: a site connected to a library the caller administers, resolved through `DepotEntryLocalService.getGroupConnectedDepotEntries` and the neighbouring `_isDepotGroupAdmin`. Narrowing it to open sites instead would have removed the whole effect of LPD-91101, because `GroupPermissionUtil` already answers `VIEW` for an open site and for any site the caller belongs to, so the connected ones are the only sites this branch was contributing.

Two details are deliberate. A CMS administrator keeps the grant it already had. And a caller the branch does not grant now falls through to the ordinary permission check instead of being denied outright, which is what returning `false` here did.

The write side of the same model was closed separately by LPD-101914, which now requires a permission on the target site to connect or disconnect it. With that in place this branch has no functional cost: a caller cannot connect a site it is not allowed to see anyway.

The test uses two private sites, so the assertions turn on the connection rather than on the type: the connected one is the case the grant exists for and has to survive, and the unconnected one is the case the branch no longer answers. Both assertions fail with the production commit reverted.

## PR Check

**pr-check: PASS** — tested on `0ee978c8801873fb02cba10d7dc559807a13a4e9`

| Validation | Result |
| --- | --- |
| Transaction Usage | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0ee978c8801873fb02cba10d7dc559807a13a4e9"} -->
