### PR TITLE
LPD-103656 Fix the Attention Required card icons and alignment

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/AttentionRequired.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/AttentionRequired.tsx
@@ -38,7 +38,7 @@ const ATTENTION_CARDS: AttentionCard[] = [
 		description: Liferay.Language.get(
 			'these-are-expired-assets-across-the-selected-spaces'
 		),
-		icon: 'warning-full',
+		icon: 'warning',
 		statKey: 'expiredCount',
 		title: Liferay.Language.get('expired-assets'),
 	},
@@ -56,7 +56,7 @@ const ATTENTION_CARDS: AttentionCard[] = [
 		description: Liferay.Language.get(
 			'these-are-assets-with-pending-workflows-across-the-selected-spaces'
 		),
-		icon: 'flag-empty',
+		icon: 'workflow',
 		statKey: 'pendingCount',
 		title: Liferay.Language.get('pending-workflows'),
 	},

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/InteractiveCard.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/InteractiveCard.tsx
@@ -68,7 +68,7 @@ export default function InteractiveCard({
 		<ClayButton
 			{...ariaAttributes}
 			className={classNames(
-				'cms-dashboard__interactive-card h-100 p-3 rounded-lg sheet text-left w-100',
+				'cms-dashboard__interactive-card d-flex flex-column h-100 p-3 rounded-lg sheet text-left w-100',
 				{active}
 			)}
 			displayType="unstyled"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103656

## What Is Being Fixed

Two style defects in the Attention Required section of the CMS Governance dashboard.

The Expired Assets and Pending Workflows cards used icons that do not appear in the design. Expired Assets rendered the filled warning triangle instead of the outlined one, and Pending Workflows rendered a flag instead of the workflow icon.

The cards also failed to align their content to the top. Every card already stretches to the height of the tallest one, but each card is a button, and the browser centers the content of a button vertically inside it, so a card whose description ran to fewer lines than its neighbors pushed its title, description, and value down. Measured on a running portal, three cards started their content at the same offset while Expired Assets started ten pixels lower, all four sharing the same height.

## How It Is Being Fixed

The two icons now name the symbols used in the design, `warning` and `workflow`.

For the alignment, the card is turned into a column flex container. That replaces the button's default vertical centering with normal top-down stacking, so every card starts its content at the same offset and keeps matching the tallest card's height. The change is made on the shared card component rather than on the Attention Required section alone, because the same centering applies wherever that card is used and top alignment is the correct behavior in each of those places. It is not visible in the other sections today only because their descriptions happen to occupy the same number of lines.

## Why Are There No Tests?

These are style changes: two icon names and one set of layout classes. There is no behavior to assert.

## PR Check

**pr-check: PASS** — tested on `ac87332d07172ad6b3de1d069032133e3e00e7a8`

| Validation | Result |
| --- | --- |
| Baseline | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ac87332d07172ad6b3de1d069032133e3e00e7a8"} -->
