### PR TITLE
LPD-103529 Functional tests for category display page URLs

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
@@ -9,7 +9,7 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
@@ -19,19 +19,14 @@ import com.liferay.layout.display.page.BaseLayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.petra.string.CharPool;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-
-import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -163,8 +158,28 @@ public class AssetCategoryLayoutDisplayPageProvider
 			_friendlyURLEntryLocalService, _portal);
 	}
 
-	private AssetCategory _fetchAssetCategory(
-		long groupId, Locale locale, String urlTitle) {
+	private AssetCategory _fetchAssetCategory(long groupId, String urlTitle) {
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		if ((group != null) && !Validator.isNumber(urlTitle)) {
+			return _fetchAssetCategoryByURLTitle(groupId, urlTitle);
+		}
+
+		AssetCategory assetCategory =
+			_assetCategoryLocalService.fetchAssetCategory(
+				GetterUtil.getLong(urlTitle));
+
+		if ((assetCategory == null) ||
+			(assetCategory.getGroupId() != groupId)) {
+
+			return null;
+		}
+
+		return assetCategory;
+	}
+
+	private AssetCategory _fetchAssetCategoryByURLTitle(
+		long groupId, String urlTitle) {
 
 		if (Validator.isNull(urlTitle)) {
 			return null;
@@ -183,48 +198,25 @@ public class AssetCategoryLayoutDisplayPageProvider
 			return null;
 		}
 
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization = null;
-
+		long classPK = 0;
 		long parentClassPK = assetVocabulary.getVocabularyId();
 
 		for (int i = 1; i < parts.length; i++) {
-			friendlyURLEntryLocalization = _fetchFriendlyURLEntryLocalization(
-				groupId, parentClassPK, locale, parts[i]);
+			classPK = _getClassPK(groupId, parentClassPK, parts[i]);
 
-			if (friendlyURLEntryLocalization == null) {
-				break;
+			if (classPK == 0) {
+				return null;
 			}
 
-			parentClassPK = friendlyURLEntryLocalization.getClassPK();
+			parentClassPK = classPK;
 		}
 
-		if (friendlyURLEntryLocalization == null) {
+		if (classPK == 0) {
 			return null;
 		}
 
 		AssetCategory assetCategory =
-			_assetCategoryLocalService.fetchAssetCategory(
-				friendlyURLEntryLocalization.getClassPK());
-
-		if ((assetCategory == null) ||
-			(assetCategory.getGroupId() != groupId)) {
-
-			return null;
-		}
-
-		return assetCategory;
-	}
-
-	private AssetCategory _fetchAssetCategory(long groupId, String urlTitle) {
-		Group group = _groupLocalService.fetchGroup(groupId);
-
-		if ((group != null) && !Validator.isNumber(urlTitle)) {
-			return _fetchAssetCategory(groupId, _getLocale(), urlTitle);
-		}
-
-		AssetCategory assetCategory =
-			_assetCategoryLocalService.fetchAssetCategory(
-				GetterUtil.getLong(urlTitle));
+			_assetCategoryLocalService.fetchAssetCategory(classPK);
 
 		if ((assetCategory == null) ||
 			(assetCategory.getGroupId() != groupId)) {
@@ -253,37 +245,33 @@ public class AssetCategoryLayoutDisplayPageProvider
 			groupId, decodedName);
 	}
 
-	private FriendlyURLEntryLocalization _fetchFriendlyURLEntryLocalization(
-		long groupId, long parentClassPK, Locale locale, String urlTitle) {
+	private long _getClassPK(
+		long groupId, long parentClassPK, String urlTitle) {
 
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
-				groupId, _portal.getClassNameId(AssetCategory.class),
-				parentClassPK, _language.getLanguageId(locale), urlTitle);
+		long classNameId = _portal.getClassNameId(AssetCategory.class);
 
-		if (friendlyURLEntryLocalization != null) {
-			return friendlyURLEntryLocalization;
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+				groupId, classNameId, parentClassPK, urlTitle);
+
+		if (friendlyURLEntry != null) {
+			return friendlyURLEntry.getClassPK();
 		}
 
 		String decodedURLTitle = HttpComponentsUtil.decodePath(urlTitle);
 
 		if (urlTitle.equals(decodedURLTitle)) {
-			return null;
+			return 0;
 		}
 
-		return _friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
-			groupId, _portal.getClassNameId(AssetCategory.class), parentClassPK,
-			_language.getLanguageId(locale), decodedURLTitle);
-	}
+		friendlyURLEntry = _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+			groupId, classNameId, parentClassPK, decodedURLTitle);
 
-	private Locale _getLocale() {
-		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
-
-		if (themeDisplayLocale != null) {
-			return themeDisplayLocale;
+		if (friendlyURLEntry != null) {
+			return friendlyURLEntry.getClassPK();
 		}
 
-		return LocaleUtil.getSiteDefault();
+		return 0;
 	}
 
 	@Reference
@@ -297,9 +285,6 @@ public class AssetCategoryLayoutDisplayPageProvider
 
 	@Reference
 	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
@@ -30,12 +30,14 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.HashMap;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,6 +65,7 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 	@Test
 	public void testGetLayoutDisplayPageObjectProvider() throws Exception {
 		_testGetLayoutDisplayPageObjectProviderERCInfoItemIdentifier();
+		_testGetLayoutDisplayPageObjectProviderLocalizedAssetCategory();
 		_testGetLayoutDisplayPageObjectProviderNestedAssetCategory();
 	}
 
@@ -159,6 +162,54 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 						assetCategory.getExternalReferenceCode())));
 
 		Assert.assertNull(layoutDisplayPageObjectProvider);
