### PR TITLE
LPD-103688 Test sharing CMS content with external users by email

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/emailSharing.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/emailSharing.spec.ts
@@ -39,7 +39,7 @@ test(
 				);
 			});
 
-		const emailAddress = 'external@example.com';
+		const emailAddress = `external-${getRandomString()}@liferay.com`;
 
 		await test.step('Open the Share modal on the content', async () => {
 			await assetsPage.gotoContents(spaceName);
@@ -70,8 +70,6 @@ test(
 			await expect(page.getByText('(guest)')).toBeVisible();
 
 			await expect(page.getByText('To Be Shared')).toBeVisible();
-
-			await expect(page.getByLabel('Allow Resharing')).not.toBeVisible();
 		});
 
 		await test.step('Submit the share modal', async () => {
@@ -95,6 +93,17 @@ test(
 				emailAddress,
 				type: 'Email',
 			});
+		});
+
+		// Deleting the object entry deletes its sharing entries but never the
+		// invitation ticket, so the collaborator list has to be emptied here.
+
+		await test.step('Remove the invitation', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[],
+				'cms/basic-web-contents',
+				objectEntry.id
+			);
 		});
 	}
 );
@@ -194,7 +203,7 @@ test(
 
 		await test.step('Type a valid external email and verify the invite option is not offered', async () => {
 			await shareModalPage.typeInCollaboratorInput(
-				'external@example.com'
+				`external-${getRandomString()}@liferay.com`
 			);
 
 			await expect(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/emailSharing.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/emailSharing.spec.ts
@@ -212,3 +212,96 @@ test(
 		});
 	}
 );
+
+test(
+	'An invited external collaborator can be removed from the Share modal',
+	{tag: '@LPD-103688'},
+	async ({apiHelpers, assetsPage, page, shareModalPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await test.step('Create a new space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const objectEntryTitle = `Content ${getRandomString()}`;
+
+		const objectEntry =
+			await test.step('Create a content in the space', async () => {
+				return await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: objectEntryTitle,
+					},
+					'cms/basic-web-contents',
+					spaceName
+				);
+			});
+
+		const emailAddress = `external-${getRandomString()}@liferay.com`;
+
+		await test.step('Invite the external user', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						emailAddress,
+						share: false,
+						type: 'Email',
+					},
+				],
+				'cms/basic-web-contents',
+				objectEntry.id
+			);
+		});
+
+		await test.step('Open the Share modal on the content', async () => {
+			await assetsPage.gotoContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: objectEntryTitle,
+			});
+
+			await expect(
+				shareModalPage.getHeader(objectEntryTitle)
+			).toBeVisible();
+		});
+
+		await test.step('Verify the invited guest is listed', async () => {
+			await expect(
+				shareModalPage.collaborator(emailAddress)
+			).toBeVisible();
+
+			await expect(
+				page.getByText('Invited', {exact: true})
+			).toBeVisible();
+		});
+
+		await test.step('Remove the access and submit', async () => {
+			await shareModalPage.removeAccess(emailAddress);
+
+			await expect(
+				shareModalPage.collaborator(emailAddress)
+			).not.toBeVisible();
+
+			await shareModalPage.submit();
+
+			await expect(
+				shareModalPage.getHeader(objectEntryTitle)
+			).not.toBeVisible();
+		});
+
+		await test.step('Verify the invitation is gone from the server', async () => {
+			const collaborators =
+				await apiHelpers.objectEntry.getObjectEntryCollaboratorsPage(
+					'cms/basic-web-contents',
+					objectEntry.id
+				);
+
+			expect(collaborators).toHaveLength(0);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ShareModalPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ShareModalPage.ts
@@ -5,6 +5,8 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
+
 export class ShareModalPage {
 	readonly collaboratorInput: Locator;
 	readonly inviteExternalUserOption: Locator;
@@ -24,8 +26,31 @@ export class ShareModalPage {
 			.getByRole('button', {exact: true, name: 'Share'});
 	}
 
+	collaborator(name: string) {
+		return this.page.getByRole('listitem').filter({hasText: name});
+	}
+
 	getHeader(title: string) {
 		return this.page.getByText(`Share "${title}"`);
+	}
+
+	async removeAccess(name: string) {
+		const collaborator = this.collaborator(name);
+
+		// The dropdown menu renders outside the collaborator list item, so the
+		// menu item is scoped to the page and not to the collaborator.
+
+		const removeAccessItem = this.page.getByRole('menuitem', {
+			exact: true,
+			name: 'Remove Access',
+		});
+
+		await clickAndExpectToBeVisible({
+			target: removeAccessItem,
+			trigger: collaborator.getByLabel('More Options'),
+		});
+
+		await removeAccessItem.click();
 	}
 
 	async submit() {

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/fixtures/cmsPagesTest.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/fixtures/cmsPagesTest.ts
@@ -9,6 +9,7 @@ import {AssetsPage} from '../../main/pages/AssetsPage';
 import {ContentsPage} from '../../main/pages/ContentsPage';
 import {FolderPage} from '../../main/pages/FolderPage';
 import {HomePage} from '../../main/pages/HomePage';
+import {ShareModalPage} from '../../main/pages/ShareModalPage';
 import {SpaceSummaryPage} from '../../main/pages/SpaceSummaryPage';
 import {CopyFolderModalPage} from '../pages/CopyFolderModalPage';
 import {DefaultPermissionsPage} from '../pages/DefaultPermissionsPage';
@@ -24,6 +25,7 @@ const cmsPagesTest = test.extend<{
 	folderPage: FolderPage;
 	homePage: HomePage;
 	permissionsPage: PermissionsPage;
+	shareModalPage: ShareModalPage;
 	spaceSummaryPage: SpaceSummaryPage;
 }>({
 	assetsPage: async ({page}, use) => {
@@ -49,6 +51,9 @@ const cmsPagesTest = test.extend<{
 	},
 	permissionsPage: async ({page}, use) => {
 		await use(new PermissionsPage(page));
+	},
+	shareModalPage: async ({page}, use) => {
+		await use(new ShareModalPage(page));
 	},
 	spaceSummaryPage: async ({page}, use) => {
 		await use(new SpaceSummaryPage(page));

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/sharing.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/sharing.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
+import getRandomString from '../../../utils/getRandomString';
+import {
+	performLoginViaApi,
+	performUserSwitchViaApi,
+	userData,
+} from '../../../utils/performLogin';
+import {SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE} from '../../setup/site-cms-site/constants/space';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+
+const spaceName = 'Default';
+
+async function clearFirstSignInWalls(
+	apiHelpers: DataApiHelpers,
+	user: TUserAccount
+) {
+	await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+	await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+}
+
+let cmsAdminUser: TUserAccount;
+let setupData: Array<{id: number | string; type: string}>;
+let spaceAdminUser: TUserAccount;
+
+test.beforeAll(async ({browser}) => {
+	const page = await browser.newPage();
+
+	await performLoginViaApi({page, screenName: 'test'});
+
+	const apiHelpers = new DataApiHelpers(page);
+
+	cmsAdminUser = await addCMSAdministrator(apiHelpers);
+
+	apiHelpers.data.push({id: cmsAdminUser.id, type: 'userAccount'});
+
+	await clearFirstSignInWalls(apiHelpers, cmsAdminUser);
+
+	const addRoleUser = async (role: string) => {
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		apiHelpers.data.push({id: user.id, type: 'userAccount'});
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE,
+			user.externalReferenceCode
+		);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE,
+			user.externalReferenceCode,
+			[role]
+		);
+
+		await clearFirstSignInWalls(apiHelpers, user);
+
+		return user;
+	};
+
+	spaceAdminUser = await addRoleUser('Asset Library Administrator');
+
+	setupData = [...apiHelpers.data];
+
+	await page.close();
+});
+
+test.afterAll(async ({browser}) => {
+	const page = await browser.newPage();
+
+	await performLoginViaApi({page, screenName: 'test'});
+
+	const apiHelpers = new DataApiHelpers(page);
+
+	apiHelpers.setData(setupData);
+
+	await apiHelpers.clearData();
+
+	await page.close();
+});
+
+// The Space Member negative case lives in
+// tests/e2e-cms-dxp/main/sharing/sharingPermissions.spec.ts (@LPD-95527/TC-4.i).
+//
+// A Space Content Reviewer is deliberately not covered here. Epic LPD-52006
+// asks for it, but sharing is gated on owning the content or administering
+// its scope. SharingPermissionImpl.containsSharePermission opens for the
+// asset owner, for a sharing entry that allows resharing, and for
+// DepotPermissionCheckerWrapper.isGroupAdmin, which accepts CMS Administrator
+// and the Asset Library Administrator and Owner roles and not Asset Library
+// Content Reviewer. So a Content Reviewer shares what they created and not
+// what they review. Raised on LPD-85358.
+
+test(
+	'The Share action is available to a CMS Administrator and a Space Administrator',
+	{tag: ['@LPD-103688', '@LPD-95527']},
+	async ({apiHelpers, assetsPage, page, shareModalPage}) => {
+		const contentTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create a content for the Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		const expectShareActionAvailable = async (screenName: string) => {
+			await performUserSwitchViaApi(page, screenName);
+
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: contentTitle,
+			});
+
+			await expect(shareModalPage.getHeader(contentTitle)).toBeVisible();
+
+			await page.keyboard.press('Escape');
+
+			await expect(
+				shareModalPage.getHeader(contentTitle)
+			).not.toBeVisible();
+		};
+
+		await test.step('A CMS Administrator can open the Share modal', async () => {
+			await expectShareActionAvailable(cmsAdminUser.alternateName);
+		});
+
+		await test.step('A Space Administrator can open the Share modal', async () => {
+			await expectShareActionAvailable(spaceAdminUser.alternateName);
+		});
+	}
+);
+
+test(
+	'A Space Administrator can invite an external user by email',
+	{tag: ['@LPD-103688', '@LPD-85836']},
+	async ({apiHelpers, assetsPage, page, shareModalPage}) => {
+		const contentTitle = `Content ${getRandomString()}`;
+		const emailAddress = `external-${getRandomString()}@liferay.com`;
+
+		const objectEntry =
+			await test.step('Create a content for the Space', async () => {
+				return await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: contentTitle,
+					},
+					'cms/basic-web-contents',
+					spaceName
+				);
+			});
+
+		await test.step('Open the Share modal as a Space Administrator', async () => {
+			await performUserSwitchViaApi(page, spaceAdminUser.alternateName);
+
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: contentTitle,
+			});
+
+			await expect(shareModalPage.getHeader(contentTitle)).toBeVisible();
+		});
+
+		await test.step('Invite the external user and submit', async () => {
+			await shareModalPage.typeInCollaboratorInput(emailAddress);
+
+			await expect(shareModalPage.inviteExternalUserOption).toBeVisible();
+
+			await shareModalPage.inviteExternalUserOption.click();
+
+			await shareModalPage.submit();
+
+			await expect(
+				shareModalPage.getHeader(contentTitle)
+			).not.toBeVisible();
+		});
+
+		await test.step('Verify the invitation reached the server', async () => {
+			const collaborators =
+				await apiHelpers.objectEntry.getObjectEntryCollaboratorsPage(
+					'cms/basic-web-contents',
+					objectEntry.id
+				);
+
+			expect(collaborators).toHaveLength(1);
+			expect(collaborators[0]).toMatchObject({
+				actionIds: ['VIEW'],
+				emailAddress,
+				type: 'Email',
+			});
+		});
+
+		// Deleting the object entry deletes its sharing entries but never the
+		// invitation ticket, so the collaborator list has to be emptied here.
+
+		await test.step('Remove the invitation', async () => {
+			await performUserSwitchViaApi(page, 'test');
+
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[],
+				'cms/basic-web-contents',
+				objectEntry.id
+			);
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103688

## What Is Being Fixed

Epic LPD-52006, sharing CMS content with external users by email, shipped with its feature flag already removed, but its functional coverage had holes and the one Playwright test it had left state behind.

Which Space roles are offered the Share action was covered only for the negative case — a Space Member, in `tests/e2e-cms-dxp/main/sharing/sharingPermissions.spec.ts` — and the `site-cms-site-initializer` permissions project had no sharing coverage at all. Adding an external collaborator was covered, removing one was not. And `main/emailSharing.spec.ts` hardcoded the invited address, which collides across parallel runs, and leaked an `INVITE_COLLABORATOR` ticket every run: deleting an object entry deletes its sharing entries, but `TicketModelListener` only goes the other way.

## How It Is Being Fixed

Four commits, ordered so a hotfix can take the hygiene repair without the new tests.

The first fixes `main/emailSharing.spec.ts`: a random address per run, and a POST of an empty collaborator list at the end, which runs the `deleteTicket` loop in `CollaboratorUtil`. It also drops the assertion that "Allow Resharing" was not visible, which could never fail because that entry is a dropdown item and the test never opened the dropdown, and which claimed the opposite of what the modal does, since `CMSShareModalContent` does not pass `showAllowResharing`.

The second adds the page object work on its own so it can be cherry-picked: `ShareModalPage` gains the collaborator row locator and the removal action, and the permissions project exposes the page object its fixture was missing.

The third adds `permissions/sharing.spec.ts` with the Share action for a CMS Administrator and a Space Administrator, plus one external invite carried through and verified against `/collaborators` rather than against the modal. The fourth covers removing an invited external collaborator, creating the invitation through the API so that only the removal goes through the UI.

The scope is deliberately small because the rest of the epic is covered elsewhere, verified rather than assumed: `SharingEntryLocalServiceTest#testAddSharingEntryWithInviteCollaboratorTicket` asserts the invitation mail through `MailServiceTestUtil` and was run against this bundle at 56 tests and 0 failures, `CreateAccountUserMVCActionCommandTest` covers link to registration to sharing entry, `CMSShareModalContent.test.tsx` covers the modal, and `CollaboratorResourceTest` covers the `/collaborators` contract.

Two findings are raised on LPD-85358 instead of being tested here. A Space Content Reviewer is not offered the Share action on content it does not own, measured both ways, so what the epic asks for is an exception to a gate built on ownership and scope administration rather than a missing branch, and that needs a product decision. And an external invitee never receives an in-app notification, which makes the epic's "access from Notifications" bullet untestable as written.

## PR Check

**pr-check: PASS** — tested on `c40573be31f923e5048b483534c477272257a778`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile and JavaScript Unit Tests have no counterpart to run. `modules/test/playwright` is not in the modules Gradle graph — it carries no `.lfrbuild-portal` marker and its only task is `runPlaywright` — and it has no Jest suite, its `test` script being the Playwright runner, which pr-check puts out of scope.

Test execution, on the tested SHA: `permissions/sharing.spec.ts` plus `main/emailSharing.spec.ts`, `main/sharingPermissions.spec.ts` and `main/sharedWithMe.spec.ts`, the last three as regression controls because `ShareModalPage` is shared. 32 passed with `--repeat-each=2` — 15 tests twice over, plus the space setup and teardown — and 0 failures.

<!-- pr-check {"result": "success", "sha": "c40573be31f923e5048b483534c477272257a778"} -->
