### PR TITLE
LPD-103458 Detect broken links referenced through an Upload field

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/assignee-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/assignee-input/index.html
@@ -69,3 +69,19 @@
 		[/#if]
 	</div>
 </div>
+
+<template class="avatar-template">
+	<span class="flex-shrink-0 mr-3 sticker sticker-circle sticker-secondary sticker-sm"></span>
+</template>
+
+<template class="portrait-template">
+	<span class="sticker-overlay">
+		<img alt="" class="sticker-img" />
+	</span>
+</template>
+
+<template class="user-icon-template">
+	<span class="inline-item">
+		[@clay["icon"] symbol="user" /]
+	</span>
+</template>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/assignee-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/assignee-input/index.js
@@ -108,6 +108,22 @@ function setSelectedAssignee(assignee) {
 	});
 }
 
+function getInitials(name) {
+	const normalizedName = (name || '').trim();
+
+	if (!normalizedName) {
+		return '';
+	}
+
+	const names = normalizedName.split(/\s+/);
+
+	if (names.length > 1) {
+		return `${names[0].charAt(0)}${names[1].charAt(0)}`.toUpperCase();
+	}
+
+	return normalizedName.substring(0, 2).toUpperCase();
+}
+
 function fetchAssignees(url, query, abortController, type) {
 	const searchURL = new URL(url, window.location.origin);
 
@@ -137,7 +153,9 @@ function fetchAssignees(url, query, abortController, type) {
 				)
 				.map((item) => ({
 					externalReferenceCode: item.externalReferenceCode,
+					id: item.id,
 					name: item.name,
+					portrait: item.image,
 					type,
 				}))
 		)
@@ -151,21 +169,66 @@ function searchAssignees(query, abortController) {
 	]).then(([users, roles]) => [...users, ...roles]);
 }
 
