### PR TITLE
LPD-103026 Scope the broken links count to the Spaces the caller sees

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
@@ -8,6 +8,9 @@ package com.liferay.headless.cms.internal.links;
 import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -87,6 +90,16 @@ public class BrokenLinkAssetSearcher {
 
 		int startPosition = Math.min(
 			pagination.getStartPosition(), _MAX_RESULT_WINDOW);
+
+		if ((pagination.getStartPosition() >= _MAX_RESULT_WINDOW) &&
+			_log.isWarnEnabled()) {
+
+			_log.warn(
+				StringBundler.concat(
+					"Requested start position ", pagination.getStartPosition(),
+					" reaches the maximum result window ", _MAX_RESULT_WINDOW,
+					", so the page is empty"));
+		}
 
 		searchRequestBuilder.addSelectedFieldNames(
 			"outboundLinks", Field.ENTRY_CLASS_PK, "objectDefinitionId",
@@ -198,6 +211,9 @@ public class BrokenLinkAssetSearcher {
 	private static final int _MAX_RESULT_WINDOW = 10000;
 
 	private static final int _TERMS_QUERY_CHUNK_SIZE = 4096;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BrokenLinkAssetSearcher.class);
 
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final Searcher _searcher;

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
@@ -169,6 +169,9 @@ public class BrokenLinkAssetSearcher {
 				ArrayUtil.toStringArray(CMSWorkflowConstants.STATUSES)),
 			QueriesUtil.term("rootDescendantNode", false));
 
+		booleanQuery.addMustNotQueryClauses(
+			QueriesUtil.term(Field.STATUS, WorkflowConstants.STATUS_EXPIRED));
+
 		return _searchRequestBuilderFactory.builder(
 		).companyId(
 			companyId

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
@@ -57,27 +57,27 @@ public class BrokenLinkAssetSearcher {
 		return searchResponse.getCount();
 	}
 
-	public Map<String, Long> getExpiredAssetObjectEntryIds(
+	public Map<String, Long> getExpiredAssetObjectEntryIdsMap(
 		long companyId, Long[] objectDefinitionIds, Long[] spaceGroupIds) {
 
-		Map<String, Long> objectEntryIds = new LinkedHashMap<>();
+		Map<String, Long> objectEntryIdsMap = new LinkedHashMap<>();
 
 		for (Object[] objects :
-				_getExpiredAssetObjects(
+				_getObjectEntryObjectsList(
 					companyId, objectDefinitionIds, spaceGroupIds)) {
 
 			long objectEntryId = GetterUtil.getLong(objects[1]);
 
-			objectEntryIds.put(
+			objectEntryIdsMap.put(
 				CMSOutboundLinksUtil.getObjectEntryExternalReferenceCodeToken(
 					GetterUtil.getString(objects[0])),
 				objectEntryId);
-			objectEntryIds.put(
+			objectEntryIdsMap.put(
 				CMSOutboundLinksUtil.getObjectEntryIdToken(objectEntryId),
 				objectEntryId);
 		}
 
-		return objectEntryIds;
+		return objectEntryIdsMap;
 	}
 
 	public SearchResponse search(
@@ -124,7 +124,7 @@ public class BrokenLinkAssetSearcher {
 		return _searcher.search(searchRequestBuilder.build());
 	}
 
-	private List<Object[]> _getExpiredAssetObjects(
+	private List<Object[]> _getObjectEntryObjectsList(
 		long companyId, Long[] objectDefinitionIds, Long[] spaceGroupIds) {
 
 		return _objectEntryLocalService.dslQuery(

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/links/BrokenLinkAssetSearcher.java
@@ -55,29 +55,14 @@ public class BrokenLinkAssetSearcher {
 	}
 
 	public Map<String, Long> getExpiredAssetObjectEntryIds(
-		long companyId, Long[] objectDefinitionIds) {
+		long companyId, Long[] objectDefinitionIds, Long[] spaceGroupIds) {
 
 		Map<String, Long> objectEntryIds = new LinkedHashMap<>();
 
-		List<Object[]> results = _objectEntryLocalService.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE.externalReferenceCode,
-				ObjectEntryTable.INSTANCE.objectEntryId
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					companyId
-				).and(
-					ObjectEntryTable.INSTANCE.objectDefinitionId.in(
-						objectDefinitionIds)
-				).and(
-					ObjectEntryTable.INSTANCE.status.eq(
-						WorkflowConstants.STATUS_EXPIRED)
-				)
-			));
+		for (Object[] objects :
+				_getExpiredAssetObjects(
+					companyId, objectDefinitionIds, spaceGroupIds)) {
 
-		for (Object[] objects : results) {
 			long objectEntryId = GetterUtil.getLong(objects[1]);
 
 			objectEntryIds.put(
@@ -124,6 +109,30 @@ public class BrokenLinkAssetSearcher {
 		}
 
 		return _searcher.search(searchRequestBuilder.build());
+	}
+
+	private List<Object[]> _getExpiredAssetObjects(
+		long companyId, Long[] objectDefinitionIds, Long[] spaceGroupIds) {
+
+		return _objectEntryLocalService.dslQuery(
+			DSLQueryFactoryUtil.select(
+				ObjectEntryTable.INSTANCE.externalReferenceCode,
+				ObjectEntryTable.INSTANCE.objectEntryId
+			).from(
+				ObjectEntryTable.INSTANCE
+			).where(
+				ObjectEntryTable.INSTANCE.companyId.eq(
+					companyId
+				).and(
+					ObjectEntryTable.INSTANCE.groupId.in(spaceGroupIds)
+				).and(
+					ObjectEntryTable.INSTANCE.objectDefinitionId.in(
+						objectDefinitionIds)
+				).and(
+					ObjectEntryTable.INSTANCE.status.eq(
+						WorkflowConstants.STATUS_EXPIRED)
+				)
+			));
 	}
 
 	private BooleanQuery _getOutboundLinksBooleanQuery(

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -167,18 +167,18 @@ public class AssetStatisticsResourceImpl
 					_objectEntryLocalService, _searcher,
 					_searchRequestBuilderFactory);
 
-			Map<String, Long> expiredAssetObjectEntryIds =
-				brokenLinkAssetSearcher.getExpiredAssetObjectEntryIds(
+			Map<String, Long> expiredAssetObjectEntryIdsMap =
+				brokenLinkAssetSearcher.getExpiredAssetObjectEntryIdsMap(
 					contextCompany.getCompanyId(), objectDefinitionIds,
 					spaceGroupIds);
 
-			if (expiredAssetObjectEntryIds.isEmpty()) {
+			if (expiredAssetObjectEntryIdsMap.isEmpty()) {
 				return 0;
 			}
 
 			return brokenLinkAssetSearcher.getCount(
 				contextCompany.getCompanyId(), selectedSpaceGroupIds,
-				expiredAssetObjectEntryIds.keySet());
+				expiredAssetObjectEntryIdsMap.keySet());
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -49,14 +49,15 @@ public class AssetStatisticsResourceImpl
 	public AssetStatistics getAssetStatistics(Long assetLibraryId)
 		throws Exception {
 
-		Long[] groupIds = CMSGroupUtil.getSelectedSpaceGroupIds(
-			assetLibraryId, contextCompany.getCompanyId(),
-			_depotEntryLocalService, groupLocalService,
-			CMSGroupUtil.getSpaceGroupIds(
-				contextCompany.getCompanyId(), _depotEntryService,
-				contextUser.getUserId()));
+		Long[] spaceGroupIds = CMSGroupUtil.getSpaceGroupIds(
+			contextCompany.getCompanyId(), _depotEntryService,
+			contextUser.getUserId());
 
-		if (ArrayUtil.isEmpty(groupIds)) {
+		Long[] selectedSpaceGroupIds = CMSGroupUtil.getSelectedSpaceGroupIds(
+			assetLibraryId, contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService, spaceGroupIds);
+
+		if (ArrayUtil.isEmpty(selectedSpaceGroupIds)) {
 			return _toAssetStatistics();
 		}
 
@@ -80,19 +81,21 @@ public class AssetStatisticsResourceImpl
 			{
 				setApprovedCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_APPROVED)));
 				setBrokenLinksCount(
-					() -> _getBrokenLinksCount(groupIds, objectDefinitionIds));
+					() -> _getBrokenLinksCount(
+						objectDefinitionIds, selectedSpaceGroupIds,
+						spaceGroupIds));
 				setExpiredCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_EXPIRED)));
 				setExpiringSoonCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_APPROVED
 						).and(
@@ -103,17 +106,17 @@ public class AssetStatisticsResourceImpl
 						)));
 				setInDraftCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_DRAFT)));
 				setPendingCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_PENDING)));
 				setReviewDateOverdueCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.reviewDate.lt(
 							date
 						).and(
@@ -122,17 +125,17 @@ public class AssetStatisticsResourceImpl
 						)));
 				setScheduledCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_SCHEDULED)));
 				setTotalCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.status.in(
 							CMSWorkflowConstants.STATUSES)));
 				setUpcomingReviewCount(
 					() -> _getCount(
-						groupIds, objectDefinitionIds,
+						selectedSpaceGroupIds, objectDefinitionIds,
 						ObjectEntryTable.INSTANCE.reviewDate.gt(
 							date
 						).and(
@@ -149,7 +152,8 @@ public class AssetStatisticsResourceImpl
 	}
 
 	private long _getBrokenLinksCount(
-		Long[] groupIds, Long[] objectDefinitionIds) {
+		Long[] objectDefinitionIds, Long[] selectedSpaceGroupIds,
+		Long[] spaceGroupIds) {
 
 		if (!FeatureFlagManagerUtil.isEnabled(
 				contextCompany.getCompanyId(), "LPD-82226")) {
@@ -165,14 +169,15 @@ public class AssetStatisticsResourceImpl
 
 			Map<String, Long> expiredAssetObjectEntryIds =
 				brokenLinkAssetSearcher.getExpiredAssetObjectEntryIds(
-					contextCompany.getCompanyId(), objectDefinitionIds);
+					contextCompany.getCompanyId(), objectDefinitionIds,
+					spaceGroupIds);
 
 			if (expiredAssetObjectEntryIds.isEmpty()) {
 				return 0;
 			}
 
 			return brokenLinkAssetSearcher.getCount(
-				contextCompany.getCompanyId(), groupIds,
+				contextCompany.getCompanyId(), selectedSpaceGroupIds,
 				expiredAssetObjectEntryIds.keySet());
 		}
 		catch (Exception exception) {

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
@@ -71,12 +71,13 @@ public class BrokenLinkAssetResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
+		Long[] spaceGroupIds = CMSGroupUtil.getSpaceGroupIds(
+			contextCompany.getCompanyId(), _depotEntryService,
+			contextUser.getUserId());
+
 		Long[] selectedSpaceGroupIds = CMSGroupUtil.getSelectedSpaceGroupIds(
 			assetLibraryId, contextCompany.getCompanyId(),
-			_depotEntryLocalService, groupLocalService,
-			CMSGroupUtil.getSpaceGroupIds(
-				contextCompany.getCompanyId(), _depotEntryService,
-				contextUser.getUserId()));
+			_depotEntryLocalService, groupLocalService, spaceGroupIds);
 
 		if (ArrayUtil.isEmpty(selectedSpaceGroupIds)) {
 			return Page.of(Collections.emptyList());
@@ -106,7 +107,8 @@ public class BrokenLinkAssetResourceImpl
 
 		Map<String, Long> expiredAssetObjectEntryIds =
 			brokenLinkAssetSearcher.getExpiredAssetObjectEntryIds(
-				contextCompany.getCompanyId(), objectDefinitionIds);
+				contextCompany.getCompanyId(), objectDefinitionIds,
+				spaceGroupIds);
 
 		if (expiredAssetObjectEntryIds.isEmpty()) {
 			return Page.of(Collections.emptyList());

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BrokenLinkAssetResourceImpl.java
@@ -105,19 +105,19 @@ public class BrokenLinkAssetResourceImpl
 				_objectEntryLocalService, _searcher,
 				_searchRequestBuilderFactory);
 
-		Map<String, Long> expiredAssetObjectEntryIds =
-			brokenLinkAssetSearcher.getExpiredAssetObjectEntryIds(
+		Map<String, Long> expiredAssetObjectEntryIdsMap =
+			brokenLinkAssetSearcher.getExpiredAssetObjectEntryIdsMap(
 				contextCompany.getCompanyId(), objectDefinitionIds,
 				spaceGroupIds);
 
-		if (expiredAssetObjectEntryIds.isEmpty()) {
+		if (expiredAssetObjectEntryIdsMap.isEmpty()) {
 			return Page.of(Collections.emptyList());
 		}
 
 		SearchResponse searchResponse = brokenLinkAssetSearcher.search(
 			contextCompany.getCompanyId(), selectedSpaceGroupIds,
 			contextAcceptLanguage.getPreferredLanguageId(),
-			expiredAssetObjectEntryIds.keySet(), pagination, search, sorts);
+			expiredAssetObjectEntryIdsMap.keySet(), pagination, search, sorts);
 
 		Map<Long, String> externalReferenceCodes = new HashMap<>();
 
@@ -131,7 +131,7 @@ public class BrokenLinkAssetResourceImpl
 			transform(
 				searchResponse.getDocuments(),
 				document -> _toBrokenLinkAsset(
-					document, expiredAssetObjectEntryIds,
+					document, expiredAssetObjectEntryIdsMap,
 					externalReferenceCodes)),
 			pagination, searchResponse.getCount());
 	}
@@ -173,13 +173,13 @@ public class BrokenLinkAssetResourceImpl
 	}
 
 	private BrokenLinkAsset _toBrokenLinkAsset(
-		Document document, Map<String, Long> expiredAssetObjectEntryIds,
+		Document document, Map<String, Long> expiredAssetObjectEntryIdsMap,
 		Map<Long, String> externalReferenceCodes) {
 
 		Set<Long> brokenLinkObjectEntryIds = new LinkedHashSet<>();
 
 		for (String outboundLink : document.getStrings("outboundLinks")) {
-			Long brokenLinkObjectEntryId = expiredAssetObjectEntryIds.get(
+			Long brokenLinkObjectEntryId = expiredAssetObjectEntryIdsMap.get(
 				outboundLink);
 
 			if (brokenLinkObjectEntryId != null) {

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -408,7 +408,7 @@ public class AssetStatisticsResourceTest
 
 			_assertBrokenLinksCount(depotEntry.getGroupId(), 1);
 
-			_addObjectEntry(
+			ObjectEntry referringObjectEntry = _addObjectEntry(
 				CMSOutboundLinkTestUtil.getImageHTML(
 					targetObjectEntry.getExternalReferenceCode()),
 				depotEntry, objectDefinition);
@@ -432,6 +432,13 @@ public class AssetStatisticsResourceTest
 				imageHTML + otherImageHTML, depotEntry, objectDefinition);
 
 			_assertBrokenLinksCount(depotEntry.getGroupId(), 3);
+
+			_objectEntryLocalService.updateStatus(
+				TestPropsValues.getUserId(),
+				referringObjectEntry.getObjectEntryId(),
+				WorkflowConstants.STATUS_EXPIRED, serviceContext);
+
+			_assertBrokenLinksCount(depotEntry.getGroupId(), 2);
 		}
 		finally {
 			_depotEntryLocalService.deleteDepotEntry(

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -22,12 +22,9 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -379,12 +376,9 @@ public class AssetStatisticsResourceTest
 	private ObjectDefinition _getBasicWebContentObjectDefinition()
 		throws Exception {
 
-		Group cmsGroup = _groupLocalService.getGroup(
-			TestPropsValues.getCompanyId(), GroupConstants.CMS);
-
 		return _objectDefinitionLocalService.
 			getObjectDefinitionByExternalReferenceCode(
-				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+				"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
 	}
 
 	private void _testGetAssetStatisticsBrokenLinksCount() throws Exception {
@@ -495,9 +489,6 @@ public class AssetStatisticsResourceTest
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Inject
-	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
@@ -77,6 +77,7 @@ public class BrokenLinkAssetResourceTest
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString());
 		_testGetBrokenLinkAssetsPageWithDuplicateTitles();
+		_testGetBrokenLinkAssetsPageWithExpiredAssetInAnotherSpace();
 	}
 
 	@Override
@@ -324,6 +325,44 @@ public class BrokenLinkAssetResourceTest
 		String targetTitle = RandomTestUtil.randomString();
 
 		_testGetBrokenLinkAssetsPage(targetTitle, targetTitle);
+	}
+
+	private void _testGetBrokenLinkAssetsPageWithExpiredAssetInAnotherSpace()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+		DepotEntry otherDepotEntry = _addSpaceDepotEntry(serviceContext);
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		ObjectEntry expiredObjectEntry = _addExpiredObjectEntry(
+			otherDepotEntry, objectDefinition, serviceContext);
+
+		String referencingTitle = RandomTestUtil.randomString();
+
+		_addObjectEntry(
+			CMSOutboundLinkTestUtil.getImageHTML(
+				expiredObjectEntry.getExternalReferenceCode()),
+			depotEntry, objectDefinition, referencingTitle);
+
+		Page<BrokenLinkAsset> brokenLinkAssetsPage =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				depotEntry.getDepotEntryId(), null, null, null);
+
+		Assert.assertEquals(1, brokenLinkAssetsPage.getTotalCount());
+
+		List<BrokenLinkAsset> brokenLinkAssets =
+			(List<BrokenLinkAsset>)brokenLinkAssetsPage.getItems();
+
+		BrokenLinkAsset brokenLinkAsset = brokenLinkAssets.get(0);
+
+		Assert.assertEquals(
+			1, GetterUtil.getInteger(brokenLinkAsset.getBrokenLinksCount()));
+		Assert.assertEquals(referencingTitle, brokenLinkAsset.getTitle());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
@@ -14,12 +14,25 @@ import com.liferay.headless.cms.client.pagination.Page;
 import com.liferay.headless.cms.client.pagination.Pagination;
 import com.liferay.headless.cms.client.resource.v1_0.BrokenLinkAssetResource;
 import com.liferay.headless.cms.resource.v1_0.test.util.CMSOutboundLinkTestUtil;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.field.builder.RichTextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -41,11 +54,14 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -84,6 +100,7 @@ public class BrokenLinkAssetResourceTest
 		_testGetBrokenLinkAssetsPageWithDuplicateTitles();
 		_testGetBrokenLinkAssetsPageWithExpiredAssetInAnotherSpace();
 		_testGetBrokenLinkAssetsPageWithExpiredAssetInHiddenSpace();
+		_testGetBrokenLinkAssetsPageWithRelationshipReference();
 	}
 
 	@Override
@@ -172,6 +189,31 @@ public class BrokenLinkAssetResourceTest
 		_assertTitleOrder(depotEntry, "bbb", "aaa", "title:desc");
 	}
 
+	private ObjectDefinition _addCMSObjectDefinition() throws Exception {
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				TestPropsValues.getCompanyId());
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				true, false, false, ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(_buildRichTextObjectField()),
+				objectFolder.getObjectFolderId(),
+				ObjectDefinitionConstants.SCOPE_DEPOT,
+				TestPropsValues.getUserId());
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS, "true");
+
+		_objectDefinitions.add(objectDefinition);
+
+		return objectDefinition;
+	}
+
 	private ObjectEntry _addExpiredObjectEntry(
 			DepotEntry depotEntry, ObjectDefinition objectDefinition,
 			ServiceContext serviceContext)
