### PR TITLE
LPD-103538 Category display page URLs 404 when a locale prefix is present

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
@@ -9,7 +9,7 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
@@ -19,19 +19,14 @@ import com.liferay.layout.display.page.BaseLayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.petra.string.CharPool;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-
-import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -163,8 +158,28 @@ public class AssetCategoryLayoutDisplayPageProvider
 			_friendlyURLEntryLocalService, _portal);
 	}
 
-	private AssetCategory _fetchAssetCategory(
-		long groupId, Locale locale, String urlTitle) {
+	private AssetCategory _fetchAssetCategory(long groupId, String urlTitle) {
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		if ((group != null) && !Validator.isNumber(urlTitle)) {
+			return _fetchAssetCategoryByURLTitle(groupId, urlTitle);
+		}
+
+		AssetCategory assetCategory =
+			_assetCategoryLocalService.fetchAssetCategory(
+				GetterUtil.getLong(urlTitle));
+
+		if ((assetCategory == null) ||
+			(assetCategory.getGroupId() != groupId)) {
+
+			return null;
+		}
+
+		return assetCategory;
+	}
+
+	private AssetCategory _fetchAssetCategoryByURLTitle(
+		long groupId, String urlTitle) {
 
 		if (Validator.isNull(urlTitle)) {
 			return null;
@@ -183,48 +198,25 @@ public class AssetCategoryLayoutDisplayPageProvider
 			return null;
 		}
 
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization = null;
-
+		long classPK = 0;
 		long parentClassPK = assetVocabulary.getVocabularyId();
 
 		for (int i = 1; i < parts.length; i++) {
-			friendlyURLEntryLocalization = _fetchFriendlyURLEntryLocalization(
-				groupId, parentClassPK, locale, parts[i]);
+			classPK = _getClassPK(groupId, parentClassPK, parts[i]);
 
-			if (friendlyURLEntryLocalization == null) {
-				break;
+			if (classPK == 0) {
+				return null;
 			}
 
-			parentClassPK = friendlyURLEntryLocalization.getClassPK();
+			parentClassPK = classPK;
 		}
 
-		if (friendlyURLEntryLocalization == null) {
+		if (classPK == 0) {
 			return null;
 		}
 
 		AssetCategory assetCategory =
-			_assetCategoryLocalService.fetchAssetCategory(
-				friendlyURLEntryLocalization.getClassPK());
-
-		if ((assetCategory == null) ||
-			(assetCategory.getGroupId() != groupId)) {
-
-			return null;
-		}
-
-		return assetCategory;
-	}
-
-	private AssetCategory _fetchAssetCategory(long groupId, String urlTitle) {
-		Group group = _groupLocalService.fetchGroup(groupId);
-
-		if ((group != null) && !Validator.isNumber(urlTitle)) {
-			return _fetchAssetCategory(groupId, _getLocale(), urlTitle);
-		}
-
-		AssetCategory assetCategory =
-			_assetCategoryLocalService.fetchAssetCategory(
-				GetterUtil.getLong(urlTitle));
+			_assetCategoryLocalService.fetchAssetCategory(classPK);
 
 		if ((assetCategory == null) ||
 			(assetCategory.getGroupId() != groupId)) {
@@ -253,37 +245,33 @@ public class AssetCategoryLayoutDisplayPageProvider
 			groupId, decodedName);
 	}
 
-	private FriendlyURLEntryLocalization _fetchFriendlyURLEntryLocalization(
-		long groupId, long parentClassPK, Locale locale, String urlTitle) {
+	private long _getClassPK(
+		long groupId, long parentClassPK, String urlTitle) {
 
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
-				groupId, _portal.getClassNameId(AssetCategory.class),
-				parentClassPK, _language.getLanguageId(locale), urlTitle);
+		long classNameId = _portal.getClassNameId(AssetCategory.class);
 
-		if (friendlyURLEntryLocalization != null) {
-			return friendlyURLEntryLocalization;
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+				groupId, classNameId, parentClassPK, urlTitle);
+
+		if (friendlyURLEntry != null) {
+			return friendlyURLEntry.getClassPK();
 		}
 
 		String decodedURLTitle = HttpComponentsUtil.decodePath(urlTitle);
 
 		if (urlTitle.equals(decodedURLTitle)) {
-			return null;
+			return 0;
 		}
 
-		return _friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
-			groupId, _portal.getClassNameId(AssetCategory.class), parentClassPK,
-			_language.getLanguageId(locale), decodedURLTitle);
-	}
+		friendlyURLEntry = _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+			groupId, classNameId, parentClassPK, decodedURLTitle);
 
-	private Locale _getLocale() {
-		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
-
-		if (themeDisplayLocale != null) {
-			return themeDisplayLocale;
+		if (friendlyURLEntry != null) {
+			return friendlyURLEntry.getClassPK();
 		}
 
-		return LocaleUtil.getSiteDefault();
+		return 0;
 	}
 
 	@Reference
@@ -297,9 +285,6 @@ public class AssetCategoryLayoutDisplayPageProvider
 
 	@Reference
 	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
@@ -30,12 +30,14 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.HashMap;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,6 +65,7 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 	@Test
 	public void testGetLayoutDisplayPageObjectProvider() throws Exception {
 		_testGetLayoutDisplayPageObjectProviderERCInfoItemIdentifier();
+		_testGetLayoutDisplayPageObjectProviderLocalizedAssetCategory();
 		_testGetLayoutDisplayPageObjectProviderNestedAssetCategory();
 	}
 
@@ -159,6 +162,54 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 						assetCategory.getExternalReferenceCode())));
 
 		Assert.assertNull(layoutDisplayPageObjectProvider);
