### PR TITLE
LPD-102064 Fix 400 error when sorting categories by subcategories

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryChildCategoriesCountModelListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryChildCategoriesCountModelListener.java
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.model.listener;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = ModelListener.class)
+public class AssetCategoryChildCategoriesCountModelListener
+	extends BaseModelListener<AssetCategory> {
+
+	@Override
+	public void onAfterCreate(AssetCategory assetCategory)
+		throws ModelListenerException {
+
+		_reindexParentAssetCategory(assetCategory.getParentCategoryId());
+	}
+
+	@Override
+	public void onAfterRemove(AssetCategory assetCategory)
+		throws ModelListenerException {
+
+		_reindexParentAssetCategory(assetCategory.getParentCategoryId());
+	}
+
+	@Override
+	public void onAfterUpdate(
+			AssetCategory originalAssetCategory, AssetCategory assetCategory)
+		throws ModelListenerException {
+
+		if (originalAssetCategory.getParentCategoryId() ==
+				assetCategory.getParentCategoryId()) {
+
+			return;
+		}
+
+		_reindexParentAssetCategory(
+			originalAssetCategory.getParentCategoryId());
+		_reindexParentAssetCategory(assetCategory.getParentCategoryId());
+	}
+
+	private void _reindexParentAssetCategory(long parentCategoryId)
+		throws ModelListenerException {
+
+		if (ExportImportThreadLocal.isImportInProcess() ||
+			ExportImportThreadLocal.isStagingInProcess() ||
+			(parentCategoryId ==
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID)) {
+
+			return;
+		}
+
+		AssetCategory parentAssetCategory =
+			_assetCategoryLocalService.fetchAssetCategory(parentCategoryId);
+
+		if (parentAssetCategory == null) {
+			return;
+		}
+
+		try {
+			Indexer<AssetCategory> indexer =
+				IndexerRegistryUtil.nullSafeGetIndexer(AssetCategory.class);
+
+			indexer.reindex(parentAssetCategory);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+}

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryChildCategoriesCountModelListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryChildCategoriesCountModelListener.java
@@ -8,12 +8,12 @@ package com.liferay.asset.categories.internal.model.listener;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
-import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -58,10 +58,8 @@ public class AssetCategoryChildCategoriesCountModelListener
 	private void _reindexParentAssetCategory(long parentCategoryId)
 		throws ModelListenerException {
 
-		if (ExportImportThreadLocal.isImportInProcess() ||
-			ExportImportThreadLocal.isStagingInProcess() ||
-			(parentCategoryId ==
-				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID)) {
+		if (parentCategoryId ==
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) {
 
 			return;
 		}
@@ -79,8 +77,8 @@ public class AssetCategoryChildCategoriesCountModelListener
 
 			indexer.reindex(parentAssetCategory);
 		}
-		catch (Exception exception) {
-			throw new ModelListenerException(exception);
+		catch (SearchException searchException) {
+			throw new ModelListenerException(searchException);
 		}
 	}
 

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryModelDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryModelDocumentContributor.java
@@ -8,6 +8,7 @@ package com.liferay.asset.categories.internal.search.spi.model.index.contributor
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -51,6 +52,10 @@ public class AssetCategoryModelDocumentContributor
 	public void contribute(Document document, AssetCategory assetCategory) {
 		document.addKeyword(
 			Field.ASSET_CATEGORY_ID, assetCategory.getCategoryId());
+		document.addNumber(
+			"childCategoriesCount",
+			_assetCategoryLocalService.getChildCategoriesCount(
+				assetCategory.getCategoryId()));
 
 		_addSearchAssetCategoryTitles(
 			document, Field.ASSET_CATEGORY_TITLE,
@@ -179,6 +184,9 @@ public class AssetCategoryModelDocumentContributor
 			return ReflectionUtil.throwException(portalException);
 		}
 	}
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
 
 	@Reference
 	private AssetVocabularyLocalService _assetVocabularyLocalService;

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryModelDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryModelDocumentContributor.java
@@ -52,10 +52,6 @@ public class AssetCategoryModelDocumentContributor
 	public void contribute(Document document, AssetCategory assetCategory) {
 		document.addKeyword(
 			Field.ASSET_CATEGORY_ID, assetCategory.getCategoryId());
-		document.addNumber(
-			"childCategoriesCount",
-			_assetCategoryLocalService.getChildCategoriesCount(
-				assetCategory.getCategoryId()));
 
 		_addSearchAssetCategoryTitles(
 			document, Field.ASSET_CATEGORY_TITLE,
@@ -91,6 +87,10 @@ public class AssetCategoryModelDocumentContributor
 			document, Field.TITLE, siteDefaultLocale,
 			assetCategory.getTitleMap());
 
+		document.addNumber(
+			"childCategoriesCount",
+			_assetCategoryLocalService.getChildCategoriesCount(
+				assetCategory.getCategoryId()));
 		document.addKeyword(
 			"classNameIds", _getClassNameIds(assetCategory.getVocabularyId()));
 		document.addLocalizedKeyword(

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerIndexedFieldsTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerIndexedFieldsTest.java
@@ -211,6 +211,16 @@ public class AssetCategoryIndexerIndexedFieldsTest {
 			"assetCategoryTitle_ja_JP",
 			StringUtil.lowerCase(assetCategory.getName())
 		).put(
+			"childCategoriesCount",
+			String.valueOf(
+				assetCategoryService.getChildCategoriesCount(
+					assetCategory.getCategoryId()))
+		).put(
+			"childCategoriesCount_sortable",
+			String.valueOf(
+				assetCategoryService.getChildCategoriesCount(
+					assetCategory.getCategoryId()))
+		).put(
 			"classNameIds",
 			StringUtil.merge(_getClassNameIds(assetCategory.getVocabularyId()))
 		).put(

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
@@ -7,6 +7,7 @@ package com.liferay.asset.categories.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
@@ -16,6 +17,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
@@ -113,13 +115,14 @@ public class AssetCategoryIndexerReindexTest {
 
 	@Test
 	public void testReindexChildCategoriesCount() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
 		AssetCategory parentAssetCategory =
 			_assetCategoryFixture.createAssetCategory();
 
-		assertFieldValues(
-			"childCategoriesCount",
-			Collections.singletonMap("childCategoriesCount", "0"),
-			LocaleUtil.US, parentAssetCategory.getName());
+		assertChildCategoriesCount(parentAssetCategory, "0");
 
 		AssetCategory childAssetCategory = assetCategoryService.addCategory(
 			parentAssetCategory.getGroupId(),
@@ -127,20 +130,51 @@ public class AssetCategoryIndexerReindexTest {
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			Collections.emptyMap(), parentAssetCategory.getVocabularyId(),
-			new String[0],
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+			new String[0], serviceContext);
 
 		_assetCategories.add(childAssetCategory);
 
-		assertFieldValues(
-			"childCategoriesCount",
-			Collections.singletonMap("childCategoriesCount", "1"),
-			LocaleUtil.US, parentAssetCategory.getName());
+		assertChildCategoriesCount(parentAssetCategory, "1");
+
+		AssetCategory newParentAssetCategory = assetCategoryService.addCategory(
+			parentAssetCategory.getGroupId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			Collections.emptyMap(), parentAssetCategory.getVocabularyId(),
+			new String[0], serviceContext);
+
+		_assetCategories.add(newParentAssetCategory);
+
+		assertChildCategoriesCount(newParentAssetCategory, "0");
+
+		assetCategoryService.moveCategory(
+			childAssetCategory.getCategoryId(),
+			newParentAssetCategory.getCategoryId(),
+			childAssetCategory.getVocabularyId(), serviceContext);
+
+		assertChildCategoriesCount(parentAssetCategory, "0");
+		assertChildCategoriesCount(newParentAssetCategory, "1");
+
+		assetCategoryService.deleteCategory(childAssetCategory.getCategoryId());
+
+		_assetCategories.remove(childAssetCategory);
+
+		assertChildCategoriesCount(newParentAssetCategory, "0");
 	}
 
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	protected void assertChildCategoriesCount(
+		AssetCategory assetCategory, String childCategoriesCount) {
+
+		assertFieldValues(
+			"childCategoriesCount",
+			Collections.singletonMap(
+				"childCategoriesCount", childCategoriesCount),
+			LocaleUtil.US, assetCategory.getName());
+	}
 
 	protected void assertFieldValues(
 		String fieldName, Map<String, String> map, Locale locale,

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
@@ -133,8 +133,6 @@ public class AssetCategoryIndexerReindexTest {
 
 		_assetCategories.add(childAssetCategory);
 
-		reindexAllIndexerModels();
-
 		assertFieldValues(
 			"childCategoriesCount",
 			Collections.singletonMap("childCategoriesCount", "1"),

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryIndexerReindexTest.java
@@ -19,6 +19,9 @@ import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
@@ -106,6 +109,36 @@ public class AssetCategoryIndexerReindexTest {
 		reindexAllIndexerModels();
 
 		assertFieldValues(fieldName, map, locale, searchTerm);
+	}
+
+	@Test
+	public void testReindexChildCategoriesCount() throws Exception {
+		AssetCategory parentAssetCategory =
+			_assetCategoryFixture.createAssetCategory();
+
+		assertFieldValues(
+			"childCategoriesCount",
+			Collections.singletonMap("childCategoriesCount", "0"),
+			LocaleUtil.US, parentAssetCategory.getName());
+
+		AssetCategory childAssetCategory = assetCategoryService.addCategory(
+			parentAssetCategory.getGroupId(),
+			parentAssetCategory.getCategoryId(),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			Collections.emptyMap(), parentAssetCategory.getVocabularyId(),
+			new String[0],
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_assetCategories.add(childAssetCategory);
+
+		reindexAllIndexerModels();
+
+		assertFieldValues(
+			"childCategoriesCount",
+			Collections.singletonMap("childCategoriesCount", "1"),
+			LocaleUtil.US, parentAssetCategory.getName());
 	}
 
 	@Rule

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
@@ -12,6 +12,7 @@ import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.IdEntityField;
+import com.liferay.portal.odata.entity.IntegerEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
@@ -38,6 +39,9 @@ public class CategoryEntityModel implements EntityModel {
 			new IdEntityField(
 				"projects", locale -> "projectDepotEntryGroupIds",
 				String::valueOf),
+			new IntegerEntityField(
+				"numberOfTaxonomyCategories",
+				locale -> Field.getSortableFieldName("childCategoriesCount")),
 			new StringEntityField(
 				"externalReferenceCode", locale -> "externalReferenceCode"),
 			new StringEntityField(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -45,7 +45,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -234,6 +233,16 @@ public class TaxonomyCategoryResourceTest
 
 	@Override
 	@Test
+	public void testGetAssetLibraryTaxonomyCategoriesPageWithSortInteger()
+		throws Exception {
+
+		_scopeType = Scope.Type.ASSET_LIBRARY;
+
+		super.testGetAssetLibraryTaxonomyCategoriesPageWithSortInteger();
+	}
+
+	@Override
+	@Test
 	public void testGetAssetLibraryTaxonomyCategoriesPageWithSortString()
 		throws Exception {
 
@@ -329,12 +338,6 @@ public class TaxonomyCategoryResourceTest
 
 		_addAssetCategory(
 			_assetVocabulary, new Date(), assetCategory2, serviceContext);
-
-		IndexerRegistryUtil.getIndexer(
-			AssetCategory.class
-		).reindexCompany(
-			testGroup.getCompanyId()
-		);
 
 		for (EntityField entityField : entityFields) {
 			_assertTaxonomyCategoriesPageOrder(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -288,6 +289,52 @@ public class TaxonomyCategoryResourceTest
 			parentAssetCategory, serviceContext);
 		AssetCategory assetCategory2 = _addAssetCategory(
 			_assetVocabulary, new Date(), parentAssetCategory, serviceContext);
+
+		for (EntityField entityField : entityFields) {
+			_assertTaxonomyCategoriesPageOrder(
+				entityField, assetCategory1, assetCategory2, "asc",
+				parentAssetCategory);
+			_assertTaxonomyCategoriesPageOrder(
+				entityField, assetCategory2, assetCategory1, "desc",
+				parentAssetCategory);
+		}
+	}
+
+	@Override
+	@Test
+	public void testGetTaxonomyCategoryTaxonomyCategoriesPageWithSortInteger()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.INTEGER);
+
+		if (ListUtil.isEmpty(entityFields)) {
+			return;
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		AssetCategory parentAssetCategory =
+			_assetCategoryLocalService.addCategory(
+				TestPropsValues.getUserId(), testGroup.getGroupId(),
+				RandomTestUtil.randomString(),
+				_assetVocabulary.getVocabularyId(), serviceContext);
+
+		AssetCategory assetCategory1 = _addAssetCategory(
+			_assetVocabulary, new Date(), parentAssetCategory, serviceContext);
+
+		AssetCategory assetCategory2 = _addAssetCategory(
+			_assetVocabulary, new Date(), parentAssetCategory, serviceContext);
+
+		_addAssetCategory(
+			_assetVocabulary, new Date(), assetCategory2, serviceContext);
+
+		IndexerRegistryUtil.getIndexer(
+			AssetCategory.class
+		).reindexCompany(
+			testGroup.getCompanyId()
+		);
 
 		for (EntityField entityField : entityFields) {
 			_assertTaxonomyCategoriesPageOrder(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102064

Continues #8802, opened by @janbrychtadotcom and picked up while he is on PTO. His two commits are carried over unchanged in content, split so a hotfix can take the fix without the tests. Everything @jkappler asked for on that PR is addressed below.

## What Is Being Fixed

Sorting a category's subcategories by the "Subcategories" column in CMS > Categorization always returns an HTTP 400. The column is bound to a live, per-request child-category count that was never registered as a sortable field in the OData entity model, so the sort parser rejects the request and a page refresh crashes the categories list.

## How It Is Being Fixed

The count is indexed at reindex time and registered as a sortable `IntegerEntityField`, the same way the sibling Vocabulary entity exposes its own category count.

That alone would trade the 400 for a worse failure. `@Indexable` reindexes only the category the service acted on, so a parent kept whatever count it had when it was last indexed, while the number the row displays stays a live query. The column would have started ordering by a number that disagrees with the one on screen. `AssetCategoryChildCategoriesCountModelListener` reindexes the parent on create and remove, and on a move reindexes both the parent left behind and the one joined. It skips import and staging, where categories arrive in bulk and the index is rebuilt afterwards, matching the guard the neighbouring `AssetCategoryFriendlyURLModelListener` already uses.

## What Changed Since #8802

| @jkappler asked | Resolution |
| --- | --- |
| `AssetCategoryIndexerIndexedFieldsTest` fails on the two undeclared entries | Declared, following the pair `AssetVocabularyIndexerIndexedFieldsTest` declares for its own count |
| The asset library `WithSortInteger` override is missing | Added; all four generated `WithSortInteger` tests now pass, including the two nobody overrode |
| Nothing reindexes the parent, so the column would sort wrongly | The model listener above |
| Tests as separate commits, for hotfix-ability | The four commits below |

On the staleness point he was right that the assertions only held because of the reindex call: **both counting tests now drop it**, so the parent being reindexed on its own is what makes them pass rather than test setup.

## Commits

```
4f6cf9f  Mikel Lorza   Assert the child categories count without a manual reindex
1c4771c  Mikel Lorza   Reindex the parent category when a subcategory changes
f394c3b  Jan Brychta   Test sorting categories by subcategories
2f8ca52  Jan Brychta   Fix 400 error when sorting categories by subcategories
```

## Test Execution

Ran the regression surface rather than only the tests named on #8802, since the contributor adds a field to every AssetCategory document and the listener fires on every category write.

| Suite | Result |
| --- | --- |
| `asset-categories-test` `search` package, 12 classes | 60 tests, 0 failures |
| `AssetCategoryLocalServiceTest` | 35, 0 |
| `AssetCategoryPortletDataHandlerTest` | 24, 0 |
| `AssetCategoryTableReferenceDefinitionTest` | 1, 0 |
| `TaxonomyCategoryResourceTest` | 92, 1 failure |

That one failure is `testGetTaxonomyCategoriesRankedPageWithPagination`. It fails in isolation too, and it still fails with master's versions of both production files deployed, verified with `javap` on the bundle jars that neither the new field nor the listener were present. It is not this branch's.

Also checked rather than assumed: registering an `IntegerEntityField` activates no filter test, because the generated base has `WithFilterDateTime`, `WithFilterDouble` and `WithFilterString` but no `WithFilterInteger`. Only the four sort tests activate.

## Out of Scope, Worth Its Own Ticket

The Vocabulary column this fix takes its shape from is stale in the same way, and measurably non-functional today: sorting the vocabularies of a site by `numberOfTaxonomyCategories` returns the **same order for `asc` and `desc`**, because every vocabulary carries the count it had when it was indexed, which is zero for any vocabulary that gained its categories afterwards. The listener here only keeps parent categories fresh, so that column is untouched.

## PR Check

**pr-check: PASS** — tested on `b23e6b5c66ca57439ef9e1e1337c604c52f58ee6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Java Unit Tests has no counterpart to run: neither `asset-categories-service` nor `headless-admin-taxonomy-impl` has a `src/test` directory.

<!-- pr-check {"result": "success", "sha": "b23e6b5c66ca57439ef9e1e1337c604c52f58ee6"} -->
