### PR TITLE
LPD-103240 Save as draft when drag-and-drop hits a required field

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
@@ -163,6 +163,29 @@ public class EditFileEntryMVCActionCommandTest {
 	}
 
 	@Test
+	public void testProcessActionAddDynamicWithZeroByteFile() throws Exception {
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		String fileName = RandomTestUtil.randomString() + ".txt";
+
+		_processAction(
+			_getMockLiferayPortletActionRequest(
+				_getParameters(
+					Constants.ADD_DYNAMIC, folder.getFolderId(),
+					folder.getRepositoryId(), new String[0]),
+				fileName, new byte[0]),
+			new MockLiferayPortletActionResponse());
+
+		FileEntry actualFileEntry = _dlAppLocalService.getFileEntryByFileName(
+			_group.getGroupId(), folder.getFolderId(), fileName);
+
+		FileVersion fileVersion = actualFileEntry.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, fileVersion.getStatus());
+	}
+
+	@Test
 	public void testProcessActionAddMultipleFileEntries() throws Exception {
 		FileEntry tempFileEntry = TempFileEntryUtil.addTempFileEntry(
 			_group.getGroupId(), TestPropsValues.getUserId(), _TEMP_FOLDER_NAME,

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
@@ -8,11 +8,18 @@ package com.liferay.document.library.web.internal.portlet.action.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.configuration.DLFileEntryMimeTypeConfiguration;
 import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeService;
 import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -30,6 +37,7 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
@@ -65,6 +73,7 @@ import jakarta.portlet.PortletException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -120,6 +129,37 @@ public class EditFileEntryMVCActionCommandTest {
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, fileVersion.getStatus());
+	}
+
+	@Test
+	public void testProcessActionAddDynamicWithRequiredDDMFormField()
+		throws Exception {
+
+		DLFileEntryType dlFileEntryType = _addFileEntryTypeWithRequiredField();
+
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		_dlAppLocalService.updateFolder(
+			folder.getFolderId(), folder.getParentFolderId(), folder.getName(),
+			folder.getDescription(), _getFolderServiceContext(dlFileEntryType));
+
+		String fileName = RandomTestUtil.randomString() + ".txt";
+
+		_processAction(
+			_getMockLiferayPortletActionRequest(
+				_getParameters(
+					Constants.ADD_DYNAMIC, folder.getFolderId(),
+					folder.getRepositoryId(), new String[0]),
+				fileName, _CONTENT_BYTES),
+			new MockLiferayPortletActionResponse());
+
+		FileEntry actualFileEntry = _dlAppLocalService.getFileEntryByFileName(
+			_group.getGroupId(), folder.getFolderId(), fileName);
+
+		FileVersion fileVersion = actualFileEntry.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, fileVersion.getStatus());
 	}
 
 	@Test
@@ -405,6 +445,31 @@ public class EditFileEntryMVCActionCommandTest {
 		Assert.assertTrue(actualFileEntry.isCheckedOut());
 	}
 
