### PR TITLE
LPD-103652 Show the date actions in all content management sections

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -83,6 +83,18 @@ import java.util.TimeZone;
  */
 public class SectionDisplayContextUtil {
 
+	public static void addScheduleDateFDSActionDropdownItems(
+		List<FDSActionDropdownItem> fdsActionDropdownItems,
+		HttpServletRequest httpServletRequest) {
+
+		fdsActionDropdownItems.add(
+			getScheduleDateFDSActionDropdownItem(
+				"update-expiration-date", httpServletRequest));
+		fdsActionDropdownItems.add(
+			getScheduleDateFDSActionDropdownItem(
+				"update-review-date", httpServletRequest));
+	}
+
 	public static String appendGroupIds(
 		String filterString, HttpServletRequest httpServletRequest) {
 
@@ -216,26 +228,9 @@ public class SectionDisplayContextUtil {
 			).build(
 				"find-and-replace"
 			));
-		bulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHref(
-				StringPool.POUND
-			).setIcon(
-				"date-time"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "update-expiration-date")
-			).build(
-				"update-expiration-date"
-			));
-		bulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHref(
-				StringPool.POUND
-			).setIcon(
-				"date-time"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "update-review-date")
-			).build(
-				"update-review-date"
-			));
+
+		_addScheduleDateBulkActionDropdownItems(
+			bulkActionDropdownItems, httpServletRequest);
 
 		_addPermissionsBulkActions(bulkActionDropdownItems, httpServletRequest);
 
@@ -264,12 +259,9 @@ public class SectionDisplayContextUtil {
 			).build(
 				"download"
 			));
-		fdsActionDropdownItems.add(
-			getScheduleDateFDSActionDropdownItem(
-				"update-expiration-date", httpServletRequest));
-		fdsActionDropdownItems.add(
-			getScheduleDateFDSActionDropdownItem(
-				"update-review-date", httpServletRequest));
+
+		addScheduleDateFDSActionDropdownItems(
+			fdsActionDropdownItems, httpServletRequest);
 
 		return fdsActionDropdownItems;
 	}
@@ -332,6 +324,9 @@ public class SectionDisplayContextUtil {
 		_addAddAssetsToProjectBulkAction(
 			bulkActionDropdownItems, httpServletRequest);
 
+		_addScheduleDateBulkActionDropdownItems(
+			bulkActionDropdownItems, httpServletRequest);
+
 		_addPermissionsBulkActions(bulkActionDropdownItems, httpServletRequest);
 
 		return bulkActionDropdownItems;
@@ -344,6 +339,9 @@ public class SectionDisplayContextUtil {
 			getFDSActionDropdownItems(httpServletRequest);
 
 		_addAddToLaunchAction(fdsActionDropdownItems, httpServletRequest);
+
+		addScheduleDateFDSActionDropdownItems(
+			fdsActionDropdownItems, httpServletRequest);
 
 		return fdsActionDropdownItems;
 	}
@@ -859,6 +857,9 @@ public class SectionDisplayContextUtil {
 		_addAddAssetsToProjectBulkAction(
 			bulkActionDropdownItems, httpServletRequest);
 
+		_addScheduleDateBulkActionDropdownItems(
+			bulkActionDropdownItems, httpServletRequest);
+
 		_addPermissionsBulkActions(bulkActionDropdownItems, httpServletRequest);
 
 		return bulkActionDropdownItems;
@@ -907,6 +908,9 @@ public class SectionDisplayContextUtil {
 			).build(
 				"download-folder"
 			));
+
+		addScheduleDateFDSActionDropdownItems(
+			fdsActionDropdownItems, httpServletRequest);
 
 		return fdsActionDropdownItems;
 	}
@@ -957,12 +961,8 @@ public class SectionDisplayContextUtil {
 		List<FDSActionDropdownItem> fdsActionDropdownItems =
 			getFDSActionDropdownItems(httpServletRequest);
 
-		fdsActionDropdownItems.add(
-			getScheduleDateFDSActionDropdownItem(
-				"update-expiration-date", httpServletRequest));
-		fdsActionDropdownItems.add(
-			getScheduleDateFDSActionDropdownItem(
-				"update-review-date", httpServletRequest));
+		addScheduleDateFDSActionDropdownItems(
+			fdsActionDropdownItems, httpServletRequest);
 
 		return fdsActionDropdownItems;
 	}