+function cloneTemplate(className) {
+	const templateElement = fragmentElement.querySelector(className);
+
+	const node = templateElement.content.cloneNode(true);
+
+	return node.firstElementChild;
+}
+
+function createAvatarElement(assignee) {
+	const avatarElement = cloneTemplate('.avatar-template');
+
+	if (assignee.portrait) {
+		const portraitElement = cloneTemplate('.portrait-template');
+
+		portraitElement.querySelector('img').src = assignee.portrait;
+
+		avatarElement.appendChild(portraitElement);
+	}
+	else if (assignee.type === 'Role') {
+		avatarElement.classList.add('bg-primary', 'text-white');
+
+		avatarElement.textContent = getInitials(assignee.name);
+	}
+	else {
+		avatarElement.classList.add(
+			`user-icon-color-${Number(assignee.id) % 10}`
+		);
+
+		avatarElement.appendChild(cloneTemplate('.user-icon-template'));
+	}
+
+	return avatarElement;
+}
+
 function createOptionElement(assignee, index) {
 	const optionElement = document.createElement('li');
 
-	optionElement.classList.add('dropdown-item');
+	optionElement.classList.add(
+		'align-items-center',
+		'd-flex',
+		'dropdown-item'
+	);
 	optionElement.dataset.index = `${index}`;
 
 	// eslint-disable-next-line no-undef
 	optionElement.id = `${fragmentElementId}-option-${index}`;
-	optionElement.textContent = assignee.name;
 
 	optionElement.setAttribute('role', 'option');
 
 	if (checkIsSelectedAssignee(assignee)) {
 		optionElement.classList.add('active');
 	}
+
+	optionElement.appendChild(createAvatarElement(assignee));
+
+	const nameElement = document.createElement('span');
+
+	nameElement.textContent = assignee.name;
+
+	optionElement.appendChild(nameElement);
 
 	return optionElement;
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/content/compatibility/converter/JournalContentCompatibilityConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/content/compatibility/converter/JournalContentCompatibilityConverterImpl.java
@@ -185,7 +185,9 @@ public class JournalContentCompatibilityConverterImpl
 			"dynamic-content");
 
 		for (Element dynamicContentElement : dynamicContentElements) {
-			if (Objects.equals(ddmFieldType, "list")) {
+			if (Objects.equals(ddmFieldType, "list") ||
+				Objects.equals(ddmFieldType, "multi-list")) {
+
 				continue;
 			}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/compatibility/converter/test/JournalContentCompatibilityConverterTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/compatibility/converter/test/JournalContentCompatibilityConverterTest.java
@@ -186,6 +186,26 @@ public class JournalContentCompatibilityConverterTest {
 	}
 
 	@Test
+	public void testMultiListFieldCompatibilityLayer() throws Exception {
+		String content = read(
+			"test-journal-content-multi-list-field-compatibility.xml");
+
+		content = _journalContentCompatibilityConverter.convert(content);
+
+		String expectedContent = read(
+			"test-journal-content-multi-list-field-compatibility-expected-" +
+				"results.xml");
+
+		Document expectedDocument = SAXReaderUtil.read(expectedContent);
+
+		Document document = SAXReaderUtil.read(content);
+
+		Assert.assertEquals(
+			_getFormattedString(expectedDocument),
+			_getFormattedString(document));
+	}
+
+	@Test
 	public void testNestedFieldsCompatibilityLayer() throws Exception {
 		String content = read(
 			"test-journal-content-nested-fields-compatibility.xml");

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/compatibility/converter/test/JournalContentCompatibilityConverterTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/compatibility/converter/test/JournalContentCompatibilityConverterTest.java
@@ -192,13 +192,13 @@ public class JournalContentCompatibilityConverterTest {
 
 		content = _journalContentCompatibilityConverter.convert(content);
 
+		Document document = SAXReaderUtil.read(content);
+
 		String expectedContent = read(
 			"test-journal-content-multi-list-field-compatibility-expected-" +
 				"results.xml");
 
 		Document expectedDocument = SAXReaderUtil.read(expectedContent);
-
-		Document document = SAXReaderUtil.read(content);
 
 		Assert.assertEquals(
 			_getFormattedString(expectedDocument),

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility-expected-results.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility-expected-results.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element index-type="keyword" instance-id="wnkr" name="MultiSelect" type="multi-list">
+		<dynamic-content language-id="en_US">
+			<option><![CDATA[Value 01]]></option>
+			<option><![CDATA[Value 02]]></option>
+		</dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/dependencies/test-journal-content-multi-list-field-compatibility.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element index-type="keyword" instance-id="wnkr" name="MultiSelect" type="multi-list">
+		<dynamic-content language-id="en_US">
+			<option><![CDATA[Value 01]]></option>
+			<option><![CDATA[Value 02]]></option>
+		</dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/test/CMSContentOutboundLinksModelDocumentContributorTest.java
@@ -12,25 +12,31 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.RichTextObjectFieldBuilder;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.model.bag.ObjectFieldBag;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -39,9 +45,14 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -51,6 +62,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -126,16 +138,28 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 	@Test
 	public void testContribute() throws Exception {
 		_testContributeWhenObjectDefinitionIsNotCMS();
+		_testContributeWithAttachmentWhenFileEntryIsForeignOwned();
+		_testContributeWithAttachmentWhenFileEntryIsSelfOwned();
+		_testContributeWithAttachmentWhenObjectEntryIsCopied();
+		_testContributeWithAttachmentWhenObjectFieldIsLocalized();
 		_testContributeWithRelationshipReference();
 		_testContributeWithRichTextReferences();
 		_testContributeWithoutReferences();
 	}
 
 	private ObjectDefinition _addCMSObjectDefinition() throws Exception {
+		return _addCMSObjectDefinition(
+			Collections.singletonList(_buildRichTextObjectField()));
+	}
+
+	private ObjectDefinition _addCMSObjectDefinition(
+			List<ObjectField> objectFields)
+		throws Exception {
+
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				false, false, false, ObjectDefinitionTestUtil.getRandomName(),
-				Collections.singletonList(_buildRichTextObjectField()),
+				objectFields,
 				_contentStructuresObjectFolder.getObjectFolderId(),
 				ObjectDefinitionConstants.SCOPE_DEPOT,
 				TestPropsValues.getUserId());
@@ -150,6 +174,18 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 		return objectDefinition;
 	}
 
+	private ObjectEntry _addFileObjectEntry(ObjectDefinition objectDefinition)
+		throws Exception {
+
+		FileEntry fileEntry = _addTempFileEntry(objectDefinition);
+
+		return _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_ATTACHMENT_OBJECT_FIELD_NAME, fileEntry.getFileEntryId()
+			).build());
+	}
+
 	private ObjectEntry _addObjectEntry(
 			ObjectDefinition objectDefinition, Map<String, Serializable> values)
 		throws Exception {
@@ -157,6 +193,65 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 		return ObjectEntryTestUtil.addObjectEntry(
 			_group.getGroupId(), objectDefinition,
 			_objectEntryFolder.getObjectEntryFolderId(), values);
+	}
+
+	private FileEntry _addTempFileEntry(ObjectDefinition objectDefinition)
+		throws Exception {
+
+		return TempFileEntryUtil.addTempFileEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getPortletId(),
+			TempFileEntryUtil.getTempFileName(
+				RandomTestUtil.randomString() + ".txt"),
+			FileUtil.createTempFile(
+				RandomTestUtil.randomString(
+				).getBytes()),
+			ContentTypes.TEXT_PLAIN);
+	}
+
+	private ObjectField _buildAttachmentObjectField(String fileSource)
+		throws Exception {
+
+		return new AttachmentObjectFieldBuilder(
+		).indexed(
+			true
+		).labelMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+		).name(
+			_ATTACHMENT_OBJECT_FIELD_NAME
+		).objectFieldSettings(
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS
+				).value(
+					"txt"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_FILE_SOURCE
+				).value(
+					fileSource
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+				).value(
+					"100"
+				).build())
+		).userId(
+			TestPropsValues.getUserId()
+		).build();
+	}
+
+	private ObjectField _buildLocalizedAttachmentObjectField(String fileSource)
+		throws Exception {
+
+		ObjectField objectField = _buildAttachmentObjectField(fileSource);
+
+		objectField.setLocalized(true);
+
+		return objectField;
 	}
 
 	private ObjectField _buildRichTextObjectField() throws Exception {
@@ -180,6 +275,11 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 			objectDefinition.getClassName());
 
 		return indexer.getDocument(objectEntry);