+	}
+
+	private void _testGetLayoutDisplayPageObjectProviderLocalizedAssetCategory()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = _addAssetVocabulary();
+
+		String spanishURLTitle = StringUtil.toLowerCase(
+			StringUtil.randomString());
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				StringUtil.toLowerCase(StringUtil.randomString())
+			).put(
+				LocaleUtil.SPAIN, spanishURLTitle
+			).build(),
+			new HashMap<>(), assetVocabulary.getVocabularyId(), false, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String friendlyURL = StringBundler.concat(
+			assetVocabulary.getName(), StringPool.SLASH, spanishURLTitle);
+
+		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		try {
+			LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.SPAIN);
+
+			LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+				_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+					_group.getGroupId(), friendlyURL);
+
+			Assert.assertEquals(
+				assetCategory,
+				layoutDisplayPageObjectProvider.getDisplayObject());
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(themeDisplayLocale);
+		}
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				_group.getGroupId(), friendlyURL);
+
+		Assert.assertEquals(
+			assetCategory, layoutDisplayPageObjectProvider.getDisplayObject());
 	}
 
 	private void _testGetLayoutDisplayPageObjectProviderNestedAssetCategory()

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -18,7 +18,7 @@ interface postSiteTaxonomyVocabularyProps {
 
 export interface postTaxonomyCategoryTaxonomyCategory {
 	name: string;
-	name_i18n?: {['ES-es']: string};
+	name_i18n?: {[key: string]: string};
 	parentTaxonomyCategoryId: number;
 }
 
@@ -26,13 +26,13 @@ export interface postTaxonomyVocabularyProps {
 	assetLibraries?: AssetLibrary[];
 	assetTypes?: AssetType[];
 	name: string;
-	name_i18n?: {['ES-es']: string};
+	name_i18n?: {[key: string]: string};
 	visibilityType?: string;
 }
 
 export interface postTaxonomyVocabularyTaxonomyCategoryProps {
 	name: string;
-	name_i18n?: {['ES-es']: string};
+	name_i18n?: {[key: string]: string};
 	system?: boolean;
 	vocabularyId: number;
 }
@@ -44,8 +44,9 @@ export type TTaxonomyVocabulary = {
 };
 
 interface patchTaxonomyCategoryProps {
+	friendlyUrlPath?: string;
 	id: number;
-	name: string;
+	name?: string;
 }
 
 interface postAssetLibraryKeywordProps {
@@ -214,12 +215,13 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 */
 
 	async patchTaxonomyCategory({
+		friendlyUrlPath,
 		id,
 		name,
 	}: patchTaxonomyCategoryProps): Promise<{id: number}> {
 		return this.apiHelpers.patch(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-categories/${id}`,
-			{name}
+			{friendlyUrlPath, name}
 		);
 	}
 

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -5,22 +5,91 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
+import {ApiHelpers} from '../../helpers/ApiHelpers';
 import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../utils/getRandomString';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
+import {PageEditorPage} from '../layout-content-page-editor-web/PageEditorPage';
 
 export class DisplayPageTemplatesPage {
 	readonly page: Page;
 
+	readonly apiHelpers: ApiHelpers;
 	readonly newButton: Locator;
 	readonly publishButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
+		this.apiHelpers = new ApiHelpers(page);
 		this.newButton = page.getByText('New', {exact: true});
 		this.publishButton = page.getByLabel('Publish', {exact: true});
+	}
+
+	/**
+	 * Creates the default display page template of an item type and maps a
+	 * Heading fragment to one of its fields, so an item of that type renders
+	 * its own value at its friendly URL.
+	 *
+	 * The template is created and marked as default through the API. Only the
+	 * fragment mapping goes through the page editor, because no API exposes it.
+	 */
+	async createDefaultTemplate({
+		className,
+		mappedField = 'Title',
+		pageEditorPage,
+		site,
+	}: {
+		className: string;
+		mappedField?: string;
+		pageEditorPage: PageEditorPage;
+		site: Site;
+	}) {
+		const name = `DPT ${getRandomString()}`;
+
+		const {classNameId} =
+			await this.apiHelpers.jsonWebServicesClassName.fetchClassName(
+				className
+			);
+
+		const {layoutPageTemplateEntryId} =
+			await this.apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addDisplayPageLayoutPageTemplateEntry(
+				{
+					classNameId,
+					groupId: String(site.id),
+					name,
+				}
+			);
+
+		await this.apiHelpers.jsonWebServicesLayoutPageTemplateEntry.markAsDefaultDisplayPageLayoutPageTemplateEntry(
+			{layoutPageTemplateEntryId}
+		);
+
+		await this.goto(site.friendlyUrlPath);
+
+		await this.editTemplate(name);
+
+		await pageEditorPage.addFragment(
+			'Basic Components',
+			'Heading',
+			this.page.getByText('Drag and drop fragments or widgets here')
+		);
+
+		const headingId = await pageEditorPage.getFragmentId('Heading');
+
+		await pageEditorPage.selectEditable(headingId, 'element-text');
+
+		await pageEditorPage.changeConfiguration({
+			fieldLabel: 'Field',
+			tab: 'Mapping',
+			value: mappedField,
+		});
+
+		await pageEditorPage.publishPage();
+
+		return name;
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {

--- a/modules/test/playwright/tests/asset-categories-admin-web/main/categoryDisplayPage.spec.ts
+++ b/modules/test/playwright/tests/asset-categories-admin-web/main/categoryDisplayPage.spec.ts
@@ -1,0 +1,446 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {displayPageTemplatesPagesTest} from '../../../fixtures/displayPageTemplatesPagesTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import getRandomString from '../../../utils/getRandomString';
+
+const _ASSET_CATEGORY_CLASS_NAME =
+	'com.liferay.asset.kernel.model.AssetCategory';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	displayPageTemplatesPagesTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+test(
+	'A category display page resolves at its name-based URL',
+	{tag: '@LPD-103529'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const taxonomy = await _createTaxonomy(apiHelpers, site);
+
+		await displayPageTemplatesPage.createDefaultTemplate({
+			className: _ASSET_CATEGORY_CLASS_NAME,
+			mappedField: 'Name',
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('The vocabulary and the category name the URL', async () => {
+			await _expectCategoryAt(
+				page,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}/${taxonomy.categoryName}`,
+				taxonomy.categoryName
+			);
+		});
+
+		await test.step('A nested category appends its own segment', async () => {
+			await _expectCategoryAt(
+				page,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}/` +
+					`${taxonomy.categoryName}/${taxonomy.childCategoryName}`,
+				taxonomy.childCategoryName
+			);
+		});
+
+		await test.step('An unknown category name does not resolve', async () => {
+			const response = await page.goto(
+				`/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}/` +
+					getRandomString()
+			);
+
+			expect(response?.status()).toBe(404);
+		});
+	}
+);
+
+test(
+	'A legacy ID-based category URL redirects to the name-based URL',
+	{tag: '@LPD-103529'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const taxonomy = await _createTaxonomy(apiHelpers, site);
+
+		await displayPageTemplatesPage.createDefaultTemplate({
+			className: _ASSET_CATEGORY_CLASS_NAME,
+			mappedField: 'Name',
+			pageEditorPage,
+			site,
+		});
+
+		await test.step('A root category redirects to its name-based URL', async () => {
+			await _expectRedirect(
+				page,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.categoryId}`,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}/` +
+					taxonomy.categoryName,
+				taxonomy.categoryName
+			);
+		});
+
+		await test.step('A nested category redirects to its full path', async () => {
+			await _expectRedirect(
+				page,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.childCategoryId}`,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}/` +
+					`${taxonomy.categoryName}/${taxonomy.childCategoryName}`,
+				taxonomy.childCategoryName
+			);
+		});
+	}
+);
+
+test(
+	'A vocabulary holding spaces and accents resolves its categories',
+	{tag: '@LPD-103529'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const categoryName = `categoría ${getRandomString()}`.toLowerCase();
+		const vocabularyName =
+			`vocabulario ñ ${getRandomString()}`.toLowerCase();
+
+		await test.step('Create the taxonomy and grant Guest VIEW', async () => {
+			const vocabulary =
+				await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary(
+					{
+						name: vocabularyName,
+						siteId: String(site.id),
+					}
+				);
+
+			const category =
+				await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+					{
+						name: categoryName,
+						vocabularyId: vocabulary.id,
+					}
+				);
+
+			await apiHelpers.headlessAdminTaxonomy.putTaxonomyVocabulariesTaxonomyVocabularyPermissions(
+				vocabulary.id,
+				{actionIds: ['VIEW'], roleName: 'Guest'}
+			);
+
+			await apiHelpers.headlessAdminTaxonomy.putTaxonomyCategoriesTaxonomyCategoryPermissions(
+				category.id,
+				{actionIds: ['VIEW'], roleName: 'Guest'}
+			);
+		});
+
+		await displayPageTemplatesPage.createDefaultTemplate({
+			className: _ASSET_CATEGORY_CLASS_NAME,
+			mappedField: 'Name',
+			pageEditorPage,
+			site,
+		});
+
+		await _expectCategoryAt(
+			page,
+			`/web${site.friendlyUrlPath}/v/${encodeURIComponent(
+				vocabularyName
+			)}/${encodeURIComponent(categoryName)}`,
+			categoryName
+		);
+	}
+);
+
+test(
+	'A category whose name-based URL exceeds the maximum length resolves by ID',
+	{tag: '@LPD-103529'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// A friendly URL holds up to 255 characters, so only a deep chain of
+		// categories takes the composed URL over its maximum length
+
+		const namePadding = 'x'.repeat(240);
+		const vocabularyName = `vocabulary-${getRandomString()}`.toLowerCase();
+
+		let categoryId: number;
+
+		await test.step('Create a chain deep enough to exceed the length', async () => {
+			const vocabulary =
+				await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary(
+					{
+						name: vocabularyName,
+						siteId: String(site.id),
+					}
+				);
+
+			await apiHelpers.headlessAdminTaxonomy.putTaxonomyVocabulariesTaxonomyVocabularyPermissions(
+				vocabulary.id,
+				{actionIds: ['VIEW'], roleName: 'Guest'}
+			);
+
+			const category =
+				await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+					{
+						name: `1-${namePadding}`,
+						vocabularyId: vocabulary.id,
+					}
+				);
+
+			categoryId = category.id;
+
+			for (let i = 2; i <= 9; i++) {
+				const childCategory =
+					await apiHelpers.headlessAdminTaxonomy.postTaxonomyCategoryTaxonomyCategory(
+						{
+							name: `${i}-${namePadding}`,
+							parentTaxonomyCategoryId: categoryId,
+						}
+					);
+
+				categoryId = childCategory.id;
+			}
+
+			await apiHelpers.headlessAdminTaxonomy.putTaxonomyCategoriesTaxonomyCategoryPermissions(
+				categoryId,
+				{actionIds: ['VIEW'], roleName: 'Guest'}
+			);
+		});
+
+		await displayPageTemplatesPage.createDefaultTemplate({
+			className: _ASSET_CATEGORY_CLASS_NAME,
+			mappedField: 'Name',
+			pageEditorPage,
+			site,
+		});
+
+		// The ID keeps serving the page instead of redirecting, because the
+		// name-based URL it would redirect to does not fit
+
+		await _expectCategoryAt(
+			page,
+			`/web${site.friendlyUrlPath}/v/${categoryId}`,
+			`9-${namePadding}`
+		);
+
+		await expect(page).toHaveURL(new RegExp(`/v/${categoryId}$`), {
+			timeout: 2000,
+		});
+	}
+);
+
+test(
+	'Editing the slug of a category moves its display page URL',
+	{tag: '@LPD-103529'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const slug = `slug-${getRandomString()}`.toLowerCase();
+
+		const taxonomy = await _createTaxonomy(apiHelpers, site);
+
+		await displayPageTemplatesPage.createDefaultTemplate({
+			className: _ASSET_CATEGORY_CLASS_NAME,
+			mappedField: 'Name',
+			pageEditorPage,
+			site,
+		});
+
+		await apiHelpers.headlessAdminTaxonomy.patchTaxonomyCategory({
+			friendlyUrlPath: slug,
+			id: taxonomy.categoryId,
+		});
+
+		await test.step('The category answers at the edited slug', async () => {
+			await _expectCategoryAt(
+				page,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}/${slug}`,
+				taxonomy.categoryName
+			);
+		});
+
+		await test.step('A nested category follows its parent slug', async () => {
+			await _expectCategoryAt(
+				page,
+				`/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}/` +
+					`${slug}/${taxonomy.childCategoryName}`,
+				taxonomy.childCategoryName
+			);
+		});
+	}
+);
+
+/**
+ * Creates a vocabulary holding a category and a nested one. Categories created
+ * through the API are born with Owner permissions only, so the display page
+ * 404s until Guest is granted VIEW on the vocabulary and on both categories.
+ */
+test(
+	'A category display page resolves behind a locale prefix',
+	{tag: '@LPD-103529'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const spanishCategoryName = `patata-${getRandomString()}`.toLowerCase();
+
+		const taxonomy = await _createTaxonomy(apiHelpers, site, {
+			'es-ES': spanishCategoryName,
+		});
+
+		await displayPageTemplatesPage.createDefaultTemplate({
+			className: _ASSET_CATEGORY_CLASS_NAME,
+			mappedField: 'Name',
+			pageEditorPage,
+			site,
+		});
+
+		const base = `/web${site.friendlyUrlPath}/v/${taxonomy.vocabularyName}`;
+
+		await test.step('The Spanish name resolves under the locale prefix', async () => {
+			await _expectCategoryAt(
+				page,
+				`/es${base}/${spanishCategoryName}`,
+				spanishCategoryName
+			);
+		});
+
+		await test.step('The Spanish name resolves without the locale prefix', async () => {
+			await _expectCategoryAt(
+				page,
+				`${base}/${spanishCategoryName}`,
+				spanishCategoryName
+			);
+		});
+
+		await test.step('The default name keeps resolving under the locale prefix', async () => {
+			await _expectCategoryAt(
+				page,
+				`/es${base}/${taxonomy.categoryName}`,
+				spanishCategoryName
+			);
+		});
+
+		await test.step('The ID keeps resolving under the locale prefix', async () => {
+			await _expectCategoryAt(
+				page,
+				`/es/web${site.friendlyUrlPath}/v/${taxonomy.categoryId}`,
+				spanishCategoryName
+			);
+		});
+	}
+);
+
+async function _createTaxonomy(
+	apiHelpers: DataApiHelpers,
+	site: Site,
+	categoryNameI18n?: {[key: string]: string}
+) {
+	const categoryName = `category-${getRandomString()}`.toLowerCase();
+	const childCategoryName = `child-${getRandomString()}`.toLowerCase();
+	const vocabularyName = `vocabulary-${getRandomString()}`.toLowerCase();
+
+	const vocabulary =
+		await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
+			name: vocabularyName,
+			siteId: String(site.id),
+		});
+
+	const category =
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{
+				name: categoryName,
+				name_i18n: categoryNameI18n,
+				vocabularyId: vocabulary.id,
+			}
+		);
+
+	const childCategory =
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyCategoryTaxonomyCategory(
+			{
+				name: childCategoryName,
+				parentTaxonomyCategoryId: category.id,
+			}
+		);
+
+	await apiHelpers.headlessAdminTaxonomy.putTaxonomyVocabulariesTaxonomyVocabularyPermissions(
+		vocabulary.id,
+		{actionIds: ['VIEW'], roleName: 'Guest'}
+	);
+
+	for (const id of [category.id, childCategory.id]) {
+		await apiHelpers.headlessAdminTaxonomy.putTaxonomyCategoriesTaxonomyCategoryPermissions(
+			id,
+			{actionIds: ['VIEW'], roleName: 'Guest'}
+		);
+	}
+
+	return {
+		categoryId: category.id,
+		categoryName,
+		childCategoryId: childCategory.id,
+		childCategoryName,
+		vocabularyName,
+	};
+}
+
+async function _expectCategoryAt(page: Page, url: string, name: string) {
+	await expect(async () => {
+		await page.goto(url);
+
+		await expect(
+			page.locator('#main-content').getByText(name, {exact: true})
+		).toBeVisible({timeout: 2000});
+	}).toPass({timeout: 10000});
+}
+
+async function _expectRedirect(
+	page: Page,
+	url: string,
+	expectedURL: string,
+	name: string
+) {
+	await expect(async () => {
+		await page.goto(url);
+
+		await expect(page).toHaveURL(new RegExp(`${expectedURL}$`), {
+			timeout: 2000,
+		});
+
+		await expect(
+			page.locator('#main-content').getByText(name, {exact: true})
+		).toBeVisible({timeout: 2000});
+	}).toPass({timeout: 10000});
+}


