### PR TITLE
LPD-103464 Functional tests for Space friendly URLs and duplication

### DIFF
--- a/modules/test/playwright/helpers/ObjectEntryApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectEntryApiHelper.ts
@@ -177,6 +177,17 @@ export class ObjectEntryApiHelper {
 		);
 	}
 
+	async postObjectEntryCopy(
+		applicationName: string,
+		objectEntryId: number,
+		objectEntryFolderId: number
+	): Promise<ObjectEntry> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${applicationName}/${objectEntryId}/by-object-entry-folder-id/${objectEntryFolderId}/copy`,
+			{data: {}}
+		);
+	}
+
 	async getObjectEntryCollaboratorsPage(
 		applicationName: string,
 		objectEntryId: number

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/display-page-template/helpers/displayPageTemplate.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/display-page-template/helpers/displayPageTemplate.ts
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {ApiHelpers} from '../../../../../helpers/ApiHelpers';
+import {PageEditorPage} from '../../../../../pages/layout-content-page-editor-web/PageEditorPage';
+import {DisplayPageTemplatesPage} from '../../../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
+import getRandomString from '../../../../../utils/getRandomString';
+
+/**
+ * Creates the default display page template of a CMS object definition and
+ * maps a Heading fragment to one of its fields, so an entry of that definition
+ * renders its own value at its friendly URL.
+ *
+ * The template itself is created and marked as default through the API. Only
+ * the fragment mapping goes through the page editor, because no API exposes it.
+ */
+export async function createDefaultDisplayPageTemplate({
+	apiHelpers,
+	displayPageTemplatesPage,
+	mappedField = 'Title',
+	objectDefinitionName,
+	page,
+	pageEditorPage,
+	site,
+}: {
+	apiHelpers: ApiHelpers;
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	mappedField?: string;
+	objectDefinitionName: string;
+	page: Page;
+	pageEditorPage: PageEditorPage;
+	site: Site;
+}) {
+	const name = `DPT ${getRandomString()}`;
+
+	const objectDefinition =
+		await apiHelpers.objectAdmin.getObjectDefinitionByName(
+			objectDefinitionName
+		);
+
+	const className = await apiHelpers.jsonWebServicesClassName.fetchClassName(
+		objectDefinition.className
+	);
+
+	const layoutPageTemplateEntry =
+		await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addDisplayPageLayoutPageTemplateEntry(
+			{
+				classNameId: className.classNameId,
+				groupId: String(site.id),
+				name,
+			}
+		);
+
+	await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.markAsDefaultDisplayPageLayoutPageTemplateEntry(
+		{
+			layoutPageTemplateEntryId:
+				layoutPageTemplateEntry.layoutPageTemplateEntryId,
+		}
+	);
+
+	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+	await displayPageTemplatesPage.editTemplate(name);
+
+	await pageEditorPage.addFragment(
+		'Basic Components',
+		'Heading',
+		page.getByText('Drag and drop fragments or widgets here')
+	);
+
+	const headingId = await pageEditorPage.getFragmentId('Heading');
+
+	await pageEditorPage.selectEditable(headingId, 'element-text');
+
+	await pageEditorPage.changeConfiguration({
+		fieldLabel: 'Field',
+		tab: 'Mapping',
+		value: mappedField,
+	});
+
+	await pageEditorPage.publishPage();
+
+	return name;
+}

--- a/modules/test/playwright/tests/e2e-cms-dxp/main/display-page-template/spaceFriendlyURLDPT.spec.ts
+++ b/modules/test/playwright/tests/e2e-cms-dxp/main/display-page-template/spaceFriendlyURLDPT.spec.ts
@@ -1,0 +1,294 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {displayPageTemplatesPagesTest} from '../../../../fixtures/displayPageTemplatesPagesTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {createDefaultDisplayPageTemplate} from './helpers/displayPageTemplate';
+
+const _APPLICATION_NAME = 'cms/basic-web-contents';
+
+const _OBJECT_DEFINITION_NAME = 'CMSBasicWebContent';
+
+const _URL_SEPARATOR = 'cmsbasicwebcontent';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	displayPageTemplatesPagesTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+test(
+	'A custom Space friendly URL replaces the asset-library segment of the Display Page URL',
+	{tag: '@LPD-103464'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const contentTitle = `Content ${getRandomString()}`;
+		const friendlyUrlPath = `custom-${getRandomString()}`.toLowerCase();
+		const spaceName = `Space ${getRandomString()}`;
+		const untouchedContentTitle = `Content ${getRandomString()}`;
+		const untouchedFriendlyUrlPath =
+			`untouched-${getRandomString()}`.toLowerCase();
+		const untouchedSpaceName = `Space ${getRandomString()}`;
+
+		let customFriendlyURL: string;
+		let space: Awaited<
+			ReturnType<
+				typeof apiHelpers.headlessAssetLibrary.createAssetLibrary
+			>
+		>;
+		let untouchedSpace: typeof space;
+
+		await test.step('Create and activate a Basic Web Content DPT', async () => {
+			await createDefaultDisplayPageTemplate({
+				apiHelpers,
+				displayPageTemplatesPage,
+				objectDefinitionName: _OBJECT_DEFINITION_NAME,
+				page,
+				pageEditorPage,
+				site,
+			});
+		});
+
+		await test.step('Create a content in a Space connected to the site', async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.connectSite(
+				space.externalReferenceCode,
+				site.externalReferenceCode
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					friendlyUrlPath,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				_APPLICATION_NAME,
+				spaceName
+			);
+		});
+
+		await test.step('The content resolves under the generated asset-library segment', async () => {
+			await _expectContentAt(
+				page,
+				_buildDisplayURL(
+					site.friendlyUrlPath,
+					`asset-library-${space.id}`,
+					friendlyUrlPath
+				),
+				contentTitle
+			);
+		});
+
+		await test.step('Edit the Space friendly URL', async () => {
+			customFriendlyURL = `/space-${getRandomString()}`.toLowerCase();
+
+			const patchedAssetLibrary =
+				await apiHelpers.headlessAssetLibrary.patchAssetLibrary(
+					space.externalReferenceCode,
+					{friendlyURL: customFriendlyURL}
+				);
+
+			expect(patchedAssetLibrary.friendlyURL).toBe(customFriendlyURL);
+		});
+
+		await test.step('The content resolves under the custom segment', async () => {
+			await _expectContentAt(
+				page,
+				_buildDisplayURL(
+					site.friendlyUrlPath,
+					customFriendlyURL.substring(1),
+					friendlyUrlPath
+				),
+				contentTitle
+			);
+		});
+
+		await test.step('The generated segment no longer resolves the content', async () => {
+			const response = await page.goto(
+				_buildDisplayURL(
+					site.friendlyUrlPath,
+					`asset-library-${space.id}`,
+					friendlyUrlPath
+				)
+			);
+
+			expect(response?.status()).toBe(404);
+
+			await expect(_getMainContentText(page, contentTitle)).toBeHidden();
+		});
+
+		await test.step('A Space whose friendly URL was never edited keeps resolving', async () => {
+			untouchedSpace =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: untouchedSpaceName,
+					type: 'Space',
+				});
+
+			await apiHelpers.headlessAssetLibrary.connectSite(
+				untouchedSpace.externalReferenceCode,
+				site.externalReferenceCode
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					friendlyUrlPath: untouchedFriendlyUrlPath,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: untouchedContentTitle,
+				},
+				_APPLICATION_NAME,
+				untouchedSpaceName
+			);
+
+			await _expectContentAt(
+				page,
+				_buildDisplayURL(
+					site.friendlyUrlPath,
+					`asset-library-${untouchedSpace.id}`,
+					untouchedFriendlyUrlPath
+				),
+				untouchedContentTitle
+			);
+		});
+	}
+);
+
+test(
+	'An internal link survives the Headless duplicate and carries no asset-library segment',
+	{tag: '@LPD-103464'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const linkedFriendlyUrlPath =
+			`linked-${getRandomString()}`.toLowerCase();
+		const linkedTitle = `Content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const title = `Content ${getRandomString()}`;
+
+		let content: string;
+		let entry: ObjectEntry;
+		let linkURL: string;
+
+		await test.step('Create and activate a Basic Web Content DPT', async () => {
+			await createDefaultDisplayPageTemplate({
+				apiHelpers,
+				displayPageTemplatesPage,
+				objectDefinitionName: _OBJECT_DEFINITION_NAME,
+				page,
+				pageEditorPage,
+				site,
+			});
+		});
+
+		await test.step('Link one content from another inside a Space with a custom friendly URL', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: spaceName,
+					type: 'Space',
+				});
+
+			const customFriendlyURL =
+				`/space-${getRandomString()}`.toLowerCase();
+
+			await apiHelpers.headlessAssetLibrary.patchAssetLibrary(
+				space.externalReferenceCode,
+				{friendlyURL: customFriendlyURL}
+			);
+
+			await apiHelpers.headlessAssetLibrary.connectSite(
+				space.externalReferenceCode,
+				site.externalReferenceCode
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					friendlyUrlPath: linkedFriendlyUrlPath,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: linkedTitle,
+				},
+				_APPLICATION_NAME,
+				spaceName
+			);
+
+			linkURL = _buildDisplayURL(
+				site.friendlyUrlPath,
+				customFriendlyURL.substring(1),
+				linkedFriendlyUrlPath
+			);
+
+			content = `<p><a href="${linkURL}">${linkedTitle}</a></p>`;
+
+			entry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					content,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title,
+				},
+				_APPLICATION_NAME,
+				spaceName
+			);
+		});
+
+		await test.step('The duplicate keeps the link untouched', async () => {
+			const copy = await apiHelpers.objectEntry.postObjectEntryCopy(
+				_APPLICATION_NAME,
+				entry.id,
+				entry.objectEntryFolderId
+			);
+
+			expect(copy.title).toBe(`${title} (Copy)`);
+
+			expect(copy.content).toBe(content);
+
+			expect(copy.content).not.toContain('asset-library-');
+		});
+
+		await test.step('The link still resolves to the target content', async () => {
+			await _expectContentAt(page, linkURL, linkedTitle);
+		});
+	}
+);
+
+function _buildDisplayURL(
+	siteFriendlyUrlPath: string,
+	spaceSegment: string,
+	friendlyUrlPath: string
+) {
+	return `/web${siteFriendlyUrlPath}/${_URL_SEPARATOR}/${spaceSegment}/${friendlyUrlPath}`;
+}
+
+async function _expectContentAt(page: Page, url: string, title: string) {
+	await expect(async () => {
+		await page.goto(url);
+
+		await expect(_getMainContentText(page, title)).toBeVisible({
+			timeout: 2000,
+		});
+	}).toPass({timeout: 10000});
+}
+
+function _getMainContentText(page: Page, title: string) {
+	return page.locator('#main-content').getByText(title, {exact: true});
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -3439,3 +3439,80 @@ test(
 		});
 	}
 );