@@ -189,8 +231,8 @@ public class BrokenLinkAssetResourceTest
 	}
 
 	private ObjectEntry _addObjectEntry(
-			String content, DepotEntry depotEntry,
-			ObjectDefinition objectDefinition, String title)
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			Map<String, Serializable> values)
 		throws Exception {
 
 		ObjectEntryFolder objectEntryFolder =
@@ -202,7 +244,17 @@ public class BrokenLinkAssetResourceTest
 		return _objectEntryLocalService.addObjectEntry(
 			depotEntry.getGroupId(), depotEntry.getUserId(),
 			objectDefinition.getObjectDefinitionId(),
-			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			objectEntryFolder.getObjectEntryFolderId(), "en_US", values,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addObjectEntry(
+			String content, DepotEntry depotEntry,
+			ObjectDefinition objectDefinition, String title)
+		throws Exception {
+
+		return _addObjectEntry(
+			depotEntry, objectDefinition,
 			HashMapBuilder.<String, Serializable>put(
 				"content_i18n",
 				HashMapBuilder.put(
@@ -213,8 +265,7 @@ public class BrokenLinkAssetResourceTest
 				HashMapBuilder.put(
 					"en_US", title
 				).build()
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
+			).build());
 	}
 
 	private DepotEntry _addSpaceDepotEntry(ServiceContext serviceContext)
@@ -258,6 +309,19 @@ public class BrokenLinkAssetResourceTest
 
 		Assert.assertEquals(
 			expectedSecondTitle, secondBrokenLinkAsset.getTitle());
+	}
+
+	private ObjectField _buildRichTextObjectField() throws Exception {
+		return new RichTextObjectFieldBuilder(
+		).indexed(
+			true
+		).labelMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+		).name(
+			"content"
+		).userId(
+			TestPropsValues.getUserId()
+		).build();
 	}
 
 	private ObjectDefinition _getBasicWebContentObjectDefinition()
@@ -462,6 +526,57 @@ public class BrokenLinkAssetResourceTest
 			referencingTitle, spaceMemberBrokenLinkAsset.getTitle());
 	}
 