### PR DESCRIPTION
> Depends on #8853 (LPD-103538). This stacks on it and shows its two commits until it merges. Five of the six tests here pass without that fix; the sixth needs it.

https://liferay.atlassian.net/browse/LPD-103529

Functional tests for the category display page URLs of epic LPD-70396 (name-based category friendly URLs).

### Why only these

Most of the epic is already covered, and at a better level. `AssetCategoryLayoutDisplayPageProviderTest.testGetURLTitle` covers how these URLs are composed, including the percent-encoding and the fallback to the ID when the URL does not fit. The categories admin specs cover the slug field and its live previews (`@LPD-99566`) and the ID shown when the URL is too long (`@LPD-102334`). `AssetCategoryFriendlyURLUpgradeProcessTest` covers the upgrade re-parenting.

What nobody had done was **navigate the URLs**. The integration test calls the provider directly, so it cannot show that a request to that URL answers. That is the gap these tests fill, and it is why they are browser tests rather than more integration coverage.

### What is covered

- A category resolves at `/v/{vocabulary}/{category}`, a nested one appends its own segment, and an unknown name returns 404.
- A legacy ID-based URL redirects to the name-based one, for a root and for a nested category. The assertion is on the resulting URL, which is what distinguishes redirecting from resolving the ID directly.
- A vocabulary holding a space and an accent resolves, which was the bug reported as LPD-100993.
- A chain too long for 255 characters keeps serving the page under its ID instead of redirecting, and the URL is asserted to stay on the ID.
- An edited slug moves the URL of the category and of everything nested under it.
- A localized name resolves with and without the site locale prefix, which is use case 2 of the epic and the one test here that needs #8853.