+
+test(
+	'Duplicate CMS contents in bulk',
+	{tag: '@LPD-103464'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const firstTitle = `Content ${getRandomString()}`;
+		const secondTitle = `Content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		await test.step('Create two contents in a new Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+
+			for (const title of [firstTitle, secondTitle]) {
+				await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title,
+					},
+					'cms/basic-web-contents',
+					spaceName
+				);
+			}
+		});
+
+		await test.step('Duplicate both contents in one bulk action', async () => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.selectItems([firstTitle, secondTitle]);
+
+			await assetsPage.execBulkItemAction('Duplicate');
+
+			await waitForModal({page});
+
+			await expect(assetsPage.modal.title).toContainText(
+				'Duplicate Items'
+			);
+
+			await assetsPage.modal.footer
+				.getByRole('button', {exact: true, name: 'Duplicate'})
+				.click();
+
+			await waitForAlert(
+				page,
+				'Info:Duplicate action started for 2 assets.',
+				{type: 'info'}
+			);
+
+			await waitForAlert(
+				page,
+				'Success:2 assets were successfully duplicated.',
+				{first: true}
+			);
+		});
+
+		await test.step('Both copies are drafts in the same Space', async () => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			for (const title of [firstTitle, secondTitle]) {
+				const copyLink = page.getByRole('link', {
+					exact: true,
+					name: `${title} (Copy)`,
+				});
+
+				await expect(copyLink).toBeVisible();
+
+				await expect(
+					assetsPage.table.bodyRows
+						.filter({has: copyLink})
+						.getByText('Draft')
+				).toBeVisible();
+			}
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/duplicate.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/duplicate.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import getRandomString from '../../../utils/getRandomString';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const _CONTENT_APPLICATION_NAME = 'cms/basic-web-contents';
+
+const _FILE_APPLICATION_NAME = 'cms/basic-documents';
+
+const _OBJECT_DEFINITION_NAME = 'CMSBasicWebContent';
+
+const _PNG_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgAAACAAEABToPCwAAAABJRU5ErkJggg==';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: false},
+	}),
+	loginTest()
+);
+
+test(
+	'Duplicating a content under workflow creates a draft copy without a workflow instance',
+	{tag: '@LPD-103464'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const title = `Content ${getRandomString()}`;
+
+		let objectDefinitionClassName: string;
+		let pendingEntryId: number;
+
+		await test.step('Link Single Approver to the content type in a new Space', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: spaceName,
+					type: 'Space',
+				});
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.getObjectDefinitionByName(
+					_OBJECT_DEFINITION_NAME
+				);
+
+			objectDefinitionClassName = objectDefinition.className;
+
+			const workflowDefinition =
+				await apiHelpers.headlessAdminWorkflow.getWorkflowDefinitionByName(
+					'Single Approver'
+				);
+
+			await apiHelpers.headlessAdminWorkflow.postWorkflowDefinitionLink(
+				objectDefinition.className,
+				space.siteId,
+				workflowDefinition.id,
+				workflowDefinition.name,
+				Number(workflowDefinition.version)
+			);
+		});
+
+		await test.step('The original content enters the workflow', async () => {
+			const pendingEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title,
+				},
+				_CONTENT_APPLICATION_NAME,
+				spaceName
+			);
+
+			pendingEntryId = pendingEntry.id;
+
+			expect(pendingEntry.status.label).toBe('pending');
+
+			expect(
+				await apiHelpers.headlessAdminWorkflow.getWorkflowTaskByAsset(
+					objectDefinitionClassName,
+					String(pendingEntryId)
+				)
+			).not.toBeNull();
+		});
+
+		await test.step('Duplicate the content', async () => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Duplicate',
+				filter: title,
+				parentAction: 'Copy',
+			});
+
+			await expect(
+				page.getByRole('link', {exact: true, name: `${title} (Copy)`})
+			).toBeVisible();
+		});
+
+		await test.step('The copy is a draft and started no workflow', async () => {
+			const copy = await _getEntryByTitle(
+				apiHelpers,
+				spaceName,
+				`${title} (Copy)`
+			);
+
+			expect(copy.id).not.toBe(pendingEntryId);
+
+			expect(copy.status.label).toBe('draft');
+
+			expect(
+				await apiHelpers.headlessAdminWorkflow.getWorkflowTaskByAsset(
+					objectDefinitionClassName,
+					String(copy.id)
+				)
+			).toBeNull();
+		});
+	}
+);
+
+test(
+	'A duplicated content keeps the references embedded in its body',
+	{tag: '@LPD-103464'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const linkedTitle = `Content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		const title = `Content ${getRandomString()}`;
+
+		let content: string;
+
+		await test.step('Create a content embedding a document and an internal link', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+
+			const fileEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: _PNG_BASE64,
+						name: `file_${getRandomString()}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: `File ${getRandomString()}`,
+				},
+				_FILE_APPLICATION_NAME,
+				spaceName
+			);
+
+			const linkedEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: linkedTitle,
+				},
+				_CONTENT_APPLICATION_NAME,
+				spaceName
+			);
+
+			content =
+				`<p><a href="/cmsbasicwebcontent/${linkedEntry.friendlyUrlPath}">` +
+				`${linkedTitle}</a></p>` +
+				`<p><img src="${fileEntry.file.link.href}" /></p>`;
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					content,
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title,
+				},
+				_CONTENT_APPLICATION_NAME,
+				spaceName
+			);
+		});
+
+		await test.step('Duplicate the content', async () => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Duplicate',
+				filter: title,
+				parentAction: 'Copy',
+			});
+
+			await expect(
+				page.getByRole('link', {exact: true, name: `${title} (Copy)`})
+			).toBeVisible();
+		});
+
+		await test.step('The copy carries the same references', async () => {
+			const copy = await _getEntryByTitle(
+				apiHelpers,
+				spaceName,
+				`${title} (Copy)`
+			);
+
+			expect(copy.content).toBe(content);
+		});
+	}
+);
+
+test(
+	'The Headless API duplicate action creates the suffixed draft copy',
+	{tag: '@LPD-103464'},
+	async ({apiHelpers}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const title = `Content ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title,
+			},
+			_CONTENT_APPLICATION_NAME,
+			spaceName
+		);
+
+		expect(entry.actions.duplicate.method).toBe('POST');
+
+		expect(entry.actions.duplicate.href).toContain(
+			`/${entry.id}/by-object-entry-folder-id/` +
+				`${entry.objectEntryFolderId}/copy`
+		);
+
+		const copy = await apiHelpers.objectEntry.postObjectEntryCopy(
+			_CONTENT_APPLICATION_NAME,
+			entry.id,
+			entry.objectEntryFolderId
+		);
+
+		expect(copy.title).toBe(`${title} (Copy)`);
+
+		expect(copy.status.label).toBe('draft');
+
+		expect(copy.objectEntryFolderId).toBe(entry.objectEntryFolderId);
+
+		const secondCopy = await apiHelpers.objectEntry.postObjectEntryCopy(
+			_CONTENT_APPLICATION_NAME,
+			entry.id,
+			entry.objectEntryFolderId
+		);
+
+		expect(secondCopy.title).toBe(`${title} (Copy 1)`);
+	}
+);
+
+async function _getEntryByTitle(
+	apiHelpers: DataApiHelpers,
+	spaceName: string,
+	title: string
+) {
+	const entriesPage =
+		await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+			_CONTENT_APPLICATION_NAME,
+			spaceName,
+			new URLSearchParams({filter: `title eq '${title}'`})
+		);
+
+	expect(entriesPage.items).toHaveLength(1);
+
+	return entriesPage.items[0];
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceFriendlyURL.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceFriendlyURL.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
@@ -159,5 +160,59 @@ test(
 			);
 
 		expect(fetchedAssetLibrary.friendlyURL).toBe(initialFriendlyURL);