+	}
+
+	private long _getFileEntryId(ObjectEntry objectEntry) {
+		return MapUtil.getLong(
+			objectEntry.getValues(), _ATTACHMENT_OBJECT_FIELD_NAME);
 	}
 
 	private String _getImageHTML(String externalReferenceCode) {
@@ -226,6 +326,136 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 		Document document = _getDocument(objectDefinition, objectEntry);
 
 		Assert.assertNull(document.getField("outboundLinks"));
+	}
+
+	private void _testContributeWithAttachmentWhenFileEntryIsForeignOwned()
+		throws Exception {
+
+		ObjectDefinition fileObjectDefinition = _addCMSObjectDefinition(
+			Collections.singletonList(
+				_buildAttachmentObjectField(
+					ObjectFieldSettingConstants.
+						VALUE_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT)));
+
+		ObjectEntry fileObjectEntry = _addFileObjectEntry(fileObjectDefinition);
+
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition(
+			Collections.singletonList(
+				_buildAttachmentObjectField(
+					ObjectFieldSettingConstants.VALUE_CMS_BASIC_DOCUMENT)));
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_ATTACHMENT_OBJECT_FIELD_NAME, _getFileEntryId(fileObjectEntry)
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertArrayEquals(
+			new String[] {
+				"objectEntryId_" + fileObjectEntry.getObjectEntryId()
+			},
+			document.getValues("outboundLinks"));
+	}
+
+	private void _testContributeWithAttachmentWhenFileEntryIsSelfOwned()
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition(
+			Arrays.asList(
+				_buildAttachmentObjectField(
+					ObjectFieldSettingConstants.
+						VALUE_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT),
+				_buildRichTextObjectField()));
+
+		FileEntry fileEntry = _addTempFileEntry(objectDefinition);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_ATTACHMENT_OBJECT_FIELD_NAME, fileEntry.getFileEntryId()
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertNull(document.getField("outboundLinks"));
+	}
+
+	private void _testContributeWithAttachmentWhenObjectEntryIsCopied()
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition(
+			Arrays.asList(
+				_buildAttachmentObjectField(
+					ObjectFieldSettingConstants.
+						VALUE_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT),
+				_buildRichTextObjectField()));
+
+		FileEntry fileEntry = _addTempFileEntry(objectDefinition);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				_ATTACHMENT_OBJECT_FIELD_NAME, fileEntry.getFileEntryId()
+			).build());
+
+		ObjectEntry copiedObjectEntry =
+			_objectEntryLocalService.copyObjectEntry(
+				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				objectEntry.getObjectEntryFolderId(), objectEntry.getValues(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Document document = _getDocument(objectDefinition, copiedObjectEntry);
+
+		Assert.assertNull(document.getField("outboundLinks"));
+	}
+
+	private void _testContributeWithAttachmentWhenObjectFieldIsLocalized()
+		throws Exception {
+
+		ObjectDefinition fileObjectDefinition = _addCMSObjectDefinition(
+			Collections.singletonList(
+				_buildAttachmentObjectField(
+					ObjectFieldSettingConstants.
+						VALUE_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT)));
+
+		ObjectEntry fileObjectEntry1 = _addFileObjectEntry(
+			fileObjectDefinition);
+		ObjectEntry fileObjectEntry2 = _addFileObjectEntry(
+			fileObjectDefinition);
+
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition(
+			Collections.singletonList(
+				_buildLocalizedAttachmentObjectField(
+					ObjectFieldSettingConstants.VALUE_CMS_BASIC_DOCUMENT)));
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		ObjectField objectField = objectFieldBag.getObjectField(
+			_ATTACHMENT_OBJECT_FIELD_NAME);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectField.getI18nObjectFieldName(),
+				(Serializable)HashMapBuilder.<String, Object>put(
+					LocaleUtil.toLanguageId(LocaleUtil.BRAZIL),
+					_getFileEntryId(fileObjectEntry2)
+				).put(
+					LocaleUtil.toLanguageId(LocaleUtil.US),
+					_getFileEntryId(fileObjectEntry1)
+				).build()
+			).build());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertEquals(
+			SetUtil.fromArray(
+				"objectEntryId_" + fileObjectEntry1.getObjectEntryId(),
+				"objectEntryId_" + fileObjectEntry2.getObjectEntryId()),
+			SetUtil.fromArray(document.getValues("outboundLinks")));
 	}
 
 	private void _testContributeWithoutReferences() throws Exception {
@@ -305,6 +535,8 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 			document.getValues("outboundLinks"));
 	}
 
