### PR TITLE
LPD-103775 Assert the update date bulk actions on the All section

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -105,7 +105,7 @@ public class ViewAllSectionDisplayContextTest
 			getBulkActionDropdownItems();
 
 		Assert.assertEquals(
-			bulkActionDropdownItems.toString(), 15,
+			bulkActionDropdownItems.toString(), 17,
 			bulkActionDropdownItems.size());
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
@@ -136,22 +136,28 @@ public class ViewAllSectionDisplayContextTest
 			"semantic-search", "find-and-replace", "Find and Replace", null,
 			bulkActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"date-time", "update-expiration-date", "Update Expiration Date",
+			null, bulkActionDropdownItems.get(10));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"date-time", "update-review-date", "Update Review Date", null,
+			bulkActionDropdownItems.get(11));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "permissions", "Permissions", null,
-			bulkActionDropdownItems.get(10));
+			bulkActionDropdownItems.get(12));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "default-permissions", "Default Permissions",
-			null, bulkActionDropdownItems.get(11));
+			null, bulkActionDropdownItems.get(13));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-default-permissions-by-role",
 			"Edit Default Permissions by Role", null,
-			bulkActionDropdownItems.get(12));
+			bulkActionDropdownItems.get(14));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-permissions-by-role",
-			"Edit Permissions by Role", null, bulkActionDropdownItems.get(13));
+			"Edit Permissions by Role", null, bulkActionDropdownItems.get(15));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "reset-to-default-permissions",
 			"Reset to Default Permissions", null,
-			bulkActionDropdownItems.get(14));
+			bulkActionDropdownItems.get(16));
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103775

## What Is Being Fixed

`ViewAllSectionDisplayContextTest.testGetBulkActionDropdownItems` has been failing on master since LPD-97871 landed. That change added Update Expiration Date and Update Review Date to the bulk actions of the All section, right after Find and Replace, but it left the test asserting the previous fifteen items and the old positions of the five permission actions.

## How It Is Being Fixed

The expected count goes from fifteen to seventeen, two assertions cover the new date actions at positions ten and eleven, and the permission actions are reindexed from twelve to sixteen. The assertions stay in the order the display context builds the items, so the test keeps documenting where each bulk action sits rather than only that it exists.

## PR Check

**pr-check: PASS** — tested on `ea38db4ac1d86d106462f0c48a720cc0514cfc14`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Transaction Usage | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "ea38db4ac1d86d106462f0c48a720cc0514cfc14"} -->
