### PR TITLE
LPD-103453 Test the review date notification and info panel time zone

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
@@ -183,8 +183,9 @@ public class CMSObjectEntryReviewUserNotificationTest {
 			_getUserNotificationFeedEntry(objectEntry, "es_ES");
 
 		Assert.assertEquals(
-			LanguageUtil.format(
-				LocaleUtil.SPAIN, "x-has-reached-its-review-date", title),
+			HtmlUtil.escape(
+				LanguageUtil.format(
+					LocaleUtil.SPAIN, "x-has-reached-its-review-date", title)),
 			userNotificationFeedEntry.getTitle());
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
@@ -7,6 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.notifications.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -18,11 +19,14 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.notifications.UserNotificationFeedEntry;
 import com.liferay.portal.kernel.notifications.UserNotificationManagerUtil;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -41,6 +45,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -124,6 +129,61 @@ public class CMSObjectEntryReviewUserNotificationTest {
 			userNotificationFeedEntry.getTitle());
 	}
 
+	@Test
+	public void testReviewDateUserNotificationEventIsSentOnlyOnce()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addCMSObjectEntry(
+			RandomTestUtil.randomString());
+
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+
+		List<UserNotificationEvent> userNotificationEvents =
+			_getReviewUserNotificationEvents(objectEntry, _user);
+
+		Assert.assertEquals(
+			userNotificationEvents.toString(), 1,
+			userNotificationEvents.size());
+	}
+
+	@Test
+	public void testReviewDateUserNotificationEventIsSentOnlyToOwner()
+		throws Exception {
+
+		User contentReviewerUser = UserTestUtil.addUser();
+
+		_userLocalService.addGroupUser(
+			_depotEntry.getGroupId(), contentReviewerUser.getUserId());
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			contentReviewerUser.getUserId(), _depotEntry.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		ObjectEntry objectEntry = _addCMSObjectEntry(
+			RandomTestUtil.randomString());
+
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+
+		List<UserNotificationEvent> ownerUserNotificationEvents =
+			_getReviewUserNotificationEvents(objectEntry, _user);
+
+		Assert.assertEquals(
+			ownerUserNotificationEvents.toString(), 1,
+			ownerUserNotificationEvents.size());
+
+		List<UserNotificationEvent> contentReviewerUserNotificationEvents =
+			_getReviewUserNotificationEvents(objectEntry, contentReviewerUser);
+
+		Assert.assertEquals(
+			contentReviewerUserNotificationEvents.toString(), 0,
+			contentReviewerUserNotificationEvents.size());
+	}
+
 	private ObjectEntry _addCMSObjectEntry(String title) throws Exception {
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.
@@ -146,35 +206,43 @@ public class CMSObjectEntryReviewUserNotificationTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
-	private UserNotificationFeedEntry _interpretUserNotificationEvent(
-			ObjectEntry objectEntry, String languageId)
+	private List<UserNotificationEvent> _getReviewUserNotificationEvents(
+			ObjectEntry objectEntry, User user)
 		throws Exception {
+
+		List<UserNotificationEvent> reviewUserNotificationEvents =
+			new ArrayList<>();
 
 		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
 
-		UserNotificationEvent reviewUserNotificationEvent = null;
-
-		List<UserNotificationEvent> userNotificationEvents =
-			_userNotificationEventLocalService.getUserNotificationEvents(
-				_user.getUserId());
-
 		for (UserNotificationEvent userNotificationEvent :
-				userNotificationEvents) {
+				_userNotificationEventLocalService.getUserNotificationEvents(
+					user.getUserId())) {
 
 			if (Objects.equals(
 					objectDefinition.getPortletId(),
 					userNotificationEvent.getType())) {
 
-				Assert.assertNull(
-					userNotificationEvents.toString(),
-					reviewUserNotificationEvent);
-
-				reviewUserNotificationEvent = userNotificationEvent;
+				reviewUserNotificationEvents.add(userNotificationEvent);
 			}
 		}
 
-		Assert.assertNotNull(
-			userNotificationEvents.toString(), reviewUserNotificationEvent);
+		return reviewUserNotificationEvents;
+	}
+
+	private UserNotificationFeedEntry _interpretUserNotificationEvent(
+			ObjectEntry objectEntry, String languageId)
+		throws Exception {
+
+		List<UserNotificationEvent> userNotificationEvents =
+			_getReviewUserNotificationEvents(objectEntry, _user);
+
+		Assert.assertEquals(
+			userNotificationEvents.toString(), 1,
+			userNotificationEvents.size());
+
+		UserNotificationEvent reviewUserNotificationEvent =
+			userNotificationEvents.get(0);
 
 		String payload = reviewUserNotificationEvent.getPayload();
 
@@ -205,7 +273,13 @@ public class CMSObjectEntryReviewUserNotificationTest {
 	@Inject
 	private Portal _portal;
 
+	@Inject
+	private RoleLocalService _roleLocalService;
+
 	private User _user;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
@@ -1,0 +1,217 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.notifications.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserNotificationEvent;
+import com.liferay.portal.kernel.notifications.UserNotificationFeedEntry;
+import com.liferay.portal.kernel.notifications.UserNotificationManagerUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Veronica Gonzalez
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class CMSObjectEntryReviewUserNotificationTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_user = UserTestUtil.addUser();
+
+		_userLocalService.addGroupUser(
+			_depotEntry.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testInterpretReviewDateUserNotificationEvent()
+		throws Exception {
+
+		String title = RandomTestUtil.randomString() + "<&>";
+
+		ObjectEntry objectEntry = _addCMSObjectEntry(title);
+
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+
+		UserNotificationFeedEntry userNotificationFeedEntry =
+			_interpretUserNotificationEvent(objectEntry, "en_US");
+
+		Assert.assertEquals(
+			HtmlUtil.escape(
+				LanguageUtil.format(
+					LocaleUtil.US, "x-has-reached-its-review-date", title)),
+			userNotificationFeedEntry.getTitle());
+		Assert.assertEquals(
+			StringBundler.concat(
+				_portal.getPathFriendlyURLPublic(),
+				GroupConstants.CMS_FRIENDLY_URL, "/view-asset?objectEntryId=",
+				objectEntry.getObjectEntryId()),
+			userNotificationFeedEntry.getLink());
+	}
+
+	@Test
+	public void testInterpretReviewDateUserNotificationEventLocalized()
+		throws Exception {
+
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addCMSObjectEntry(title);
+
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+
+		UserNotificationFeedEntry userNotificationFeedEntry =
+			_interpretUserNotificationEvent(objectEntry, "es_ES");
+
+		Assert.assertEquals(
+			LanguageUtil.format(
+				LocaleUtil.SPAIN, "x-has-reached-its-review-date", title),
+			userNotificationFeedEntry.getTitle());
+	}
+
+	private ObjectEntry _addCMSObjectEntry(String title) throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			_depotEntry.getGroupId(), _user.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			LocaleUtil.toLanguageId(LocaleUtil.US),
+			HashMapBuilder.<String, Serializable>put(
+				"reviewDate", new Date()
+			).put(
+				"title_i18n",
+				HashMapBuilder.<String, Object>put(
+					LocaleUtil.toLanguageId(LocaleUtil.US), title
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private UserNotificationFeedEntry _interpretUserNotificationEvent(
+			ObjectEntry objectEntry, String languageId)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		UserNotificationEvent reviewUserNotificationEvent = null;
+
+		List<UserNotificationEvent> userNotificationEvents =
+			_userNotificationEventLocalService.getUserNotificationEvents(
+				_user.getUserId());
+
+		for (UserNotificationEvent userNotificationEvent :
+				userNotificationEvents) {
+
+			if (Objects.equals(
+					objectDefinition.getPortletId(),
+					userNotificationEvent.getType())) {
+
+				Assert.assertNull(
+					userNotificationEvents.toString(),
+					reviewUserNotificationEvent);
+
+				reviewUserNotificationEvent = userNotificationEvent;
+			}
+		}
+
+		Assert.assertNotNull(
+			userNotificationEvents.toString(), reviewUserNotificationEvent);
+
+		String payload = reviewUserNotificationEvent.getPayload();
+
+		Assert.assertTrue(
+			payload,
+			payload.contains("classPK\":" + objectEntry.getObjectEntryId()));
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setLanguageId(languageId);
+		serviceContext.setUserId(_user.getUserId());
+
+		return UserNotificationManagerUtil.interpret(
+			StringPool.BLANK, reviewUserNotificationEvent, serviceContext);
+	}
+
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@Inject
+	private UserNotificationEventLocalService
+		_userNotificationEventLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
@@ -17,6 +17,8 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -222,15 +224,18 @@ public class CMSObjectEntryReviewUserNotificationTest {
 
 		List<UserNotificationEvent> userNotificationEvents = new ArrayList<>();
 
-		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
-
 		for (UserNotificationEvent userNotificationEvent :
 				_userNotificationEventLocalService.getUserNotificationEvents(
 					user.getUserId())) {
 
-			if (Objects.equals(
-					objectDefinition.getPortletId(),
-					userNotificationEvent.getType())) {
+			JSONObject payloadJSONObject = JSONFactoryUtil.createJSONObject(
+				userNotificationEvent.getPayload());
+
+			if ((payloadJSONObject.getLong("classPK") ==
+					objectEntry.getObjectEntryId()) &&
+				Objects.equals(
+					payloadJSONObject.getString("notificationMessageKey"),
+					"x-has-reached-its-review-date")) {
 
 				userNotificationEvents.add(userNotificationEvent);
 			}
@@ -252,12 +257,6 @@ public class CMSObjectEntryReviewUserNotificationTest {
 
 		UserNotificationEvent userNotificationEvent =
 			userNotificationEvents.get(0);
-
-		String payload = userNotificationEvent.getPayload();
-
-		Assert.assertTrue(
-			payload,
-			payload.contains("classPK\":" + objectEntry.getObjectEntryId()));
 
 		ServiceContext serviceContext = new ServiceContext();
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
@@ -85,54 +85,7 @@ public class CMSObjectEntryReviewUserNotificationTest {
 	}
 
 	@Test
-	public void testInterpretReviewDateUserNotificationEvent()
-		throws Exception {
-
-		String title = RandomTestUtil.randomString() + "<&>";
-
-		ObjectEntry objectEntry = _addCMSObjectEntry(title);
-
-		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
-
-		UserNotificationFeedEntry userNotificationFeedEntry =
-			_interpretUserNotificationEvent(objectEntry, "en_US");
-
-		Assert.assertEquals(
-			HtmlUtil.escape(
-				LanguageUtil.format(
-					LocaleUtil.US, "x-has-reached-its-review-date", title)),
-			userNotificationFeedEntry.getTitle());
-		Assert.assertEquals(
-			StringBundler.concat(
-				_portal.getPathFriendlyURLPublic(),
-				GroupConstants.CMS_FRIENDLY_URL, "/view-asset?objectEntryId=",
-				objectEntry.getObjectEntryId()),
-			userNotificationFeedEntry.getLink());
-	}
-
-	@Test
-	public void testInterpretReviewDateUserNotificationEventLocalized()
-		throws Exception {
-
-		String title = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = _addCMSObjectEntry(title);
-
-		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
-
-		UserNotificationFeedEntry userNotificationFeedEntry =
-			_interpretUserNotificationEvent(objectEntry, "es_ES");
-
-		Assert.assertEquals(
-			LanguageUtil.format(
-				LocaleUtil.SPAIN, "x-has-reached-its-review-date", title),
-			userNotificationFeedEntry.getTitle());
-	}
-
-	@Test
-	public void testReviewDateUserNotificationEventIsSentOnlyOnce()
-		throws Exception {
-
+	public void testCheckObjectEntriesTwice() throws Exception {
 		ObjectEntry objectEntry = _addCMSObjectEntry(
 			RandomTestUtil.randomString());
 
@@ -140,7 +93,7 @@ public class CMSObjectEntryReviewUserNotificationTest {
 		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
 
 		List<UserNotificationEvent> userNotificationEvents =
-			_getReviewUserNotificationEvents(objectEntry, _user);
+			_getUserNotificationEvents(objectEntry, _user);
 
 		Assert.assertEquals(
 			userNotificationEvents.toString(), 1,
@@ -148,9 +101,7 @@ public class CMSObjectEntryReviewUserNotificationTest {
 	}
 
 	@Test
-	public void testReviewDateUserNotificationEventIsSentOnlyToOwner()
-		throws Exception {
-
+	public void testCheckObjectEntriesWithContentReviewer() throws Exception {
 		User contentReviewerUser = UserTestUtil.addUser();
 
 		_userLocalService.addGroupUser(
@@ -170,18 +121,71 @@ public class CMSObjectEntryReviewUserNotificationTest {
 		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
 
 		List<UserNotificationEvent> ownerUserNotificationEvents =
-			_getReviewUserNotificationEvents(objectEntry, _user);
+			_getUserNotificationEvents(objectEntry, _user);
 
 		Assert.assertEquals(
 			ownerUserNotificationEvents.toString(), 1,
 			ownerUserNotificationEvents.size());
 
 		List<UserNotificationEvent> contentReviewerUserNotificationEvents =
-			_getReviewUserNotificationEvents(objectEntry, contentReviewerUser);
+			_getUserNotificationEvents(objectEntry, contentReviewerUser);
 
 		Assert.assertEquals(
 			contentReviewerUserNotificationEvents.toString(), 0,
 			contentReviewerUserNotificationEvents.size());
+	}
+
+	@Test
+	public void testGetLink() throws Exception {
+		ObjectEntry objectEntry = _addCMSObjectEntry(
+			RandomTestUtil.randomString());
+
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+
+		UserNotificationFeedEntry userNotificationFeedEntry =
+			_getUserNotificationFeedEntry(objectEntry, "en_US");
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				_portal.getPathFriendlyURLPublic(),
+				GroupConstants.CMS_FRIENDLY_URL, "/view-asset?objectEntryId=",
+				objectEntry.getObjectEntryId()),
+			userNotificationFeedEntry.getLink());
+	}
+
+	@Test
+	public void testGetTitle() throws Exception {
+		String title = RandomTestUtil.randomString() + "<&>";
+
+		ObjectEntry objectEntry = _addCMSObjectEntry(title);
+
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+
+		UserNotificationFeedEntry userNotificationFeedEntry =
+			_getUserNotificationFeedEntry(objectEntry, "en_US");
+
+		Assert.assertEquals(
+			HtmlUtil.escape(
+				LanguageUtil.format(
+					LocaleUtil.US, "x-has-reached-its-review-date", title)),
+			userNotificationFeedEntry.getTitle());
+	}
+
+	@Test
+	public void testGetTitleWithSpanishLocale() throws Exception {
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addCMSObjectEntry(title);
+
+		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
+
+		UserNotificationFeedEntry userNotificationFeedEntry =
+			_getUserNotificationFeedEntry(objectEntry, "es_ES");
+
+		Assert.assertEquals(
+			LanguageUtil.format(
+				LocaleUtil.SPAIN, "x-has-reached-its-review-date", title),
+			userNotificationFeedEntry.getTitle());
 	}
 
 	private ObjectEntry _addCMSObjectEntry(String title) throws Exception {
@@ -206,12 +210,11 @@ public class CMSObjectEntryReviewUserNotificationTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
-	private List<UserNotificationEvent> _getReviewUserNotificationEvents(
+	private List<UserNotificationEvent> _getUserNotificationEvents(
 			ObjectEntry objectEntry, User user)
 		throws Exception {
 
-		List<UserNotificationEvent> reviewUserNotificationEvents =
-			new ArrayList<>();
+		List<UserNotificationEvent> userNotificationEvents = new ArrayList<>();
 
 		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
 
@@ -223,28 +226,28 @@ public class CMSObjectEntryReviewUserNotificationTest {
 					objectDefinition.getPortletId(),
 					userNotificationEvent.getType())) {
 
-				reviewUserNotificationEvents.add(userNotificationEvent);
+				userNotificationEvents.add(userNotificationEvent);
 			}
 		}
 
-		return reviewUserNotificationEvents;
+		return userNotificationEvents;
 	}
 
-	private UserNotificationFeedEntry _interpretUserNotificationEvent(
+	private UserNotificationFeedEntry _getUserNotificationFeedEntry(
 			ObjectEntry objectEntry, String languageId)
 		throws Exception {
 
 		List<UserNotificationEvent> userNotificationEvents =
-			_getReviewUserNotificationEvents(objectEntry, _user);
+			_getUserNotificationEvents(objectEntry, _user);
 
 		Assert.assertEquals(
 			userNotificationEvents.toString(), 1,
 			userNotificationEvents.size());
 
-		UserNotificationEvent reviewUserNotificationEvent =
+		UserNotificationEvent userNotificationEvent =
 			userNotificationEvents.get(0);
 
-		String payload = reviewUserNotificationEvent.getPayload();
+		String payload = userNotificationEvent.getPayload();
 
 		Assert.assertTrue(
 			payload,
@@ -256,7 +259,7 @@ public class CMSObjectEntryReviewUserNotificationTest {
 		serviceContext.setUserId(_user.getUserId());
 
 		return UserNotificationManagerUtil.interpret(
-			StringPool.BLANK, reviewUserNotificationEvent, serviceContext);
+			StringPool.BLANK, userNotificationEvent, serviceContext);
 	}
 
 	private DepotEntry _depotEntry;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
@@ -94,12 +94,7 @@ public class CMSObjectEntryReviewUserNotificationTest {
 		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
 		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
 
-		List<UserNotificationEvent> userNotificationEvents =
-			_getUserNotificationEvents(objectEntry, _user);
-
-		Assert.assertEquals(
-			userNotificationEvents.toString(), 1,
-			userNotificationEvents.size());
+		_assertUserNotificationEventsCount(1, objectEntry, _user);
 	}
 
 	@Test
@@ -127,19 +122,8 @@ public class CMSObjectEntryReviewUserNotificationTest {
 
 		_objectEntryLocalService.checkObjectEntries(objectEntry.getCompanyId());
 
-		List<UserNotificationEvent> ownerUserNotificationEvents =
-			_getUserNotificationEvents(objectEntry, _user);
-
-		Assert.assertEquals(
-			ownerUserNotificationEvents.toString(), 1,
-			ownerUserNotificationEvents.size());
-
-		List<UserNotificationEvent> contentReviewerUserNotificationEvents =
-			_getUserNotificationEvents(objectEntry, contentReviewerUser);
-
-		Assert.assertEquals(
-			contentReviewerUserNotificationEvents.toString(), 0,
-			contentReviewerUserNotificationEvents.size());
+		_assertUserNotificationEventsCount(1, objectEntry, _user);
+		_assertUserNotificationEventsCount(0, objectEntry, contentReviewerUser);
 	}
 
 	@Test
@@ -216,6 +200,18 @@ public class CMSObjectEntryReviewUserNotificationTest {
 				).build()
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertUserNotificationEventsCount(
+			int count, ObjectEntry objectEntry, User user)
+		throws Exception {
+
+		List<UserNotificationEvent> userNotificationEvents =
+			_getUserNotificationEvents(objectEntry, user);
+
+		Assert.assertEquals(
+			userNotificationEvents.toString(), count,
+			userNotificationEvents.size());
 	}
 
 	private List<UserNotificationEvent> _getUserNotificationEvents(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/CMSObjectEntryReviewUserNotificationTest.java
@@ -115,6 +115,11 @@ public class CMSObjectEntryReviewUserNotificationTest {
 			contentReviewerUser.getUserId(), _depotEntry.getGroupId(),
 			new long[] {role.getRoleId()});
 
+		Assert.assertTrue(
+			_userGroupRoleLocalService.hasUserGroupRole(
+				contentReviewerUser.getUserId(), _depotEntry.getGroupId(),
+				role.getRoleId()));
+
 		ObjectEntry objectEntry = _addCMSObjectEntry(
 			RandomTestUtil.randomString());
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/AssetTypeInfoPanelContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/AssetTypeInfoPanelContent.test.tsx
@@ -360,4 +360,47 @@ describe('CMS Asset Type Info Panel', () => {
 			within(breadcrumb).getByRole('button', {name: 'content-folder'})
 		).toBeInTheDocument();
 	});
+
+	describe('user time zone', () => {
+		const originalGetTimeZone = global.Liferay.ThemeDisplay.getTimeZone;
+
+		beforeEach(() => {
+			global.Liferay.ThemeDisplay.getTimeZone = jest
+				.fn()
+				.mockReturnValue('America/Los_Angeles');
+		});
+
+		afterEach(() => {
+			global.Liferay.ThemeDisplay.getTimeZone = originalGetTimeZone;
+		});
+
+		it('shows the metadata dates in the user time zone', () => {
+			render(
+				<SidePanel containerRef={{current: null}}>
+					<AssetTypeInfoPanelContent
+						additionalProps={testAdditionalProps}
+						items={
+							[
+								{
+									...CONTENT_OBJECT_ENTRY,
+									embedded: {
+										...CONTENT_OBJECT_ENTRY.embedded,
+										expirationDate: '2026-03-01T02:30:00Z',
+										reviewDate: '2026-03-02T01:15:00Z',
+									},
+								},
+							] as any
+						}
+					/>
+				</SidePanel>
+			);
+
+			expect(
+				screen.getByText('02/28/2026, 06:30 PM')
+			).toBeInTheDocument();
+			expect(
+				screen.getByText('03/01/2026, 05:15 PM')
+			).toBeInTheDocument();
+		});
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103453

## What Is Being Fixed

The Advanced Content Governance story (LPD-78629) shipped with some of its testing checklist uncovered: nothing verified the review date notification as the user receives it (`ObjectUserNotificationsHandler` had no tests at all), the refined recipient contract from LPD-79668 (owner only, one notification per review date) was unpinned, and the info panel metadata dates had no coverage for the user's time zone.

## How It Is Being Fixed

A new integration test class, `CMSObjectEntryReviewUserNotificationTest`, exercises the full flow against a CMS Space: a plain Space member owns a basic web content whose review date has passed, `checkObjectEntries` runs, and the resulting notification is interpreted through the real handler, asserting the rendered title, the localized Spanish message (including HTML escaping of the asset title) and the link to the CMS viewer. Two more cases pin the LPD-79668 contract: a Space Content Reviewer in the same Space receives no notification, and running the check twice still produces a single event. On the frontend, a new Jest case in `AssetTypeInfoPanelContent.test.tsx` renders the info panel with expiration and review dates that cross the day boundary in `America/Los_Angeles`, proving the metadata panel formats dates in the user's time zone rather than UTC.

## PR Check

**pr-check: PASS** — tested on `c7f243a094b908718308424f505e571fc1db264c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c7f243a094b908718308424f505e571fc1db264c"} -->