+	private static final String _ATTACHMENT_OBJECT_FIELD_NAME = "upload";
+
 	private static final String _RICH_TEXT_OBJECT_FIELD_NAME = "content";
 
 	private ObjectFolder _contentStructuresObjectFolder;
@@ -328,6 +560,9 @@ public class CMSContentOutboundLinksModelDocumentContributorTest {
 
 	@Inject
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Inject
 	private ObjectFolderLocalService _objectFolderLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -94,7 +94,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 							ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
 
 					for (String content :
-							_getContents(indexedValues, objectField)) {
+							_getValues(indexedValues, objectField)) {
 
 						for (String externalReferenceCode :
 								OutboundLinksUtil.
@@ -125,7 +125,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 		}
 	}
 
-	private List<String> _getContents(
+	private List<String> _getValues(
 		Map<String, Serializable> indexedValues, ObjectField objectField) {
 
 		if (objectField.isLocalized()) {
@@ -147,13 +147,13 @@ public class CMSContentOutboundLinksModelDocumentContributor
 			}
 		}
 
-		Object content = indexedValues.get(objectField.getName());
+		Object indexedValue = indexedValues.get(objectField.getName());
 
-		if (content == null) {
+		if (indexedValue == null) {
 			return Collections.emptyList();
 		}
 
-		return Collections.singletonList(String.valueOf(content));
+		return Collections.singletonList(String.valueOf(indexedValue));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -5,11 +5,14 @@
 
 package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor;
 
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -31,6 +34,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -108,6 +112,24 @@ public class CMSContentOutboundLinksModelDocumentContributor
 						}
 					}
 				}
+				else if (Objects.equals(
+							businessType,
+							ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+					for (String value :
+							_getValues(indexedValues, objectField)) {
+
+						long referencedObjectEntryId =
+							_getReferencedObjectEntryId(
+								GetterUtil.getLong(value), objectEntry);
+
+						if (referencedObjectEntryId != 0) {
+							outboundLinks.add(
+								CMSOutboundLinksUtil.getObjectEntryIdToken(
+									referencedObjectEntryId));
+						}
+					}
+				}
 			}
 
 			if (!outboundLinks.isEmpty()) {
@@ -123,6 +145,37 @@ public class CMSContentOutboundLinksModelDocumentContributor
 					exception);
 			}
 		}