@@ -1198,6 +1198,32 @@ public class SectionDisplayContextUtil {
 					httpServletRequest, "reset-to-default-permissions")
 			).build(
 				"reset-to-default-permissions"
+			));
+	}
+
+	private static void _addScheduleDateBulkActionDropdownItems(
+		List<DropdownItem> bulkActionDropdownItems,
+		HttpServletRequest httpServletRequest) {
+
+		bulkActionDropdownItems.add(
+			FDSActionDropdownItemBuilder.setHref(
+				StringPool.POUND
+			).setIcon(
+				"date-time"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "update-expiration-date")
+			).build(
+				"update-expiration-date"
+			));
+		bulkActionDropdownItems.add(
+			FDSActionDropdownItemBuilder.setHref(
+				StringPool.POUND
+			).setIcon(
+				"date-time"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "update-review-date")
+			).build(
+				"update-review-date"
 			));
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -115,6 +115,9 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 				LanguageUtil.get(httpServletRequest, "download"), "get", null,
 				"link"));
 
+		SectionDisplayContextUtil.addScheduleDateFDSActionDropdownItems(
+			fdsActionDropdownItems, httpServletRequest);
+
 		return fdsActionDropdownItems;
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -416,14 +416,14 @@ export default function AssetsFDSPropsTransformer({
 						Boolean(item?.embedded?.file?.link?.href),
 				};
 			}