+	}
+
+	private void _testGetLayoutDisplayPageObjectProviderLocalizedAssetCategory()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = _addAssetVocabulary();
+
+		String spanishURLTitle = StringUtil.toLowerCase(
+			StringUtil.randomString());
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				StringUtil.toLowerCase(StringUtil.randomString())
+			).put(
+				LocaleUtil.SPAIN, spanishURLTitle
+			).build(),
+			new HashMap<>(), assetVocabulary.getVocabularyId(), false, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String friendlyURL = StringBundler.concat(
+			assetVocabulary.getName(), StringPool.SLASH, spanishURLTitle);
+
+		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		try {
+			LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.SPAIN);
+
+			LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+				_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+					_group.getGroupId(), friendlyURL);
+
+			Assert.assertEquals(
+				assetCategory,
+				layoutDisplayPageObjectProvider.getDisplayObject());
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(themeDisplayLocale);
+		}
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				_group.getGroupId(), friendlyURL);
+
+		Assert.assertEquals(
+			assetCategory, layoutDisplayPageObjectProvider.getDisplayObject());
 	}
 
 	private void _testGetLayoutDisplayPageObjectProviderNestedAssetCategory()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103538

On a site reached through a locale prefix, category display page URLs do not resolve. That includes the ID based URL, which the epic promised to keep working so existing customer links would not break.

### Measured

Anonymous requests, with the test user's `languageId` logged as `en_US` before and after so nothing was contaminated. A category with an English and a Spanish name, Guest VIEW on the vocabulary and the category, a default category display page template.

| Request | Before | After |
| --- | --- | --- |
| English slug, no prefix | 200 | 200 |
| English slug, `/es/` prefix | 404 | 200 |
| Spanish slug, `/es/` prefix | 404 | 200 |
| Spanish slug, no prefix | 404 | 200 |
| Category ID, no prefix | 200 | 200 |
| Category ID, `/es/` prefix | 404 | 200 |

Only the site's base language resolved, and only without a prefix.

### Why the ID broke too

The ID path never looks at the language: it takes the numeric branch and fetches by primary key. It failed because of the canonical redirect. The resolver compares the requested friendly URL with the canonical one and redirects when they differ, and since hierarchical slugs landed the canonical URL is the localized slug. So under a locale prefix every form of the URL was redirected to a URL the resolver could not resolve.

### The fix

The language never had to take part. A slug is unique per parent across languages, and the check that enforces it compares the category, so every localization sharing a slug under one parent belongs to the same category. Looking the slug up without the language therefore finds the same category the active locale would, and also finds it when the visitor's locale is not the language the slug belongs to — which happens without any prefix at all, because a visitor can have Spanish selected on their account.

This is what web content and the Commerce category resolver already do. The whole locale plumbing that LPD-90910 introduced comes out with it, so the change removes more lines than it adds.

### Where it came from

Commit `1e2ff16b168e6` (LPD-90910) introduced the locale specific lookup and the localized canonical URL. Before it, `/v/` resolved by ID only, so the canonical URL matched what was requested. LPD-97350 removed the feature flag and made this reachable.

Checked against git rather than the Fix Version field: present in `release-7.4.13.152` and `release-2026.q3`, absent in `release-2026.q1` and `release-2026.q2`.

### Coverage

`AssetCategoryLayoutDisplayPageProviderTest` gains a case that fails without this change and passes with it. It pins the lookup.

It does **not** pin the two cases above that need HTTP — the canonical redirect and the ID URL under a prefix. Those are covered by a Playwright test that sits on top of this branch in #8852, which is why that pull request is a draft until this one merges.

### Test evidence

pr-check PASS. `AssetCategoryLayoutDisplayPageProviderTest`: 2 tests, 0 failures, verified failing before the fix and passing after, with the deployed jar checked rather than the build output. The six requests in the table re-measured after every rewrite of the fix.