+	}
+
+	private long _getReferencedObjectEntryId(
+		long fileEntryId, ObjectEntry objectEntry) {
+
+		if (fileEntryId == 0) {
+			return 0;
+		}
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
+			fileEntryId);
+
+		if (dlFileEntry == null) {
+			return 0;
+		}
+
+		long classPK = dlFileEntry.getClassPK();
+
+		if ((classPK == 0) || (classPK == objectEntry.getObjectEntryId())) {
+			return 0;
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+				objectEntry.getCompanyId(), dlFileEntry.getClassName());
+
+		if (objectDefinition == null) {
+			return 0;
+		}
+
+		return classPK;
 	}
 
 	private List<String> _getValues(
@@ -158,5 +211,11 @@ public class CMSContentOutboundLinksModelDocumentContributor
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CMSContentOutboundLinksModelDocumentContributor.class);
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentOutboundLinksModelDocumentContributor.java
@@ -8,6 +8,8 @@ package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.co
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
@@ -114,7 +116,8 @@ public class CMSContentOutboundLinksModelDocumentContributor
 				}
 				else if (Objects.equals(
 							businessType,
-							ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+							ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) &&
+						 _isReferenceFileSource(objectField)) {
 
 					for (String value :
 							_getValues(indexedValues, objectField)) {
@@ -123,7 +126,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 							_getReferencedObjectEntryId(
 								GetterUtil.getLong(value), objectEntry);
 
-						if (referencedObjectEntryId != 0) {
+						if (referencedObjectEntryId > 0) {
 							outboundLinks.add(
 								CMSOutboundLinksUtil.getObjectEntryIdToken(
 									referencedObjectEntryId));
@@ -150,7 +153,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 	private long _getReferencedObjectEntryId(
 		long fileEntryId, ObjectEntry objectEntry) {
 
-		if (fileEntryId == 0) {
+		if (fileEntryId <= 0) {
 			return 0;
 		}
 
@@ -163,7 +166,7 @@ public class CMSContentOutboundLinksModelDocumentContributor
 
 		long classPK = dlFileEntry.getClassPK();
 
-		if ((classPK == 0) || (classPK == objectEntry.getObjectEntryId())) {
+		if ((classPK <= 0) || (classPK == objectEntry.getObjectEntryId())) {
 			return 0;
 		}
 
@@ -207,6 +210,22 @@ public class CMSContentOutboundLinksModelDocumentContributor
 		}
 
 		return Collections.singletonList(String.valueOf(indexedValue));
+	}
+
+	private boolean _isReferenceFileSource(ObjectField objectField) {
+		String fileSource = ObjectFieldSettingUtil.getValue(
+			ObjectFieldSettingConstants.NAME_FILE_SOURCE, objectField);
+
+		if (Objects.equals(
+				fileSource,
+				ObjectFieldSettingConstants.VALUE_CMS_BASIC_DOCUMENT) ||
+			Objects.equals(
+				fileSource, ObjectFieldSettingConstants.VALUE_DOCS_AND_MEDIA)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {createReadStream} from 'fs';
+
 import {getRandomInt} from '../utils/getRandomInt';
 import {ApiHelpers, DataApiHelpers} from './ApiHelpers';
 
@@ -656,6 +658,20 @@ export class HeadlessAdminUserApiHelper {
 		}
 
 		return userAccount;
+	}
+
+	async postUserAccountImage(userAccountId: string, filePath: string) {
+
+		// The default headers send a JSON content type, which the multipart
+		// request must not carry, so only the CSRF token is passed through.
+
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/user-accounts/${userAccountId}/image`,
+			{
+				headers: await this.apiHelpers.getCSRFTokenHeader(),
+				multipart: {image: createReadStream(filePath)},
+			}
+		);
 	}
 
 	async postUserGroup(userGroup?: TUserGroup): Promise<TUserGroup> {

--- a/modules/test/playwright/tests/layout-content-page-editor-web/form-container/assigneeInputFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/form-container/assigneeInputFragment.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import {expect, mergeTests} from '@playwright/test';
+import path from 'path';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {displayPageTemplatesPagesTest} from '../../../fixtures/displayPageTemplatesPagesTest';
@@ -34,7 +35,7 @@ const test = mergeTests(
 
 test(
 	'Can search for a user, select it, and submit the form',
-	{tag: '@LPD-102916'},
+	{tag: ['@LPD-102916', '@LPD-103446']},
 	async ({apiHelpers, page, site}) => {
 
 		// Create a user and a role sharing the same search term
@@ -42,16 +43,32 @@ test(
 		const searchTerm = `Assignee${getRandomInt()}`;
 
 		const userAccount = await apiHelpers.headlessAdminUser.postUserAccount({
-			alternateName: searchTerm.toLowerCase(),
-			emailAddress: `${searchTerm.toLowerCase()}@liferay.com`,
-			familyName: 'User',
+			alternateName: `portrait${searchTerm.toLowerCase()}`,
+			emailAddress: `portrait${searchTerm.toLowerCase()}@liferay.com`,
+			familyName: 'Portrait',
 			givenName: searchTerm,
 			password: 'test',
 		});
 
+		const plainUserAccount =
+			await apiHelpers.headlessAdminUser.postUserAccount({
+				alternateName: `plain${searchTerm.toLowerCase()}`,
+				emailAddress: `plain${searchTerm.toLowerCase()}@liferay.com`,
+				familyName: 'Plain',
+				givenName: searchTerm,
+				password: 'test',
+			});
+
 		const role = await apiHelpers.headlessAdminUser.postRole({
 			name: `${searchTerm} Role`,
 		});
+
+		// Give only the first user a profile picture
+
+		await apiHelpers.headlessAdminUser.postUserAccountImage(
+			userAccount.id,
+			path.join(__dirname, '../main/dependencies/file_upload_image_1.jpg')
+		);
 
 		// Create an object with an assignee field
 
@@ -111,11 +128,32 @@ test(
 		await expect(async () => {
 			await assigneeInput.fill(searchTerm, {timeout: 1000});
 
-			await expect(option).toHaveCount(2, {timeout: 5000});
+			await expect(option).toHaveCount(3, {timeout: 5000});
 		}).toPass();
 
 		await expect(option.filter({hasText: userAccount.name})).toBeVisible();
+		await expect(
+			option.filter({hasText: plainUserAccount.name})
+		).toBeVisible();
 		await expect(option.filter({hasText: role.name})).toBeVisible();
+
+		// Check the avatar of each assignee
+
+		await expect(
+			option
+				.filter({hasText: userAccount.name})
+				.locator('img.sticker-img')
+		).toBeVisible();
+
+		await expect(
+			option
+				.filter({hasText: plainUserAccount.name})
+				.locator('svg.lexicon-icon-user')
+		).toBeVisible();
+
+		await expect(
+			option.filter({hasText: role.name}).locator('.sticker')
+		).toHaveText('AR');
 
 		// Select the user and submit the form
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103458

## What Is Being Fixed

A content that references a document through an Upload field never appeared in the broken links report. The outbound links contributor harvested relationship and rich text fields only, so when the referenced document expired the referencing content was not flagged and the Broken Links count under-reported.

## How It Is Being Fixed

Attachment fields are now harvested alongside relationship and rich text fields.

The discriminator is the field's `fileSource` setting rather than the ownership of the file. An Upload field that uploads from the user's computer copies the file and stamps the new content as its owner, so there is no reference to another asset and nothing to harvest. The two reference sources, `CMSBasicDocument` and `docsAndMedia`, instead point at a file entry owned by a different object entry, and that entry is the outbound link. Consulting `fileSource` before ownership also settles the duplicate case, where a copied content shares the original's file entry and an ownership comparison on its own would report a link that is not there.

The referenced object entry is resolved from the file entry's `classNameId` and `classPK`, which record the object entry that owns the attachment. Three guards stop a stamp we cannot use from producing a bogus token: an unset owner, an owner that is the contributing entry itself, and a class name that does not resolve to an object definition, which is what a file owned by some other model looks like.

Reading the value is shared with the rich text branch through one helper, so a localized attachment field contributes every locale's referent rather than only the default one. Attachment fields on CMS content structures are localized by default, so that is the common case rather than an edge one.

## Review Notes

Two contracts this leans on are owned outside CMS and are worth a confirming glance:

- `DLFileEntry.classNameId` and `classPK` record the object entry that owns an attachment.
- `CMSBasicDocument` and `docsAndMedia` are the file sources that reference rather than copy, so they are the two that can carry an outbound link.

## Test Execution

```bash
cd modules/apps/site/site-cms-site-initializer-test
gradlew testIntegration --tests CMSContentOutboundLinksModelDocumentContributorTest
```

Four scenarios cover a foreign owned file entry, a self owned one, a duplicated content, and a localized field carrying a different referent per locale.

## PR Check

**pr-check: PASS** — tested on `53c4f382643be7dd17805013a76889425549e823`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "53c4f382643be7dd17805013a76889425549e823"} -->