+	}
+);
+
+test(
+	'Confirming the save persists a custom Friendly URL entered in Space Settings',
+	{tag: '@LPD-103464'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		const assetLibrary =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+
+		const friendlyURLPath = `cms-${getRandomString()}`.toLowerCase();
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+
+		await page.getByRole('menuitem', {name: 'Space Settings'}).click();
+
+		const friendlyURLTextbox = page.getByRole('textbox', {
+			name: 'Friendly URL Required',
+		});
+
+		await expect(friendlyURLTextbox).toHaveValue(
+			`/asset-library-${assetLibrary.id}`
+		);
+
+		await friendlyURLTextbox.fill(friendlyURLPath);
+
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		const dialog = page.getByRole('alertdialog', {
+			name: 'Save Custom Friendly URL',
+		});
+
+		await dialog.waitFor();
+
+		await dialog.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(
+			page,
+			`Success:${spaceName} was saved successfully.`
+		);
+
+		const fetchedAssetLibrary =
+			await apiHelpers.headlessAssetLibrary.getAssetLibrary(
+				assetLibrary.externalReferenceCode
+			);
+
+		expect(fetchedAssetLibrary.friendlyURL).toBe(`/${friendlyURLPath}`);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103464

Functional test coverage for the three use cases of epic LPD-87059 (editable Space friendly URLs and in-place content duplication). The epic asks that every use case have a corresponding functional test; this fills the gaps that were left.

### What was already covered

`spaceFriendlyURL.spec.ts` and `permissions/spaceSettings.spec.ts` (`@LPD-88344`) cover the friendly URL API validations and the per-role access to Space Settings. `all.spec.ts` and `folders.spec.ts` (`@LPD-88346`, `@LPD-88657`) cover the single item Duplicate action, `permissions/bulkActionsConfirmation.spec.ts` (`@LPD-90340`) covers the bulk confirmation dialog, and `copyMove.spec.ts` covers "Copy to" as a regression. None of that is touched here.

### What this adds

**Use case 1 — the Display Page URL.** Editing the friendly URL of a Space exists to replace the generated `asset-library-{id}` segment in Display Page URLs, and that was the one part with no coverage. The new test asserts the content resolves under the custom segment, that the generated segment then returns `404` — which is what the "Save Custom Friendly URL" dialog warns about, and follows from `GroupLocalServiceImpl.fetchFriendlyURLGroup` doing a plain lookup with no history — and that a Space whose friendly URL was never edited keeps resolving, which is the backward compatibility the epic requires.

**Use case 1 — the UI.** The existing spec only covered the *cancel* path of the confirmation dialog, so nothing proved that confirming it persists the value.

**Use case 2.** The two environment UAT to PRD scenario is not reproducible against a single portal, so the test covers the property that makes it work: an internal link written with a custom Space segment survives the Headless copy unchanged and carries no environment specific identifier.

**Use case 3.** Bulk Duplicate was only exercised up to its confirmation dialog, so nothing verified the copies were created. Nothing verified that a copy skips the workflow its original went through, that references embedded in the body survive, or that the action advertised on the entry is the endpoint that performs the copy.

### Notes for the reviewer

The second commit is separate on purpose so it can be cherry-picked. `addDisplayPageLayoutPageTemplateEntry` is currently called inline in about nineteen specs; the new helper is deliberately scoped to the CMS display page directory rather than refactoring all of them in a test PR.

Every test creates its own Space through `apiHelpers`. Duplicate produces entries the fixture does not track, so deleting the Space is what removes them; using a shared Space would accumulate `(Copy)` rows for later runs.

Two things found while writing these, worth raising on the ticket rather than here:

- The epic asks for Duplicate in the detail view. It only exists as a list item action and a bulk action.
- Localization, accessibility and non-ASCII sanitization from the epic's testing section are not covered by this PR.

### Test evidence

All four specs green locally against a bundle built from master (`13 passed` for the three specs run together, plus the bulk test in `bulkActions.spec.ts`).