+	private void _testGetBrokenLinkAssetsPageWithRelationshipReference()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		ObjectEntry expiredObjectEntry = _addExpiredObjectEntry(
+			depotEntry, objectDefinition, serviceContext);
+
+		ObjectDefinition referencingObjectDefinition =
+			_addCMSObjectDefinition();
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition,
+				referencingObjectDefinition);
+
+		_addObjectEntry(
+			depotEntry, referencingObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					objectDefinition, objectRelationship.getName()),
+				expiredObjectEntry.getObjectEntryId()
+			).build());
+
+		Page<BrokenLinkAsset> brokenLinkAssetsPage =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				depotEntry.getDepotEntryId(), null, null, null);
+
+		Assert.assertEquals(1, brokenLinkAssetsPage.getTotalCount());
+
+		List<BrokenLinkAsset> brokenLinkAssets =
+			(List<BrokenLinkAsset>)brokenLinkAssetsPage.getItems();
+
+		BrokenLinkAsset brokenLinkAsset = brokenLinkAssets.get(0);
+
+		Assert.assertEquals(
+			1, GetterUtil.getInteger(brokenLinkAsset.getBrokenLinksCount()));
+		Assert.assertEquals(
+			expiredObjectEntry.getTitleValue("en_US", true),
+			brokenLinkAsset.getBrokenLinkTitle());
+		Assert.assertEquals(
+			referencingObjectDefinition.getExternalReferenceCode(),
+			brokenLinkAsset.getObjectDefinitionExternalReferenceCode());
+	}
+
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
@@ -471,11 +586,24 @@ public class BrokenLinkAssetResourceTest
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
+	@DeleteAfterTestRun
+	private final List<ObjectDefinition> _objectDefinitions = new ArrayList<>();
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+
 	@Inject
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@DeleteAfterTestRun
 	private User _spaceMemberUser;

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BrokenLinkAssetResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.cms.client.dto.v1_0.BrokenLinkAsset;
 import com.liferay.headless.cms.client.pagination.Page;
 import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.BrokenLinkAssetResource;
 import com.liferay.headless.cms.resource.v1_0.test.util.CMSOutboundLinkTestUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -20,16 +21,20 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -78,6 +83,7 @@ public class BrokenLinkAssetResourceTest
 			RandomTestUtil.randomString());
 		_testGetBrokenLinkAssetsPageWithDuplicateTitles();
 		_testGetBrokenLinkAssetsPageWithExpiredAssetInAnotherSpace();
