### PR TITLE
LPD-103205 Bypass the finder cache when loading article versions

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4149,7 +4149,8 @@ public class JournalArticleLocalServiceImpl
 
 		List<JournalArticle> articleVersions =
 			journalArticlePersistence.findByG_A(
-				article.getGroupId(), article.getArticleId());
+				article.getGroupId(), article.getArticleId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null, false);
 
 		articleVersions = ListUtil.sort(
 			articleVersions, ArticleVersionComparator.getInstance(false));
@@ -4187,7 +4188,11 @@ public class JournalArticleLocalServiceImpl
 			articleVersion.setArticleId(trashArticleId);
 			articleVersion.setStatus(WorkflowConstants.STATUS_IN_TRASH);
 
-			journalArticlePersistence.update(articleVersion);
+			articleVersion = journalArticlePersistence.update(articleVersion);
+
+			if (article.equals(articleVersion)) {
+				article = articleVersion;
+			}
 		}
 
 		articleResource.setArticleId(trashArticleId);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -2168,6 +2168,51 @@ public class JournalArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testMoveArticleToTrashWithCachedArticleVersions()
+		throws Exception {
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		journalArticle = JournalTestUtil.updateArticle(
+			journalArticle, RandomTestUtil.randomString());
+
+		JournalArticle latestJournalArticle = JournalTestUtil.updateArticle(
+			journalArticle, RandomTestUtil.randomString());
+
+		_journalArticleLocalService.deleteArticle(latestJournalArticle);
+
+		List<JournalArticle> journalArticles =
+			_journalArticleLocalService.getArticles(
+				journalArticle.getGroupId(), journalArticle.getArticleId());
+
+		Assert.assertEquals(
+			journalArticles.toString(), 2, journalArticles.size());
+
+		journalArticle = _journalArticleLocalService.moveArticleToTrash(
+			TestPropsValues.getUserId(), journalArticle.getGroupId(),
+			journalArticle.getArticleId());
+
+		Assert.assertTrue(journalArticle.isInTrash());
+
+		journalArticles = _journalArticleLocalService.getArticles(
+			journalArticle.getGroupId(), journalArticle.getArticleId(),
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			ArticleVersionComparator.getInstance(false));
+
+		Assert.assertEquals(
+			journalArticles.toString(), 2, journalArticles.size());
+
+		for (JournalArticle curJournalArticle : journalArticles) {
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_IN_TRASH,
+				curJournalArticle.getStatus());
+		}
+	}
+
+	@Test
 	public void testRemoveArticleLocale() throws Exception {
 		DataDefinition dataDefinition =
 			DataDefinitionTestUtil.addDataDefinition(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103205

## What is this trying to solve?

A customer (LPP-65269 / LRHC-155131) cannot delete a web content article when a user is subscribed to it and the article's latest version was deleted beforehand. The delete fails with:

```
jakarta.persistence.OptimisticLockException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [com.liferay.journal.model.impl.JournalArticleImpl#37453]
```

`moveArticleToTrash` loads every article version through `findByG_A` before `updateStatus` bumps the latest version's `mvccVersion`. When the JournalArticle finder cache is warm — in the customer's case re-warmed by the asynchronous subscription notification after the latest version was deleted — that snapshot holds detached, deserialized copies, and writing them back after the status update matches zero rows and throws. The snapshot has sat before `updateStatus` since LPD-15151, which needed the pre-trash version statuses (2025.Q1 unaffected, 2026.Q1 affected).

## How am I fixing it?

Load the article version snapshot with `useFinderCache = false`, so the rename loop operates on session-attached entities instead of detached finder cache copies — a session-attached instance always carries the current `mvccVersion`, so the later writes cannot go stale. The snapshot stays where LPD-15151 put it, keeping `getArticleVersionStatuses` and the recorded status history untouched. The loop also re-points `article` at the instance it updates, matching `restoreArticleFromTrash`, so the final update never depends on instance identity with the finder result.

## How can you verify that it works?

Manual steps, following the customer's scenario:

1. Create a web content article and update it twice, so it has three approved versions.
1. Subscribe a second user to the article (Web Content → article actions → Subscribe).
1. Open the article's version history and delete the latest version.
1. Move the article to the Recycle Bin from the Web Content list.

Without the fix, step 4 fails with the `OptimisticLockException` above whenever the finder cache holds the article's versions; with the fix, the article lands in the Recycle Bin with every remaining version in trash status, and restoring it brings the version statuses back.

Tests:

The new integration test reproduces the customer's exact `OptimisticLockException` deterministically — it deletes the latest version, warms the JournalArticle finder cache (standing in for the asynchronous subscription notification), and moves the article to the trash:

```
cd modules/apps/journal/journal-test
gradlew testIntegration --tests JournalArticleLocalServiceTest.testMoveArticleToTrashAfterLatestVersionDeletion
```

`JournalArticleLocalServiceTest` (60 tests, including `testArticleStatusHistoryAfterTrashAndRestore` from LPD-15151) and `JournalArticleTrashHandlerTest` (85 tests) pass with the fix.

## PR Check

**pr-check: PASS** — tested on `88d810bcfffb4442f8032df023a680e93f6197f8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "88d810bcfffb4442f8032df023a680e93f6197f8"} -->