### Notes for the reviewer

The first commit is separate on purpose. Creating a display page template and marking it as default already has an API, and only the fragment mapping needs the page editor, so `DisplayPageTemplatesPage` gains a `createDefaultTemplate` method that does it the way `object-web/entry/objectEntry.spec.ts` already does. About nineteen specs currently inline that same API call; this does not refactor them, but the method is there for whoever wants to.

Every test runs on an isolated site, so the vocabulary, the categories and the template are removed with it. Categories created through the API are born with Owner permissions only, so Guest VIEW is granted on the vocabulary and on every category — without it the display page returns 404 with nothing in the log.

The `AssetCategory` mappable field is `Name`, not `Title`. Mapping `Title` does not error, it hangs the page editor until the test times out.

**Use case 2 needed a product fix first.** A localized slug did not resolve at all, with or without the site locale prefix, and neither did the ID-based URL once a locale prefix was present. That is LPD-103538, fixed in #8853, which this pull request sits on top of. Patching `name_i18n` on a category does not regenerate its localized friendly URL, so the localized name is passed at creation.

### Test evidence

`5 passed`, and `10 passed` with `--repeat-each=2`. `friendlyURLDPT.spec.ts` re-run as a control after touching the shared page object. `structuredContentDPT.spec.ts` fails on this bundle both with and without these changes, so it is unrelated.