+		_testGetBrokenLinkAssetsPageWithExpiredAssetInHiddenSpace();
 	}
 
 	@Override
@@ -262,6 +268,28 @@ public class BrokenLinkAssetResourceTest
 				"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
 	}
 
+	private BrokenLinkAssetResource _getSpaceMemberBrokenLinkAssetResource(
+			DepotEntry depotEntry)
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		_spaceMemberUser = UserTestUtil.addUser(testCompany, password);
+
+		_userLocalService.addGroupUsers(
+			depotEntry.getGroupId(), new long[] {_spaceMemberUser.getUserId()});
+
+		return BrokenLinkAssetResource.builder(
+		).authentication(
+			_spaceMemberUser.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	private void _testGetBrokenLinkAssetsPage(String... targetTitles)
 		throws Exception {
 
@@ -365,6 +393,75 @@ public class BrokenLinkAssetResourceTest
 		Assert.assertEquals(referencingTitle, brokenLinkAsset.getTitle());
 	}
 
+	private void _testGetBrokenLinkAssetsPageWithExpiredAssetInHiddenSpace()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DepotEntry depotEntry = _addSpaceDepotEntry(serviceContext);
+		DepotEntry hiddenDepotEntry = _addSpaceDepotEntry(serviceContext);
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		ObjectEntry expiredObjectEntry = _addExpiredObjectEntry(
+			depotEntry, objectDefinition, serviceContext);
+		ObjectEntry hiddenExpiredObjectEntry = _addExpiredObjectEntry(
+			hiddenDepotEntry, objectDefinition, serviceContext);
+
+		String imageHTML = CMSOutboundLinkTestUtil.getImageHTML(
+			expiredObjectEntry.getExternalReferenceCode());
+		String hiddenImageHTML = CMSOutboundLinkTestUtil.getImageHTML(
+			hiddenExpiredObjectEntry.getExternalReferenceCode());
+
+		String referencingTitle = RandomTestUtil.randomString();
+
+		_addObjectEntry(
+			imageHTML + hiddenImageHTML, depotEntry, objectDefinition,
+			referencingTitle);
+
+		Page<BrokenLinkAsset> brokenLinkAssetsPage =
+			brokenLinkAssetResource.getBrokenLinkAssetsPage(
+				depotEntry.getDepotEntryId(), null, null, null);
+
+		Assert.assertEquals(1, brokenLinkAssetsPage.getTotalCount());
+
+		List<BrokenLinkAsset> brokenLinkAssets =
+			(List<BrokenLinkAsset>)brokenLinkAssetsPage.getItems();
+
+		BrokenLinkAsset brokenLinkAsset = brokenLinkAssets.get(0);
+
+		Assert.assertEquals(
+			2, GetterUtil.getInteger(brokenLinkAsset.getBrokenLinksCount()));
+		Assert.assertEquals(referencingTitle, brokenLinkAsset.getTitle());
+
+		BrokenLinkAssetResource spaceMemberBrokenLinkAssetResource =
+			_getSpaceMemberBrokenLinkAssetResource(depotEntry);
+
+		Page<BrokenLinkAsset> spaceMemberBrokenLinkAssetsPage =
+			spaceMemberBrokenLinkAssetResource.getBrokenLinkAssetsPage(
+				depotEntry.getDepotEntryId(), null, null, null);
+
+		Assert.assertEquals(1, spaceMemberBrokenLinkAssetsPage.getTotalCount());
+
+		List<BrokenLinkAsset> spaceMemberBrokenLinkAssets =
+			(List<BrokenLinkAsset>)spaceMemberBrokenLinkAssetsPage.getItems();
+
+		BrokenLinkAsset spaceMemberBrokenLinkAsset =
+			spaceMemberBrokenLinkAssets.get(0);
+
+		Assert.assertEquals(
+			1,
+			GetterUtil.getInteger(
+				spaceMemberBrokenLinkAsset.getBrokenLinksCount()));
+		Assert.assertEquals(
+			expiredObjectEntry.getTitleValue("en_US", true),
+			spaceMemberBrokenLinkAsset.getBrokenLinkTitle());
+		Assert.assertEquals(
+			referencingTitle, spaceMemberBrokenLinkAsset.getTitle());
+	}
+
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
@@ -379,5 +476,11 @@ public class BrokenLinkAssetResourceTest
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@DeleteAfterTestRun
+	private User _spaceMemberUser;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103026