+	private DLFileEntryType _addFileEntryTypeWithRequiredField()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(LocaleUtil.US),
+			LocaleUtil.US);
+
+		DDMFormTestUtil.addDDMFormFields(
+			ddmForm,
+			DDMFormTestUtil.createLocalizedTextDDMFormField(
+				RandomTestUtil.randomString(), false, true, LocaleUtil.US));
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), DLFileEntryMetadata.class.getName(), ddmForm);
+
+		String fileEntryTypeName = RandomTestUtil.randomString();
+
+		return _dlFileEntryTypeService.addFileEntryType(
+			null, _group.getGroupId(), ddmStructure.getStructureId(), null,
+			Collections.singletonMap(LocaleUtil.US, fileEntryTypeName),
+			Collections.singletonMap(LocaleUtil.US, fileEntryTypeName),
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
+	}
+
 	private MockMultipartHttpServletRequest
 		_createMockMultipartHttpServletRequest() {
 
@@ -450,6 +515,25 @@ public class EditFileEntryMVCActionCommandTest {
 			"\r\n--", boundary, StringPool.DOUBLE_DASH);
 
 		return ArrayUtil.append(start.getBytes(), bytes, end.getBytes());
+	}
+
+	private ServiceContext _getFolderServiceContext(
+			DLFileEntryType dlFileEntryType)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		serviceContext.setAttribute(
+			"defaultFileEntryTypeId", dlFileEntryType.getPrimaryKey());
+		serviceContext.setAttribute(
+			"dlFileEntryTypesSearchContainerPrimaryKeys",
+			String.valueOf(dlFileEntryType.getPrimaryKey()));
+		serviceContext.setAttribute(
+			"restrictionType",
+			DLFolderConstants.RESTRICTION_TYPE_FILE_ENTRY_TYPES_AND_WORKFLOW);
+
+		return serviceContext;
 	}
 
 	private InputStream _getInputStream() {
@@ -646,6 +730,9 @@ public class EditFileEntryMVCActionCommandTest {
 
 	@Inject
 	private DLAppService _dlAppService;
+
+	@Inject
+	private DLFileEntryTypeService _dlFileEntryTypeService;
 
 	@Inject(filter = "mvc.command.name=/document_library/edit_file_entry")
 	private MVCActionCommand _editFileEntryMVCActionCommand;

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
@@ -12,17 +12,21 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
@@ -37,6 +41,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -49,6 +54,7 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -89,6 +95,31 @@ public class EditFileEntryMVCActionCommandTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testProcessActionAddDynamicWithoutRequiredDDMFormField()
+		throws Exception {
+
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		String fileName = RandomTestUtil.randomString() + ".txt";
+
+		_processAction(
+			_getMockLiferayPortletActionRequest(
+				_getParameters(
+					Constants.ADD_DYNAMIC, folder.getFolderId(),
+					folder.getRepositoryId(), new String[0]),
+				fileName, _CONTENT_BYTES),
+			new MockLiferayPortletActionResponse());
+
+		FileEntry actualFileEntry = _dlAppLocalService.getFileEntryByFileName(
+			_group.getGroupId(), folder.getFolderId(), fileName);
+
+		FileVersion fileVersion = actualFileEntry.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, fileVersion.getStatus());
 	}
 
 	@Test
@@ -389,16 +420,54 @@ public class EditFileEntryMVCActionCommandTest {
 		return mockMultipartHttpServletRequest;
 	}
 
+	private MockMultipartHttpServletRequest
+		_createMockMultipartHttpServletRequest(String fileName, byte[] bytes) {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			new MockMultipartHttpServletRequest();
+
+		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
+
+		String boundary = "WebKitFormBoundary" + StringUtil.randomString();
+
+		mockMultipartHttpServletRequest.setContent(
+			_getFileContent(boundary, fileName, bytes));
+		mockMultipartHttpServletRequest.setContentType(
+			StringBundler.concat(
+				MediaType.MULTIPART_FORM_DATA_VALUE, "; boundary=", boundary));
+
+		return mockMultipartHttpServletRequest;
+	}
+
+	private byte[] _getFileContent(
+		String boundary, String fileName, byte[] bytes) {
+
+		String start = StringBundler.concat(
+			StringPool.DOUBLE_DASH, boundary,
+			"\r\nContent-Disposition: form-data; name=\"file\"; filename=\"",
+			fileName, "\"\r\nContent-Type: text/plain\r\n\r\n");
+		String end = StringBundler.concat(
+			"\r\n--", boundary, StringPool.DOUBLE_DASH);
+
+		return ArrayUtil.append(start.getBytes(), bytes, end.getBytes());
+	}
+
 	private InputStream _getInputStream() {
-		return new ByteArrayInputStream("test".getBytes());
+		return new ByteArrayInputStream(_CONTENT_BYTES);
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
 			Map<String, String[]> parameters)
 		throws PortalException {
 
-		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
-			_createMockMultipartHttpServletRequest();
+		return _getMockLiferayPortletActionRequest(
+			parameters, _createMockMultipartHttpServletRequest());
+	}
+
+	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
+			Map<String, String[]> parameters,
+			MockMultipartHttpServletRequest mockMultipartHttpServletRequest)
+		throws PortalException {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest(
@@ -422,6 +491,32 @@ public class EditFileEntryMVCActionCommandTest {
 
 		mockLiferayPortletActionRequest.setPortletSession(
 			new MockPortletSession());
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
+			Map<String, String[]> parameters, String fileName, byte[] bytes)
+		throws Exception {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			_createMockMultipartHttpServletRequest(fileName, bytes);
+
+		mockMultipartHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, "/document_library/edit_file_entry");
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(
+				parameters, mockMultipartHttpServletRequest);
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)mockLiferayPortletActionRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutSet(layout.getLayoutSet());
 
 		return mockLiferayPortletActionRequest;
 	}
@@ -454,6 +549,9 @@ public class EditFileEntryMVCActionCommandTest {
 			"repositoryId", new String[] {String.valueOf(repositoryId)}
 		).put(
 			"selectedFileName", tempFileEntryNames
+		).put(
+			"workflowAction",
+			new String[] {String.valueOf(WorkflowConstants.ACTION_PUBLISH)}
 		).build();
 	}
 
@@ -533,6 +631,8 @@ public class EditFileEntryMVCActionCommandTest {
 					return method.invoke(_portal, args);
 				}));
 	}
