### PR TITLE
LPD-103643 Deflake the repeatable groups content editor test

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1728,35 +1728,52 @@ test(
 
 		await page.getByPlaceholder(`New ${structureLabel}`).fill(title);
 
-		// Add Repeatable Groups
+		// Add Repeatable Groups, waiting for each new row to render before
+		// clicking again
 
-		await page.getByRole('button', {name: 'Add New'}).first().click();
+		const addNewButtons = page.getByRole('button', {name: 'Add New'});
+		const groupFields = page.getByRole('textbox', {
+			name: /^(Text|Long Text)$/,
+		});
 
-		await page.getByRole('button', {name: 'Add New'}).last().click();
+		await expect(addNewButtons).toHaveCount(2);
+		await expect(groupFields).toHaveCount(2);
+
+		await addNewButtons.first().click();
+
+		await expect(groupFields).toHaveCount(3);
+
+		await addNewButtons.last().click();
+
+		await expect(groupFields).toHaveCount(4);
 
 		// Fill the fields
 
-		const firstText = page
-			.getByRole('textbox', {exact: true, name: 'Text'})
-			.first();
+		const textFields = page.getByRole('textbox', {
+			exact: true,
+			name: 'Text',
+		});
+		const longTextFields = page.getByRole('textbox', {
+			exact: true,
+			name: 'Long Text',
+		});
+
+		await expect(textFields).toHaveCount(2);
+		await expect(longTextFields).toHaveCount(2);
+
+		const firstText = textFields.first();
 
 		await firstText.fill('First Text');
 
-		const secondText = page
-			.getByRole('textbox', {exact: true, name: 'Text'})
-			.last();
+		const secondText = textFields.last();
 
 		await secondText.fill('Second Text');
 
-		const firstLongText = page
-			.getByRole('textbox', {exact: true, name: 'Long Text'})
-			.first();
+		const firstLongText = longTextFields.first();
 
 		await firstLongText.fill('First Long Text');
 
-		const secondLongText = page
-			.getByRole('textbox', {exact: true, name: 'Long Text'})
-			.last();
+		const secondLongText = longTextFields.last();
 
 		await secondLongText.fill('Second Long Text');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103643

## What Is Being Fixed

The test "Create item with repeatable groups" fails intermittently. Reproduced locally at 3 out of 5 runs, the failure surfaces as `expect(firstText).toHaveValue('First Text')` receiving `"Second Text"`.

The test clicks both "Add New" buttons back to back, without waiting for the form to settle after the first click. The re-render triggered by the first click swallows the second one, so one of the two repeatable groups is left with a single row. With a single row, `first()` and `last()` resolve to the same input, so `fill('First Text')` is silently overwritten by `fill('Second Text')`. Nothing fails at that point, and the assertion that finally breaks sits thirty lines further down, after the content is saved and reopened.

Instrumenting the form also showed that the content editor does not render the two groups in a stable order: across six runs the group titles came back as `["Repeatable Group 1","Repeatable Group 2"]` once and as `["Repeatable Group 2","Repeatable Group 1"]` five times. Any fix that assumes `first()` is Group 1 therefore fails on its own.

## How It Is Being Fixed

The test now waits for each new row to render before clicking again. It asserts that both "Add New" buttons are present, counts the group fields as a whole after each click, and checks that each field type ends up with two rows before filling anything. Counting the combined set keeps the check agnostic to which group the editor renders first, and gating on the count after the first click lets the DOM settle so the second click is no longer swallowed.

Validated with `--repeat-each=8`: 8 out of 8 green, against 3 out of 5 and 5 out of 8 failing before the change.

## PR Check

**pr-check: PASS** — tested on `b0e1fbfd34010892dedaec6ae4ed1344446c3e91`

| Validation | Result |
| --- | --- |
| Baseline | N/A |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Baseline, Per-Module Compile and JavaScript Unit Tests match by regex but do not apply to a Playwright-only TypeScript diff: the diff touches no `.java`, `bnd.bnd` or `packageinfo`; `modules/test/playwright` is not an OSGi module and has no `deploy` task, its type checking being covered by the formatter's TypeScript project check; and the module has no Jest suite, its `npm test` being the Playwright suite that pr-check declares out of scope.

<!-- pr-check {"result": "success", "sha": "b0e1fbfd34010892dedaec6ae4ed1344446c3e91"} -->