## What Is Being Fixed

The broken links count and the broken links listing disagreed with each other and with what the caller is entitled to see. The expired assets a broken link points at were enumerated across every Space in the company rather than the Spaces the caller has access to, so a caller with access to a subset of Spaces saw links attributed to assets outside that subset. Contents that are themselves expired were also counted as having broken links, inflating the number against assets that are no longer live. Finally, a request past the search engine's result window returned an empty page with nothing in the logs to explain it.

## How It Is Being Fixed

The expired asset enumeration is now scoped to the Spaces the caller can reach, resolved once per request and shared between the count and the listing so the two can no longer diverge. A caller who cannot reach every Space now sees a smaller number than before, which is deliberate: a count the caller cannot drill into is worse than a smaller count.

Expired contents are excluded from the results with a must-not clause on the status, so an expired content is no longer reported as a content with broken links.

The result-window boundary now logs a warning naming the requested start position and the window, so an empty page past the window is explainable from the logs.

The last commit takes the naming advice from the previous review round. The DSL query helper is named after the table it selects from and its return type, matching `_getLayoutClassedModelUsageObjectsList` in this same module, and the map accessor gains the `Map` suffix that the module's other map accessor already carries.

## Test Execution

	cd modules/apps/headless/headless-cms/headless-cms-test
	../../../../../gradlew testIntegration --tests "*BrokenLinkAssetResourceTest"
	../../../../../gradlew testIntegration --tests "*AssetStatisticsResourceTest"

15 tests, all passing, against a bundle with `headless-cms-impl` deployed from this branch.

## PR Check

**pr-check: PASS** — tested on `963e375bb78baa52ad07976109213c366685f59d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "963e375bb78baa52ad07976109213c366685f59d"} -->