+
+	private static final byte[] _CONTENT_BYTES = "test".getBytes();
 
 	private static final String _TEMP_FOLDER_NAME =
 		"com.liferay.document.library.web.internal.portlet.action." +

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
@@ -400,16 +400,16 @@ public class EditFileEntryMVCActionCommandTest {
 		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
 			_createMockMultipartHttpServletRequest();
 
-		mockMultipartHttpServletRequest.setAttribute(
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest(
+				mockMultipartHttpServletRequest);
+
+		mockLiferayPortletActionRequest.setAttribute(
 			JavaConstants.JAKARTA_PORTLET_CONFIG,
 			PortletConfigFactoryUtil.create(
 				_portletLocalService.getPortletById(
 					DLPortletKeys.DOCUMENT_LIBRARY),
 				null));
-
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			new MockLiferayPortletActionRequest(
-				mockMultipartHttpServletRequest);
 
 		mockLiferayPortletActionRequest.setAttribute(
 			WebKeys.THEME_DISPLAY,

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -122,8 +122,11 @@ import jakarta.portlet.PortletRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 
 import java.text.Format;
 
@@ -369,6 +372,23 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		catch (Exception exception) {
 			_handleUploadException(
 				actionRequest, actionResponse, cmd, exception);
+		}
+	}
+
+	private FileEntry _addFileEntry(
+			String externalReferenceCode, long repositoryId, long folderId,
+			String uniqueFileName, String contentType, String uniqueFileTitle,
+			String description, String changeLog, File file, long size,
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
+		throws IOException, PortalException {
+
+		try (InputStream inputStream = new FileInputStream(file)) {
+			return _dlAppService.addFileEntry(
+				externalReferenceCode, repositoryId, folderId, uniqueFileName,
+				contentType, uniqueFileTitle, StringPool.BLANK, description,
+				changeLog, inputStream, size, displayDate, expirationDate,
+				reviewDate, serviceContext);
 		}
 	}
 
@@ -1491,11 +1511,47 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 					themeDisplay.getScopeGroupId(), folderId,
 					FileUtil.stripExtension(sourceFileName));
 
-				fileEntry = _dlAppService.addFileEntry(
-					externalReferenceCode, repositoryId, folderId,
-					uniqueFileName, contentType, uniqueFileTitle,
-					StringPool.BLANK, description, changeLog, inputStream, size,
-					displayDate, expirationDate, reviewDate, serviceContext);
+				File file = uploadPortletRequest.getFile("file", true);
+
+				try {
+					fileEntry = _addFileEntry(
+						externalReferenceCode, repositoryId, folderId,
+						uniqueFileName, contentType, uniqueFileTitle,
+						description, changeLog, file, size, displayDate,
+						expirationDate, reviewDate, serviceContext);
+				}
+				catch (DDMFormValuesValidationException.RequiredValue
+							ddmFormValuesValidationException) {
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Adding file entry as a draft because a required " +
+								"field is missing",
+							ddmFormValuesValidationException);
+					}
+
+					Serializable validateDDMFormValues =
+						serviceContext.getAttribute("validateDDMFormValues");
+					int workflowAction = serviceContext.getWorkflowAction();
+
+					serviceContext.setAttribute(
+						"validateDDMFormValues", Boolean.FALSE);
+					serviceContext.setWorkflowAction(
+						WorkflowConstants.ACTION_SAVE_DRAFT);
+
+					try {
+						fileEntry = _addFileEntry(
+							externalReferenceCode, repositoryId, folderId,
+							uniqueFileName, contentType, uniqueFileTitle,
+							description, changeLog, file, size, displayDate,
+							expirationDate, reviewDate, serviceContext);
+					}
+					finally {
+						serviceContext.setAttribute(
+							"validateDDMFormValues", validateDDMFormValues);
+						serviceContext.setWorkflowAction(workflowAction);
+					}
+				}
 
 				JSONObject jsonObject = JSONUtil.put(
 					"fileEntryId", fileEntry.getFileEntryId());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103240

## What Is Being Fixed

Dragging a file into a Documents & Media folder restricted to a document type with a required field failed outright. Drag-and-drop never collects any document-type field values, and the DDM validator rejects the empty required field for that folder's document type. The button-driven upload avoids this by showing a metadata form first; drag-and-drop has no such form to fill in.

## How It Is Being Fixed

EditFileEntryMVCActionCommand now catches the specific DDM validation failure on the ADD_DYNAMIC path and retries the upload with DDM validation turned off and the workflow action set to save-as-draft, so the file is still created and left at its already-inserted draft status instead of failing, matching existing behavior for folders whose document type has no required fields. The retry reopens the uploaded file rather than reusing the original stream, since getFileAsStream deletes its backing file on close by default and the first, failing attempt may have already consumed and closed it for certain content-type and upload-size combinations; forcing file creation also covers a zero-byte upload, whose backing file is otherwise never written to disk. Both attempts go through a shared helper so the addFileEntry call site exists once, and the ServiceContext mutations used to relax validation and force draft status are snapshotted beforehand and restored in a finally block. A separate commit fixes an unrelated test-harness bug (MockLiferayPortletActionRequest's constructor overwriting a real PortletConfig set before construction), and three commits add test coverage: a baseline ADD_DYNAMIC test for an unrestricted folder, a test proving the required-field folder now saves a draft, and a pinning test for the zero-byte upload case.

## PR Check

**pr-check: PASS** — tested on `69488cdfa7e4e394d8ff21cd0dfb62d5e8df2ea2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "69488cdfa7e4e394d8ff21cd0dfb62d5e8df2ea2"} -->