-			else if (action?.data?.id === 'actionLink') {
+			else if (
+				action?.data?.id === 'actionLink' ||
+				isScheduleDateActionId(action?.data?.id)
+			) {
 				return {
 					...action,
 					isVisible: (item: any) =>
-						Boolean(
-							item?.entryClassName !==
-								OBJECT_ENTRY_FOLDER_CLASS_NAME
-						),
+						item?.entryClassName !== OBJECT_ENTRY_FOLDER_CLASS_NAME,
 				};
 			}
 			else if (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -5,6 +5,8 @@
 
 import {IBulkActionItem} from '@liferay/frontend-data-set-web';
 
+import {OBJECT_ENTRY_FOLDER_CLASS_NAME} from '../../../common/utils/constants';
+
 const BULK_ACTION_PERMISSION_KEYS: Record<string, string> = {
 	'assign-default-workflow': 'update',
 	'copy-to': 'update',
@@ -22,7 +24,14 @@ const BULK_ACTION_PERMISSION_KEYS: Record<string, string> = {
 	'permissions': 'permissions',
 	'reset-to-default-permissions': 'permissions',
 	'restore': 'restore',
+	'update-expiration-date': 'update',
+	'update-review-date': 'update',
 };
+
+const NON_FOLDER_BULK_ACTION_IDS = new Set([
+	'update-expiration-date',
+	'update-review-date',
+]);
 
 export default function transformFDSBulkActions(
 	bulkActions: Array<IBulkActionItem>
@@ -52,6 +61,17 @@ export default function transformFDSBulkActions(
 					return (
 						selectedItems?.every((item: any) =>
 							Boolean(item?.embedded?.file?.link?.href)
+						) ?? false
+					);
+				}
+
+				if (NON_FOLDER_BULK_ACTION_IDS.has(key)) {
+					return (
+						selectedItems?.every(
+							(item: any) =>
+								item?.actions?.[permissionKey] &&
+								item?.entryClassName !==
+									OBJECT_ENTRY_FOLDER_CLASS_NAME
 						) ?? false
 					);
 				}

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformerScheduleDate.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/AssetsFDSPropsTransformerScheduleDate.test.ts
@@ -27,11 +27,12 @@ const ITEM = {
 
 const SELECTED_DATA = {items: [ITEM], selectAll: false};
 
-function getTransformerProps() {
+function getTransformerProps(itemsActions: unknown[] = []) {
 	return AssetsFDSPropsTransformer({
 		additionalProps: {},
 		creationMenu: {primaryItems: []},
 		id: 'allSection',
+		itemsActions,
 		views: [],
 	} as any);
 }
@@ -86,4 +87,23 @@ describe('[CMS] AssetsFDSPropsTransformer schedule date actions', () => {
 
 		expect(openScheduleDateModal).not.toHaveBeenCalled();
 	});
+
+	it.each(['update-expiration-date', 'update-review-date'])(
+		'hides the %s action for folders and shows it for assets',
+		(actionId) => {
+			const {itemsActions} = getTransformerProps([
+				{data: {id: actionId}},
+			]);
+
+			const [action] = itemsActions;
+
+			expect(action.isVisible(ITEM)).toBe(true);
+			expect(
+				action.isVisible({
+					entryClassName:
+						'com.liferay.object.model.ObjectEntryFolder',
+				})
+			).toBe(false);
+		}
+	);
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/utils/transformFDSBulkActions.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/utils/transformFDSBulkActions.test.ts
@@ -23,6 +23,11 @@ const fileItemWithLink = () => ({
 
 const fileItemWithoutLink = () => ({embedded: {file: {}}});
 
+const folderItemWith = (actions: Record<string, unknown>) => ({
+	actions,
+	entryClassName: 'com.liferay.object.model.ObjectEntryFolder',
+});
+
 describe('transformFDSBulkActions', () => {
 	it('passes through actions whose id is not in the permission map', () => {
 		const unknown = action('unknown-action');
@@ -76,6 +81,36 @@ describe('transformFDSBulkActions', () => {
 				isVisible({selectedItems: [itemWith({['move-to']: {}})]})
 			).toBe(false);
 		});
+
+		it.each(['update-expiration-date', 'update-review-date'])(
+			'hides the %s action when the selection contains a folder',
+			(id) => {
+				const isVisible = isVisibleFor(id);
+
+				expect(
+					isVisible({selectedItems: [itemWith({update: {}})]})
+				).toBe(true);
+				expect(
+					isVisible({
+						selectedItems: [
+							itemWith({update: {}}),
+							folderItemWith({update: {}}),
+						],
+					})
+				).toBe(false);
+			}
+		);
+
+		it.each(['update-expiration-date', 'update-review-date'])(
+			'hides the %s action when any selected item cannot be updated',
+			(id) => {
+				expect(
+					isVisibleFor(id)({
+						selectedItems: [itemWith({update: {}}), itemWith({})],
+					})
+				).toBe(false);
+			}
+		);
 
 		it('checks file link presence for the download action', () => {
 			const isVisible = isVisibleFor('download');

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/scheduleDateActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/scheduleDateActions.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import getRandomString from '../../../utils/getRandomString';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+import {addRoleMemberAndSwitch} from './spaces/helpers/roleMembership';
+
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-web-contents';
+
+const DATE_ACTIONS = ['Update Expiration Date', 'Update Review Date'];
+
+async function createContent(apiHelpers: DataApiHelpers, scope = 'Default') {
+	const title = getRandomString();
+
+	const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+		{
+			objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			title,
+		},
+		APPLICATION_NAME,
+		scope
+	);
+
+	apiHelpers.data.push({
+		applicationName: APPLICATION_NAME,
+		id: objectEntry.id,
+		type: 'objectEntry',
+	});
+
+	return title;
+}
+
+async function createFile(apiHelpers: DataApiHelpers) {
+	const title = getRandomString();
+
+	const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+		{
+			objectEntryFolderExternalReferenceCode: 'L_FILES',
+			title,
+			videoURL: 'https://www.youtube.com/watch?v=IqCSx3omX4o',
+		},
+		'cms/external-videos',
+		'Default'
+	);
+
+	apiHelpers.data.push({
+		id: objectEntry.id,
+		type: 'document',
+	});
+
+	return title;
+}
+
+async function expectDateActionsInMenu(page: Page, trigger: Locator) {
+	await trigger.click();
+
+	const menu = page.getByRole('menu');
+
+	await expect(menu).toBeVisible();
+
+	for (const action of DATE_ACTIONS) {
+		await expect(
+			menu.getByRole('menuitem', {exact: true, name: action})
+		).toBeVisible();
+	}
+
+	await page.keyboard.press('Escape');
+
+	await expect(
+		page.getByRole('menuitem', {exact: true, name: DATE_ACTIONS[0]})
+	).toBeHidden();
+}
+
+function getBulkActionsTrigger(page: Page) {
+	return page
+		.getByTestId(/visualization-mode/)
+		.getByLabel('Actions', {exact: true});
+}
+
+test(
+	'The date actions appear in the Home, Contents, and Files sections',
+	{tag: '@LPD-103652'},
+	async ({apiHelpers, assetsPage, homePage, page}) => {
+		const contentTitle = await createContent(apiHelpers);
+		const fileTitle = await createFile(apiHelpers);
+
+		await homePage.goto();
+
+		await expectDateActionsInMenu(
+			page,
+			page.getByRole('button', {name: `${contentTitle} Actions`})
+		);
+
+		await assetsPage.gotoContents();
+
+		await expectDateActionsInMenu(
+			page,
+			assetsPage
+				.getItem(contentTitle)
+				.getByRole('button', {name: `${contentTitle} Actions`})
+		);
+
+		await assetsPage.gotoFiles();
+
+		await expectDateActionsInMenu(
+			page,
+			assetsPage.getCardItem(fileTitle).getByLabel(`${fileTitle} Actions`)
+		);
+	}
+);
+
+test(
+	'The date actions are hidden for folders but offered for content',
+	{tag: '@LPD-103652'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const contentTitle = await createContent(apiHelpers);
+
+		const folderTitle = getRandomString();
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: 'Default',
+			title: folderTitle,
+		});
+
+		try {
+			await assetsPage.gotoContents();
+
+			await expectDateActionsInMenu(
+				page,
+				assetsPage
+					.getItem(contentTitle)
+					.getByRole('button', {name: `${contentTitle} Actions`})
+			);
+
+			for (const action of DATE_ACTIONS) {
+				await assetsPage.expectItemActionHidden(action, folderTitle);
+			}
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+		}
+	}
+);
+
+test(
+	'The date bulk actions are hidden when a folder is selected',
+	{tag: '@LPD-103652'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const contentTitle = await createContent(apiHelpers);
+
+		const folderTitle = getRandomString();
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: 'Default',
+			title: folderTitle,
+		});
+
+		try {
+			await assetsPage.gotoContents();
+
+			await assetsPage.selectItems([contentTitle]);
+
+			await expectDateActionsInMenu(page, getBulkActionsTrigger(page));
+
+			await assetsPage.selectItems([folderTitle]);
+
+			for (const action of DATE_ACTIONS) {
+				await assetsPage.expectBulkItemActionHidden(action);
+			}
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+		}
+	}
+);
+
+test(
+	'The date bulk actions appear in the Contents and Files sections',
+	{tag: '@LPD-103652'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const contentTitle = await createContent(apiHelpers);
+		const fileTitle = await createFile(apiHelpers);
+
+		const bulkActionsTrigger = getBulkActionsTrigger(page);
+
+		await assetsPage.gotoContents();
+
+		await assetsPage.selectItems([contentTitle]);
+
+		await expectDateActionsInMenu(page, bulkActionsTrigger);
+
+		await assetsPage.gotoFiles();
+
+		await assetsPage.selectItems([fileTitle]);
+
+		await expectDateActionsInMenu(page, bulkActionsTrigger);
+	}
+);
+
+for (const role of ['Space Administrator', 'Space Content Reviewer'] as const) {
+	test(
+		`A ${role} sees the date actions on their space content`,
+		{tag: '@LPD-103652'},
+		async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: `Space ${getRandomString()}`,
+					type: 'Space',
+				});
+
+			apiHelpers.data.push({id: space.id, type: 'assetLibrary'});
+
+			const contentTitle = getRandomString();
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				APPLICATION_NAME,
+				space.name
+			);
+
+			await addRoleMemberAndSwitch({
+				apiHelpers,
+				page,
+				role,
+				spaceName: space.name,
+				spaceSummaryPage,
+			});
+
+			await assetsPage.gotoSpaceContents(space.name);
+
+			await expectDateActionsInMenu(
+				page,
+				assetsPage
+					.getItem(contentTitle)
+					.getByRole('button', {name: `${contentTitle} Actions`})
+			);
+		}
+	);
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103652

## What Is Being Fixed

The Update Review Date and Update Expiration Date actions introduced with the Governance Dashboard work were only served in the All section and in the dashboard listings. As reported in LPD-103466, CMS Administrators were missing them in the Home section, and Space Administrators and Space Content Reviewers could not reach them at all, because the sections they work in (Contents, Files, and the space views) never offered the actions.

## How It Is Being Fixed

The two actions are now added to the Home (Recent Assets), Contents, and Files section listings through a shared helper in `SectionDisplayContextUtil`, which also deduplicates the entries that the All and Needs Review listings were building inline. The folder navigation and the space views reuse those same listings, so they are covered by the same change. The matching bulk actions are added to the Contents and Files sections, at parity with the All section.

Visibility stays permission-driven through the existing `update` permission key, and the `actionLink` branch in `AssetsFDSPropsTransformer` now also covers both actions, so neither is offered on a folder, which has no review or expiration date. Bulk visibility is handled where FDS actually evaluates it: `filterBulkActions` only honors `isVisible` and ignores `permissionKey`, so both ids are registered in `transformFDSBulkActions`, mapped to `update` next to `edit-tags` and `edit-categories`, and hidden whenever the selection contains a folder. Without that, a selection holding a folder reported the folder as updated even though the bulk action skips it.

## Tests

`transformFDSBulkActions.test.ts` covers the two new permission map entries and the folder exclusion, both for a selection containing a folder and for an item that cannot be updated. `AssetsFDSPropsTransformerScheduleDate.test.ts` covers the row level visibility on folders. `scheduleDateActions.spec.ts` covers the Home, Contents, and Files listings, the folder row against a content row in the same listing, the bulk entries in Contents and Files, the bulk entries against a selection containing a folder, and a Space Administrator and a Space Content Reviewer on their space content.

## Test Execution

```bash
cd modules/apps/site/site-cms-site-initializer && yarn test

cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/scheduleDateActions.spec.ts
```

Both layers were run green on `dd749fbea3e6a`: 182 Jest suites (1053 tests) and the 6 Playwright tests of the spec.

## PR Check

**pr-check: PASS** — tested on `dd749fbea3e6a8494e55aedf47e52a39a8d43a4f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |
