### PR TITLE
LPD-103046 Keep multi-list selections during the content upgrade

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/content/compatibility/converter/JournalContentCompatibilityConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/content/compatibility/converter/JournalContentCompatibilityConverterImpl.java
@@ -185,7 +185,9 @@ public class JournalContentCompatibilityConverterImpl
 			"dynamic-content");
 
 		for (Element dynamicContentElement : dynamicContentElements) {
-			if (Objects.equals(ddmFieldType, "list")) {
+			if (Objects.equals(ddmFieldType, "list") ||
+				Objects.equals(ddmFieldType, "multi-list")) {
+
 				continue;
 			}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/compatibility/converter/test/JournalContentCompatibilityConverterTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/compatibility/converter/test/JournalContentCompatibilityConverterTest.java
@@ -186,6 +186,26 @@ public class JournalContentCompatibilityConverterTest {
 	}
 
 	@Test
+	public void testMultiListFieldCompatibilityLayer() throws Exception {
+		String content = read(
+			"test-journal-content-multi-list-field-compatibility.xml");
+
+		content = _journalContentCompatibilityConverter.convert(content);
+
+		String expectedContent = read(
+			"test-journal-content-multi-list-field-compatibility-expected-" +
+				"results.xml");
+
+		Document expectedDocument = SAXReaderUtil.read(expectedContent);
+
+		Document document = SAXReaderUtil.read(content);
+
+		Assert.assertEquals(
+			_getFormattedString(expectedDocument),
+			_getFormattedString(document));
+	}
+
+	@Test
 	public void testNestedFieldsCompatibilityLayer() throws Exception {
 		String content = read(
 			"test-journal-content-nested-fields-compatibility.xml");

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility-expected-results.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility-expected-results.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element index-type="keyword" instance-id="wnkr" name="MultiSelect" type="multi-list">
+		<dynamic-content language-id="en_US">
+			<option><![CDATA[Value 01]]></option>
+			<option><![CDATA[Value 02]]></option>
+		</dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element index-type="keyword" instance-id="wnkr" name="MultiSelect" type="multi-list">
+		<dynamic-content language-id="en_US">
+			<option><![CDATA[Value 01]]></option>
+			<option><![CDATA[Value 02]]></option>
+		</dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
## What Is Being Fixed

Ticket - https://liferay.atlassian.net/browse/LPD-103046.

Web content created in Liferay 6.1 with a Multi-Selection List field loses its selected values when the database is upgraded. The structure upgrades correctly, so the field still renders with all of its options and nothing selected, and no error is raised.

## How It Is Being Fixed

`JournalContentCompatibilityConverterImpl._convertDDMFieldValue` skipped only fields of type `list`. A 6.1 field is type `multi-list`, so it fell through to `getText()`, `clearContent()` and `addCDATA()`. On an element whose children are `option` tags, `getText()` returns only the whitespace between them, so the options were deleted and that whitespace written back in their place. Adding `multi-list` to the guard leaves the content untouched, as it already does for `list`.

The converter also runs on every article save through `JournalArticleLocalServiceImpl`, so the guard matters outside the upgrade path too. `_convertDDMFieldType` maps `list` to `select` but has no `multi-list` case; that is left alone here to keep the change minimal.

## PR Check

**pr-check: PASS** — tested on `8046cd960e9a62a4206e4694592d666e339aa98e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8046cd960e9a62a4206e4694592d666e339aa98e"} -->
