### PR TITLE
LPD-103657 Move a category's friendly URL with the category

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryFriendlyURLModelListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryFriendlyURLModelListener.java
@@ -8,6 +8,8 @@ package com.liferay.asset.categories.internal.model.listener;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -15,6 +17,9 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -48,6 +53,64 @@ public class AssetCategoryFriendlyURLModelListener
 				_friendlyURLEntryLocalService.getUniqueUrlTitleMap(
 					assetCategory.getGroupId(), classNameId, parentClassPK,
 					assetCategory.getCategoryId(), assetCategory.getTitleMap()),
+				new ServiceContext());
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
+	}
+
+	@Override
+	public void onAfterUpdate(
+			AssetCategory originalAssetCategory, AssetCategory assetCategory)
+		throws ModelListenerException {
+
+		try {
+			if (ExportImportThreadLocal.isImportInProcess() ||
+				ExportImportThreadLocal.isStagingInProcess()) {
+
+				return;
+			}
+
+			long parentClassPK = _getAssetCategoryParentClassPK(assetCategory);
+
+			if (parentClassPK == _getAssetCategoryParentClassPK(
+					originalAssetCategory)) {
+
+				return;
+			}
+
+			long classNameId = _classNameLocalService.getClassNameId(
+				AssetCategory.class);
+
+			FriendlyURLEntry friendlyURLEntry =
+				_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+					classNameId, assetCategory.getCategoryId());
+
+			if (friendlyURLEntry == null) {
+				return;
+			}
+
+			Map<String, String> urlTitleMap = new HashMap<>();
+
+			for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+					_friendlyURLEntryLocalService.
+						getFriendlyURLEntryLocalizations(
+							friendlyURLEntry.getFriendlyURLEntryId())) {
+
+				urlTitleMap.put(
+					friendlyURLEntryLocalization.getLanguageId(),
+					_friendlyURLEntryLocalService.getUniqueUrlTitle(
+						assetCategory.getGroupId(), classNameId, parentClassPK,
+						assetCategory.getCategoryId(),
+						friendlyURLEntryLocalization.getUrlTitle(),
+						friendlyURLEntryLocalization.getLanguageId()));
+			}
+
+			_friendlyURLEntryLocalService.updateFriendlyURLEntry(
+				friendlyURLEntry.getFriendlyURLEntryId(), classNameId,
+				parentClassPK, assetCategory.getCategoryId(),
+				friendlyURLEntry.getDefaultLanguageId(), urlTitleMap,
 				new ServiceContext());
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/model/listener/test/AssetCategoryFriendlyURLModelListenerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/model/listener/test/AssetCategoryFriendlyURLModelListenerTest.java
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class AssetCategoryFriendlyURLModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		_assetVocabularyId = assetVocabulary.getVocabularyId();
+
+		_parentAssetCategory = _addAssetCategory(
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		_assetCategory = _addAssetCategory(
+			_parentAssetCategory.getCategoryId());
+	}
+
+	@Test
+	public void testOnAfterUpdateWhenParentCategoryIdIsChanged()
+		throws Exception {
+
+		Assert.assertEquals(
+			_parentAssetCategory.getCategoryId(), _getParentClassPK());
+
+		AssetCategory assetCategory = _addAssetCategory(
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		_assetCategoryLocalService.moveCategory(
+			_assetCategory.getCategoryId(), assetCategory.getCategoryId(),
+			_assetVocabularyId,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Assert.assertEquals(assetCategory.getCategoryId(), _getParentClassPK());
+	}
+
+	@Test
+	public void testOnAfterUpdateWhenParentCategoryIdIsUnchanged()
+		throws Exception {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization1 =
+			_getFriendlyURLEntryLocalization();
+
+		_assetCategoryLocalService.updateCategory(
+			null, TestPropsValues.getUserId(), _assetCategory.getCategoryId(),
+			_assetCategory.getParentCategoryId(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				StringUtil.toLowerCase(StringUtil.randomString())
+			).build(),
+			new HashMap<>(), _assetVocabularyId, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization2 =
+			_getFriendlyURLEntryLocalization();
+
+		Assert.assertEquals(
+			_parentAssetCategory.getCategoryId(),
+			friendlyURLEntryLocalization2.getParentClassPK());
+		Assert.assertEquals(
+			friendlyURLEntryLocalization1.getUrlTitle(),
+			friendlyURLEntryLocalization2.getUrlTitle());
+	}
+
+	private AssetCategory _addAssetCategory(long parentAssetCategoryId)
+		throws Exception {
+
+		return _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			parentAssetCategoryId,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				StringUtil.toLowerCase(StringUtil.randomString())
+			).build(),
+			new HashMap<>(), _assetVocabularyId, false, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private FriendlyURLEntryLocalization _getFriendlyURLEntryLocalization()
+		throws Exception {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				_assetCategory.getCategoryId());
+
+		return _friendlyURLEntryLocalService.getFriendlyURLEntryLocalization(
+			friendlyURLEntry.getFriendlyURLEntryId(),
+			LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+	}
+
+	private long _getParentClassPK() throws Exception {
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			_getFriendlyURLEntryLocalization();
+
+		return friendlyURLEntryLocalization.getParentClassPK();
+	}
+
+	private AssetCategory _assetCategory;
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	private long _assetVocabularyId;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private AssetCategory _parentAssetCategory;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103657

## What Is Being Fixed

A category's display page URL mirrors its position in the hierarchy, but two different sources of truth build it and resolve it. `AssetCategoryLayoutDisplayPageObjectProvider.getURLTitle` composes the path from the live hierarchy through `AssetCategory.getAncestors()`, while `AssetCategoryLayoutDisplayPageProvider` resolves an incoming path by walking `FriendlyURLEntryLocalization.parentClassPK`. `AssetCategoryFriendlyURLModelListener` only implemented `onAfterCreate`, and `_moveCategory` does not touch friendly URLs, so moving a category to another parent left that column pointing at the previous parent and the two diverged.

The result is worse than a dead link. The path the product hands out is the one that 404s, while the stale path still resolves, so the portal issues a canonical redirect from the old URL to the new one and then fails to resolve where it just sent the user. Measured on a moved category, the old path returns 302 to the new path and the new path returns 404.

There is no repair through the UI either. Renaming the category does not regenerate its slug, so an affected category can only be fixed by deleting and recreating it, which loses its assignments.

## How It Is Being Fixed

`AssetCategoryFriendlyURLModelListener` gains `onAfterUpdate`, which returns early unless the parent actually changed and otherwise moves the category's friendly URL entry to the new parent. Each language goes through `getUniqueUrlTitle`, the same helper `onAfterCreate` uses, so a slug already taken under the destination gets the next free suffix rather than colliding. Import and staging are skipped, matching the guard the existing methods already carry.

## PR Check

**pr-check: PASS** — tested on `203700675dac6b7ad4166cce0561563922a10d68`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "203700675dac6b7ad4166cce0561563922a10d68"} -->
