### PR TITLE
LPD-97867 Group near duplicate CMS content into similar asset groups

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAsset.java
@@ -1,0 +1,416 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A CMS content asset that belongs to a similar asset group.",
+	value = "SimilarAsset"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A CMS content asset that belongs to a similar asset group."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarAsset")
+public class SimilarAsset implements Serializable {
+
+	public static SimilarAsset toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarAsset.class, json);
+	}
+
+	public static SimilarAsset unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(SimilarAsset.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The localized label of the asset's content type."
+	)
+	public String getContentType() {
+		if (_contentTypeSupplier != null) {
+			contentType = _contentTypeSupplier.get();
+
+			_contentTypeSupplier = null;
+		}
+
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+
+		_contentTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		_contentTypeSupplier = () -> {
+			try {
+				return contentTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The localized label of the asset's content type."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String contentType;
+
+	@JsonIgnore
+	private Supplier<String> _contentTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAsset)) {
+			return false;
+		}
+
+		SimilarAsset similarAsset = (SimilarAsset)object;
+
+		return Objects.equals(toString(), similarAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		String contentType = getContentType();
+
+		if (contentType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentType));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarAsset",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:628374762

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAssetGroup.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAssetGroup.java
@@ -1,0 +1,308 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A group of CMS content assets detected as near duplicates of one another.",
+	value = "SimilarAssetGroup"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A group of CMS content assets detected as near duplicates of one another."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarAssetGroup")
+public class SimilarAssetGroup implements Serializable {
+
+	public static SimilarAssetGroup toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarAssetGroup.class, json);
+	}
+
+	public static SimilarAssetGroup unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(SimilarAssetGroup.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The group's assets that fall inside the requested page. A group split across pages repeats in the next page with the remaining assets."
+	)
+	@Valid
+	public SimilarAsset[] getSimilarAssets() {
+		if (_similarAssetsSupplier != null) {
+			similarAssets = _similarAssetsSupplier.get();
+
+			_similarAssetsSupplier = null;
+		}
+
+		return similarAssets;
+	}
+
+	public void setSimilarAssets(SimilarAsset[] similarAssets) {
+		this.similarAssets = similarAssets;
+
+		_similarAssetsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSimilarAssets(
+		UnsafeSupplier<SimilarAsset[], Exception> similarAssetsUnsafeSupplier) {
+
+		_similarAssetsSupplier = () -> {
+			try {
+				return similarAssetsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The group's assets that fall inside the requested page. A group split across pages repeats in the next page with the remaining assets."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected SimilarAsset[] similarAssets;
+
+	@JsonIgnore
+	private Supplier<SimilarAsset[]> _similarAssetsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The total number of assets in the group, independent of the requested page."
+	)
+	public Integer getSize() {
+		if (_sizeSupplier != null) {
+			size = _sizeSupplier.get();
+
+			_sizeSupplier = null;
+		}
+
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+
+		_sizeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		_sizeSupplier = () -> {
+			try {
+				return sizeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The total number of assets in the group, independent of the requested page."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Integer size;
+
+	@JsonIgnore
+	private Supplier<Integer> _sizeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAssetGroup)) {
+			return false;
+		}
+
+		SimilarAssetGroup similarAssetGroup = (SimilarAssetGroup)object;
+
+		return Objects.equals(toString(), similarAssetGroup.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		SimilarAsset[] similarAssets = getSimilarAssets();
+
+		if (similarAssets != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarAssets.length; i++) {
+				sb.append(String.valueOf(similarAssets[i]));
+
+				if ((i + 1) < similarAssets.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Integer size = getSize();
+
+		if (size != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(size);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarAssetGroup",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1989429158

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarAssetGroupResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarAssetGroupResource.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetGroup;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-cms/v1.0
+ *
+ * @author Crescenzo Rega
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface SimilarAssetGroupResource {
+
+	public Page<SimilarAssetGroup> getSimilarAssetGroupsPage(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public SimilarAssetGroupResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1123368712

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAsset.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAsset implements Cloneable, Serializable {
+
+	public static SimilarAsset toDTO(String json) {
+		return SimilarAssetSerDes.toDTO(json);
+	}
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		try {
+			contentType = contentTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String contentType;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public SimilarAsset clone() throws CloneNotSupportedException {
+		return (SimilarAsset)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAsset)) {
+			return false;
+		}
+
+		SimilarAsset similarAsset = (SimilarAsset)object;
+
+		return Objects.equals(toString(), similarAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarAssetSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-522998368

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAssetGroup.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAssetGroup.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetGroupSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAssetGroup implements Cloneable, Serializable {
+
+	public static SimilarAssetGroup toDTO(String json) {
+		return SimilarAssetGroupSerDes.toDTO(json);
+	}
+
+	public SimilarAsset[] getSimilarAssets() {
+		return similarAssets;
+	}
+
+	public void setSimilarAssets(SimilarAsset[] similarAssets) {
+		this.similarAssets = similarAssets;
+	}
+
+	public void setSimilarAssets(
+		UnsafeSupplier<SimilarAsset[], Exception> similarAssetsUnsafeSupplier) {
+
+		try {
+			similarAssets = similarAssetsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected SimilarAsset[] similarAssets;
+
+	public Integer getSize() {
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+	}
+
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		try {
+			size = sizeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer size;
+
+	@Override
+	public SimilarAssetGroup clone() throws CloneNotSupportedException {
+		return (SimilarAssetGroup)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAssetGroup)) {
+			return false;
+		}
+
+		SimilarAssetGroup similarAssetGroup = (SimilarAssetGroup)object;
+
+		return Objects.equals(toString(), similarAssetGroup.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarAssetGroupSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:303157712

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarAssetGroupResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarAssetGroupResource.java
@@ -1,0 +1,283 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.resource.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetGroup;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetGroupSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public interface SimilarAssetGroupResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<SimilarAssetGroup> getSimilarAssetGroupsPage(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSimilarAssetGroupsPageHttpResponse(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public SimilarAssetGroupResource build() {
+			return new SimilarAssetGroupResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class SimilarAssetGroupResourceImpl
+		implements SimilarAssetGroupResource {
+
+		public Page<SimilarAssetGroup> getSimilarAssetGroupsPage(
+				Long assetLibraryId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSimilarAssetGroupsPageHttpResponse(
+					assetLibraryId, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, SimilarAssetGroupSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSimilarAssetGroupsPageHttpResponse(
+				Long assetLibraryId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetLibraryId != null) {
+				httpInvoker.parameter(
+					"assetLibraryId", String.valueOf(assetLibraryId));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cms/v1.0/similar-asset-groups");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private SimilarAssetGroupResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			SimilarAssetGroupResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-715117071

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetGroupSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetGroupSerDes.java
@@ -1,0 +1,256 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetGroup;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAssetGroupSerDes {
+
+	public static SimilarAssetGroup toDTO(String json) {
+		SimilarAssetGroupJSONParser similarAssetGroupJSONParser =
+			new SimilarAssetGroupJSONParser();
+
+		return similarAssetGroupJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarAssetGroup[] toDTOs(String json) {
+		SimilarAssetGroupJSONParser similarAssetGroupJSONParser =
+			new SimilarAssetGroupJSONParser();
+
+		return similarAssetGroupJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarAssetGroup similarAssetGroup) {
+		if (similarAssetGroup == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (similarAssetGroup.getSimilarAssets() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarAssetGroup.getSimilarAssets().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(similarAssetGroup.getSimilarAssets()[i]));
+
+				if ((i + 1) < similarAssetGroup.getSimilarAssets().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (similarAssetGroup.getSize() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(similarAssetGroup.getSize());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarAssetGroupJSONParser similarAssetGroupJSONParser =
+			new SimilarAssetGroupJSONParser();
+
+		return similarAssetGroupJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		SimilarAssetGroup similarAssetGroup) {
+
+		if (similarAssetGroup == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (similarAssetGroup.getSimilarAssets() == null) {
+			map.put("similarAssets", null);
+		}
+		else {
+			map.put(
+				"similarAssets",
+				String.valueOf(similarAssetGroup.getSimilarAssets()));
+		}
+
+		if (similarAssetGroup.getSize() == null) {
+			map.put("size", null);
+		}
+		else {
+			map.put("size", String.valueOf(similarAssetGroup.getSize()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarAssetGroupJSONParser
+		extends BaseJSONParser<SimilarAssetGroup> {
+
+		@Override
+		protected SimilarAssetGroup createDTO() {
+			return new SimilarAssetGroup();
+		}
+
+		@Override
+		protected SimilarAssetGroup[] createDTOArray(int size) {
+			return new SimilarAssetGroup[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "similarAssets")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarAssetGroup similarAssetGroup, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "similarAssets")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					SimilarAsset[] similarAssetsArray =
+						new SimilarAsset[jsonParserFieldValues.length];
+
+					for (int i = 0; i < similarAssetsArray.length; i++) {
+						similarAssetsArray[i] = SimilarAssetSerDes.toDTO(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					similarAssetGroup.setSimilarAssets(similarAssetsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				if (jsonParserFieldValue != null) {
+					similarAssetGroup.setSize(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1872620494

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetSerDes.java
@@ -1,0 +1,303 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAssetSerDes {
+
+	public static SimilarAsset toDTO(String json) {
+		SimilarAssetJSONParser similarAssetJSONParser =
+			new SimilarAssetJSONParser();
+
+		return similarAssetJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarAsset[] toDTOs(String json) {
+		SimilarAssetJSONParser similarAssetJSONParser =
+			new SimilarAssetJSONParser();
+
+		return similarAssetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarAsset similarAsset) {
+		if (similarAsset == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarAsset.getContentType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarAsset.getContentType()));
+
+			sb.append("\"");
+		}
+
+		if (similarAsset.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(similarAsset.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (similarAsset.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(similarAsset.getId());
+		}
+
+		if (similarAsset.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarAsset.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarAssetJSONParser similarAssetJSONParser =
+			new SimilarAssetJSONParser();
+
+		return similarAssetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(SimilarAsset similarAsset) {
+		if (similarAsset == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarAsset.getContentType() == null) {
+			map.put("contentType", null);
+		}
+		else {
+			map.put(
+				"contentType", String.valueOf(similarAsset.getContentType()));
+		}
+
+		if (similarAsset.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(similarAsset.getDateModified()));
+		}
+
+		if (similarAsset.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(similarAsset.getId()));
+		}
+
+		if (similarAsset.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(similarAsset.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarAssetJSONParser
+		extends BaseJSONParser<SimilarAsset> {
+
+		@Override
+		protected SimilarAsset createDTO() {
+			return new SimilarAsset();
+		}
+
+		@Override
+		protected SimilarAsset[] createDTOArray(int size) {
+			return new SimilarAsset[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarAsset similarAsset, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setContentType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setTitle((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:2041123751

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -97,6 +97,42 @@ components:
         ResetAssetPermissionAction:
             allOf:
                 -   $ref: "#/components/schemas/AssetPermissionAction"
+        SimilarAsset:
+            description:
+                A CMS content asset that belongs to a similar asset group.
+            properties:
+                contentType:
+                    description:
+                        The localized label of the asset's content type.
+                    readOnly: true
+                    type: string
+                dateModified:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                title:
+                    readOnly: true
+                    type: string
+        SimilarAssetGroup:
+            description:
+                A group of CMS content assets detected as near duplicates of one another.
+            properties:
+                similarAssets:
+                    description:
+                        The group's assets that fall inside the requested page. A group split across pages repeats in the next page with the remaining assets.
+                    items:
+                        $ref: "#/components/schemas/SimilarAsset"
+                    readOnly: true
+                    type: array
+                size:
+                    description:
+                        The total number of assets in the group, independent of the requested page.
+                    readOnly: true
+                    type: integer
 info:
     license:
         name: Apache 2.0
@@ -226,3 +262,36 @@ paths:
                                     $ref: "#/components/schemas/BrokenLinkAsset"
                                 type: array
             tags: ["BrokenLinkAsset"]
+    "/similar-asset-groups":
+        get:
+            description:
+                List the groups of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and grouping always spans the whole space, so a group's size never depends on the requested page. Omit assetLibraryId to span all accessible spaces. Note that totalCount counts the grouped assets while the items are the groups that hold them, so it is the number of assets that have a near duplicate rather than a page count, and a group that straddles a page boundary is returned on both pages with its full size.
+            operationId: getSimilarAssetGroupsPage
+            parameters:
+                -   in: query
+                    name: assetLibraryId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SimilarAssetGroup"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SimilarAssetGroup"
+                                type: array
+            tags: ["SimilarAssetGroup"]

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -8,9 +8,11 @@ package com.liferay.headless.cms.internal.graphql.query.v1_0;
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.dto.v1_0.AssetUsage;
 import com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetGroup;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
 import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetGroupResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -66,6 +68,14 @@ public class Query {
 
 		_brokenLinkAssetResourceComponentServiceObjects =
 			brokenLinkAssetResourceComponentServiceObjects;
+	}
+
+	public static void setSimilarAssetGroupResourceComponentServiceObjects(
+		ComponentServiceObjects<SimilarAssetGroupResource>
+			similarAssetGroupResourceComponentServiceObjects) {
+
+		_similarAssetGroupResourceComponentServiceObjects =
+			similarAssetGroupResourceComponentServiceObjects;
 	}
 
 	/**
@@ -132,6 +142,29 @@ public class Query {
 					Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(
 						brokenLinkAssetResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {similarAssetGroups(assetLibraryId: ___, page: ___, pageSize: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "List the groups of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and grouping always spans the whole space, so a group's size never depends on the requested page. Omit assetLibraryId to span all accessible spaces. Note that totalCount counts the grouped assets while the items are the groups that hold them, so it is the number of assets that have a near duplicate rather than a page count, and a group that straddles a page boundary is returned on both pages with its full size."
+	)
+	public SimilarAssetGroupPage similarAssetGroups(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_similarAssetGroupResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			similarAssetGroupResource -> new SimilarAssetGroupPage(
+				similarAssetGroupResource.getSimilarAssetGroupsPage(
+					Long.valueOf(assetLibraryId),
+					Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLName("AssetStatisticsPage")
@@ -233,6 +266,39 @@ public class Query {
 
 	}
 
+	@GraphQLName("SimilarAssetGroupPage")
+	public class SimilarAssetGroupPage {
+
+		public SimilarAssetGroupPage(Page similarAssetGroupPage) {
+			actions = similarAssetGroupPage.getActions();
+
+			items = similarAssetGroupPage.getItems();
+			lastPage = similarAssetGroupPage.getLastPage();
+			page = similarAssetGroupPage.getPage();
+			pageSize = similarAssetGroupPage.getPageSize();
+			totalCount = similarAssetGroupPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<SimilarAssetGroup> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R
 			_applyComponentServiceObjects(
 				ComponentServiceObjects<T> componentServiceObjects,
@@ -309,12 +375,34 @@ public class Query {
 		brokenLinkAssetResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private void _populateResourceContext(
+			SimilarAssetGroupResource similarAssetGroupResource)
+		throws Exception {
+
+		similarAssetGroupResource.setContextAcceptLanguage(_acceptLanguage);
+		similarAssetGroupResource.setContextCompany(_company);
+		similarAssetGroupResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		similarAssetGroupResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		similarAssetGroupResource.setContextUriInfo(_uriInfo);
+		similarAssetGroupResource.setContextUser(_user);
+		similarAssetGroupResource.setGroupLocalService(_groupLocalService);
+		similarAssetGroupResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarAssetGroupResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarAssetGroupResource.setRoleLocalService(_roleLocalService);
+	}
+
 	private static ComponentServiceObjects<AssetStatisticsResource>
 		_assetStatisticsResourceComponentServiceObjects;
 	private static ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BrokenLinkAssetResource>
 		_brokenLinkAssetResourceComponentServiceObjects;
+	private static ComponentServiceObjects<SimilarAssetGroupResource>
+		_similarAssetGroupResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
 	private com.liferay.portal.kernel.model.Company _company;
@@ -333,4 +421,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-802839611
+// LIFERAY-REST-BUILDER-HASH:-534871514

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -11,10 +11,12 @@ import com.liferay.headless.cms.internal.resource.v1_0.AssetPermissionActionReso
 import com.liferay.headless.cms.internal.resource.v1_0.AssetStatisticsResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetUsageResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.BrokenLinkAssetResourceImpl;
+import com.liferay.headless.cms.internal.resource.v1_0.SimilarAssetGroupResourceImpl;
 import com.liferay.headless.cms.resource.v1_0.AssetPermissionActionResource;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
 import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetGroupResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 
@@ -49,6 +51,8 @@ public class ServletDataImpl implements ServletData {
 			_assetUsageResourceComponentServiceObjects);
 		Query.setBrokenLinkAssetResourceComponentServiceObjects(
 			_brokenLinkAssetResourceComponentServiceObjects);
+		Query.setSimilarAssetGroupResourceComponentServiceObjects(
+			_similarAssetGroupResourceComponentServiceObjects);
 	}
 
 	public String getApplicationName() {
@@ -106,6 +110,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							BrokenLinkAssetResourceImpl.class,
 							"getBrokenLinkAssetsPage"));
+					put(
+						"query#similarAssetGroups",
+						new ObjectValuePair<>(
+							SimilarAssetGroupResourceImpl.class,
+							"getSimilarAssetGroupsPage"));
 				}
 			};
 
@@ -125,5 +134,9 @@ public class ServletDataImpl implements ServletData {
 	private ComponentServiceObjects<BrokenLinkAssetResource>
 		_brokenLinkAssetResourceComponentServiceObjects;
 
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarAssetGroupResource>
+		_similarAssetGroupResourceComponentServiceObjects;
+
 }
-// LIFERAY-REST-BUILDER-HASH:1309969940
+// LIFERAY-REST-BUILDER-HASH:-1292353404

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarAssetGroupResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarAssetGroupResourceImpl.java
@@ -1,0 +1,536 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetGroup;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetGroupResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseSimilarAssetGroupResourceImpl
+	implements SimilarAssetGroupResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-cms/v1.0/similar-asset-groups'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "List the groups of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and grouping always spans the whole space, so a group's size never depends on the requested page. Omit assetLibraryId to span all accessible spaces. Note that totalCount counts the grouped assets while the items are the groups that hold them, so it is the number of assets that have a near duplicate rather than a page count, and a group that straddles a page boundary is returned on both pages with its full size."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "SimilarAssetGroup")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/similar-asset-groups")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<SimilarAssetGroup> getSimilarAssetGroupsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetLibraryId")
+			Long assetLibraryId,
+			@jakarta.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-cms";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSimilarAssetGroupResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:92532725

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -93,9 +93,11 @@ public class OpenAPIResourceImpl {
 
 			add(BrokenLinkAssetResourceImpl.class);
 
+			add(SimilarAssetGroupResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-529876021
+// LIFERAY-REST-BUILDER-HASH:1343595549

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarAssetGroupResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarAssetGroupResourceImpl.java
@@ -1,0 +1,631 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.headless.cms.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetGroup;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetGroupResource;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.IncludeExcludeClause;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.GroupUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/similar-asset-group.properties",
+	scope = ServiceScope.PROTOTYPE, service = SimilarAssetGroupResource.class
+)
+public class SimilarAssetGroupResourceImpl
+	extends BaseSimilarAssetGroupResourceImpl {
+
+	@Override
+	public Page<SimilarAssetGroup> getSimilarAssetGroupsPage(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-82226")) {
+
+			return Page.of(new ArrayList<>(), pagination, 0);
+		}
+
+		Long[] groupIds = _getGroupIds(assetLibraryId);
+		List<ObjectDefinition> objectDefinitions = _getCMSObjectDefinitions();
+
+		if (ArrayUtil.isEmpty(groupIds) || objectDefinitions.isEmpty()) {
+			return Page.of(new ArrayList<>(), pagination, 0);
+		}
+
+		String[] entryClassNames = ArrayUtil.toStringArray(
+			ListUtil.toList(objectDefinitions, ObjectDefinition::getClassName));
+
+		List<String> sharedSimilarAssetBuckets =
+			_searchSharedSimilarAssetBuckets(entryClassNames, groupIds);
+
+		Map<Long, List<Long>> objectEntryIdsMap = _getObjectEntryIdsMap(
+			_searchSharedSimilarAssetBucketDocuments(
+				entryClassNames, groupIds, sharedSimilarAssetBuckets),
+			new HashSet<>(sharedSimilarAssetBuckets));
+
+		long totalCount = 0;
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			totalCount += objectEntryIds.size();
+		}
+
+		Map<Long, ObjectDefinition> objectDefinitionsMap = new HashMap<>();
+
+		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			objectDefinitionsMap.put(
+				objectDefinition.getObjectDefinitionId(), objectDefinition);
+		}
+
+		return Page.of(
+			_getSimilarAssetGroups(
+				objectDefinitionsMap, objectEntryIdsMap, pagination),
+			pagination, totalCount);
+	}
+
+	private List<ObjectDefinition> _getCMSObjectDefinitions() throws Exception {
+		return _objectDefinitionService.getCMSObjectDefinitions(
+			contextCompany.getCompanyId(),
+			new String[] {
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+			});
+	}
+
+	private Map<Long, List<Long>> _getGroupedObjectEntryIdsMap(
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Map<Long, List<Long>> objectEntryIdsMap = new LinkedHashMap<>();
+
+		for (Long objectEntryId : parentObjectEntryIds.keySet()) {
+			List<Long> rootObjectEntryIds = objectEntryIdsMap.computeIfAbsent(
+				_getRootObjectEntryId(objectEntryId, parentObjectEntryIds),
+				rootObjectEntryId -> new ArrayList<>());
+
+			rootObjectEntryIds.add(objectEntryId);
+		}
+
+		Map<Long, List<Long>> groupedObjectEntryIdsMap = new HashMap<>();
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			if (objectEntryIds.size() < 2) {
+				continue;
+			}
+
+			Collections.sort(objectEntryIds);
+
+			groupedObjectEntryIdsMap.put(objectEntryIds.get(0), objectEntryIds);
+		}
+
+		return _getSortedObjectEntryIdsMap(groupedObjectEntryIdsMap);
+	}
+
+	private Long[] _getGroupIds(Long assetLibraryId) {
+		List<Long> depotEntryGroupIds =
+			_depotEntryService.getDepotEntryGroupIds(
+				contextCompany.getCompanyId(), contextUser.getUserId(),
+				DepotConstants.TYPE_SPACE);
+
+		if (assetLibraryId == null) {
+			return depotEntryGroupIds.toArray(new Long[0]);
+		}
+
+		Long groupId = GroupUtil.getDepotGroupId(
+			String.valueOf(assetLibraryId), contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService);
+
+		if ((groupId == null) || !depotEntryGroupIds.contains(groupId)) {
+			return new Long[0];
+		}
+
+		return new Long[] {groupId};
+	}
+
+	private Map<Long, List<Long>> _getObjectEntryIdsMap(
+		List<Document> documents, Set<String> sharedSimilarAssetBuckets) {
+
+		Map<Long, Long> parentObjectEntryIds = new LinkedHashMap<>();
+		Map<String, List<Long>> objectEntryIdsMap = new HashMap<>();
+
+		for (Document document : documents) {
+			Long objectEntryId = document.getLong("objectEntryId");
+
+			if (objectEntryId == null) {
+				continue;
+			}
+
+			parentObjectEntryIds.putIfAbsent(objectEntryId, objectEntryId);
+
+			for (String similarAssetBucket :
+					document.getStrings("similarAssetBuckets")) {
+
+				if (!sharedSimilarAssetBuckets.contains(similarAssetBucket)) {
+					continue;
+				}
+
+				List<Long> similarAssetBucketObjectEntryIds =
+					objectEntryIdsMap.computeIfAbsent(
+						similarAssetBucket, key -> new ArrayList<>());
+
+				similarAssetBucketObjectEntryIds.add(objectEntryId);
+			}
+		}
+
+		_mergeDuplicateObjectEntryIds(objectEntryIdsMap, parentObjectEntryIds);
+
+		return _getGroupedObjectEntryIdsMap(parentObjectEntryIds);
+	}
+
+	private Long _getRootObjectEntryId(
+		Long objectEntryId, Map<Long, Long> parentObjectEntryIds) {
+
+		Long rootObjectEntryId = objectEntryId;
+
+		Long parentObjectEntryId = parentObjectEntryIds.get(rootObjectEntryId);
+
+		while (!parentObjectEntryId.equals(rootObjectEntryId)) {
+			rootObjectEntryId = parentObjectEntryId;
+
+			parentObjectEntryId = parentObjectEntryIds.get(rootObjectEntryId);
+		}
+
+		while (!objectEntryId.equals(rootObjectEntryId)) {
+			objectEntryId = parentObjectEntryIds.put(
+				objectEntryId, rootObjectEntryId);
+		}
+
+		return rootObjectEntryId;
+	}
+
+	private Consumer<SearchContext> _getSearchContextConsumer(Long[] groupIds) {
+		long[] scopedGroupIds = ArrayUtil.toArray(groupIds);
+
+		return searchContext -> {
+			searchContext.setAttribute(
+				Field.STATUS, WorkflowConstants.STATUS_APPROVED);
+			searchContext.setGroupIds(scopedGroupIds);
+
+			searchContext.setUserId(contextUser.getUserId());
+		};
+	}
+
+	private List<SimilarAssetGroup> _getSimilarAssetGroups(
+			Map<Long, ObjectDefinition> objectDefinitionsMap,
+			Map<Long, List<Long>> objectEntryIdsMap, Pagination pagination)
+		throws Exception {
+
+		List<SimilarAssetGroup> similarAssetGroups = new ArrayList<>();
+
+		int endPosition = -1;
+		int startPosition = -1;
+
+		if (pagination != null) {
+			endPosition = pagination.getEndPosition();
+			startPosition = pagination.getStartPosition();
+		}
+
+		int position = 0;
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			int groupStartPosition = position;
+
+			position += objectEntryIds.size();
+
+			List<Long> pageObjectEntryIds = objectEntryIds;
+
+			if ((endPosition >= 0) && (startPosition >= 0)) {
+				if (position <= startPosition) {
+					continue;
+				}
+
+				if (groupStartPosition >= endPosition) {
+					break;
+				}
+
+				pageObjectEntryIds = objectEntryIds.subList(
+					Math.max(startPosition - groupStartPosition, 0),
+					Math.min(
+						endPosition - groupStartPosition,
+						objectEntryIds.size()));
+			}
+
+			similarAssetGroups.add(
+				_toSimilarAssetGroup(
+					objectDefinitionsMap, pageObjectEntryIds,
+					objectEntryIds.size()));
+		}
+
+		return similarAssetGroups;
+	}
+
+	private Map<Long, List<Long>> _getSortedObjectEntryIdsMap(
+		Map<Long, List<Long>> objectEntryIdsMap) {
+
+		List<Long> lowestObjectEntryIds = ListUtil.fromMapKeys(
+			objectEntryIdsMap);
+
+		lowestObjectEntryIds.sort(
+			Comparator.comparingInt(
+				(Long lowestObjectEntryId) -> {
+					List<Long> objectEntryIds = objectEntryIdsMap.get(
+						lowestObjectEntryId);
+
+					return objectEntryIds.size();
+				}
+			).reversed(
+			).thenComparing(
+				Comparator.naturalOrder()
+			));
+
+		Map<Long, List<Long>> sortedObjectEntryIdsMap = new LinkedHashMap<>();
+
+		for (Long lowestObjectEntryId : lowestObjectEntryIds) {
+			sortedObjectEntryIdsMap.put(
+				lowestObjectEntryId,
+				objectEntryIdsMap.get(lowestObjectEntryId));
+		}
+
+		return sortedObjectEntryIdsMap;
+	}
+
+	private void _mergeDuplicateObjectEntryIds(
+		Map<String, List<Long>> objectEntryIdsMap,
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Map<Long, List<String>> similarAssetBucketsMap = new LinkedHashMap<>();
+		Map<Long, Map<Long, Integer>> sharedSimilarAssetBucketCounts =
+			new HashMap<>();
+
+		for (Map.Entry<String, List<Long>> entry :
+				objectEntryIdsMap.entrySet()) {
+
+			List<Long> objectEntryIds = entry.getValue();
+
+			if (objectEntryIds.size() > _MAX_ASSETS_PER_SIMILAR_ASSET_BUCKET) {
+				for (Long objectEntryId : objectEntryIds) {
+					List<String> similarAssetBuckets =
+						similarAssetBucketsMap.computeIfAbsent(
+							objectEntryId, key -> new ArrayList<>());
+
+					similarAssetBuckets.add(entry.getKey());
+				}
+
+				continue;
+			}
+
+			for (int i = 0; i < objectEntryIds.size(); i++) {
+				for (int j = i + 1; j < objectEntryIds.size(); j++) {
+					Long objectEntryId1 = objectEntryIds.get(i);
+					Long objectEntryId2 = objectEntryIds.get(j);
+
+					Long rootObjectEntryId1 = _getRootObjectEntryId(
+						objectEntryId1, parentObjectEntryIds);
+					Long rootObjectEntryId2 = _getRootObjectEntryId(
+						objectEntryId2, parentObjectEntryIds);
+
+					if (rootObjectEntryId1.equals(rootObjectEntryId2)) {
+						continue;
+					}
+
+					Map<Long, Integer> counts =
+						sharedSimilarAssetBucketCounts.computeIfAbsent(
+							Math.min(objectEntryId1, objectEntryId2),
+							objectEntryId -> new HashMap<>());
+
+					int count = counts.merge(
+						Math.max(objectEntryId1, objectEntryId2), 1,
+						Integer::sum);
+
+					if (count >= _MIN_SHARED_SIMILAR_ASSET_BUCKETS) {
+						_mergeObjectEntryIds(
+							objectEntryId1, objectEntryId2,
+							parentObjectEntryIds);
+					}
+				}
+			}
+		}
+
+		_mergeObjectEntryIds(similarAssetBucketsMap, parentObjectEntryIds);
+	}
+
+	private void _mergeObjectEntryIds(
+		Long objectEntryId1, Long objectEntryId2,
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Long rootObjectEntryId1 = _getRootObjectEntryId(
+			objectEntryId1, parentObjectEntryIds);
+		Long rootObjectEntryId2 = _getRootObjectEntryId(
+			objectEntryId2, parentObjectEntryIds);
+
+		if (!rootObjectEntryId1.equals(rootObjectEntryId2)) {
+			parentObjectEntryIds.put(rootObjectEntryId1, rootObjectEntryId2);
+		}
+	}
+
+	private void _mergeObjectEntryIds(
+		Map<Long, List<String>> similarAssetBucketsMap,
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Map<String, Long> objectEntryIdsMap = new HashMap<>();
+
+		for (Map.Entry<Long, List<String>> entry :
+				similarAssetBucketsMap.entrySet()) {
+
+			List<String> similarAssetBuckets = entry.getValue();
+
+			if (similarAssetBuckets.size() <
+					_MIN_SHARED_SIMILAR_ASSET_BUCKETS) {
+
+				continue;
+			}
+
+			Long objectEntryId = objectEntryIdsMap.putIfAbsent(
+				StringUtil.merge(similarAssetBuckets), entry.getKey());
+
+			if (objectEntryId != null) {
+				_mergeObjectEntryIds(
+					objectEntryId, entry.getKey(), parentObjectEntryIds);
+			}
+		}
+	}
+
+	private List<Document> _searchSharedSimilarAssetBucketDocuments(
+		String[] entryClassNames, Long[] groupIds,
+		List<String> sharedSimilarAssetBuckets) {
+
+		List<Document> documents = new ArrayList<>();
+
+		if (sharedSimilarAssetBuckets.isEmpty()) {
+			return documents;
+		}
+
+		TermsQuery termsQuery = QueriesUtil.terms("similarAssetBuckets");
+
+		termsQuery.addValues(sharedSimilarAssetBuckets.toArray());
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).addComplexQueryPart(
+				_complexQueryPartBuilderFactory.builder(
+				).occur(
+					"must"
+				).query(
+					termsQuery
+				).build()
+			).companyId(
+				contextCompany.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				entryClassNames
+			).fetchSourceIncludes(
+				new String[] {"objectEntryId", "similarAssetBuckets"}
+			).size(
+				_MAX_DOCUMENTS
+			).withSearchContext(
+				_getSearchContextConsumer(groupIds)
+			).build());
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		for (SearchHit searchHit : searchHits.getSearchHits()) {
+			documents.add(searchHit.getDocument());
+		}
+
+		return documents;
+	}
+
+	private List<String> _searchSharedSimilarAssetBuckets(
+		String[] entryClassNames, Long[] groupIds) {
+
+		List<String> sharedSimilarAssetBuckets = new ArrayList<>();
+
+		TermsAggregation termsAggregation = _aggregations.terms(
+			_SIMILAR_ASSET_BUCKETS_AGGREGATION_NAME, "similarAssetBuckets");
+
+		termsAggregation.setMinDocCount(2);
+		termsAggregation.setIncludeExcludeClause(
+			new IncludeExcludeClauseImpl(
+				contextAcceptLanguage.getPreferredLanguageId() + "_.*", null));
+		termsAggregation.setSize(_MAX_SIMILAR_ASSET_BUCKETS);
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).addAggregation(
+				termsAggregation
+			).companyId(
+				contextCompany.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				entryClassNames
+			).size(
+				0
+			).withSearchContext(
+				_getSearchContextConsumer(groupIds)
+			).build());
+
+		TermsAggregationResult termsAggregationResult =
+			(TermsAggregationResult)searchResponse.getAggregationResult(
+				_SIMILAR_ASSET_BUCKETS_AGGREGATION_NAME);
+
+		if (termsAggregationResult == null) {
+			return sharedSimilarAssetBuckets;
+		}
+
+		for (Bucket bucket : termsAggregationResult.getBuckets()) {
+			sharedSimilarAssetBuckets.add(bucket.getKey());
+		}
+
+		return sharedSimilarAssetBuckets;
+	}
+
+	private SimilarAssetGroup _toSimilarAssetGroup(
+			Map<Long, ObjectDefinition> objectDefinitionsMap,
+			List<Long> objectEntryIds, int size)
+		throws Exception {
+
+		SimilarAssetGroup similarAssetGroup = new SimilarAssetGroup();
+
+		SimilarAsset[] similarAssets = transformToArray(
+			objectEntryIds,
+			objectEntryId -> {
+				ObjectEntry objectEntry =
+					_objectEntryLocalService.fetchObjectEntry(objectEntryId);
+
+				if (objectEntry == null) {
+					return null;
+				}
+
+				SimilarAsset similarAsset = new SimilarAsset();
+
+				similarAsset.setDateModified(objectEntry::getModifiedDate);
+				similarAsset.setId(() -> objectEntryId);
+				similarAsset.setTitle(
+					() -> objectEntry.getTitleValue(
+						contextAcceptLanguage.getPreferredLanguageId(), true));
+
+				ObjectDefinition objectDefinition = objectDefinitionsMap.get(
+					objectEntry.getObjectDefinitionId());
+
+				if (objectDefinition != null) {
+					similarAsset.setContentType(
+						() -> objectDefinition.getLabel(
+							contextAcceptLanguage.getPreferredLanguageId(),
+							true));
+				}
+
+				return similarAsset;
+			},
+			SimilarAsset.class);
+
+		similarAssetGroup.setSimilarAssets(() -> similarAssets);
+
+		similarAssetGroup.setSize(() -> size);
+
+		return similarAssetGroup;
+	}
+
+	private static final int _MAX_ASSETS_PER_SIMILAR_ASSET_BUCKET = 500;
+
+	private static final int _MAX_DOCUMENTS = 10000;
+
+	private static final int _MAX_SIMILAR_ASSET_BUCKETS = 10000;
+
+	private static final int _MIN_SHARED_SIMILAR_ASSET_BUCKETS = 3;
+
+	private static final String _SIMILAR_ASSET_BUCKETS_AGGREGATION_NAME =
+		"similarAssetBuckets";
+
+	@Reference
+	private Aggregations _aggregations;
+
+	@Reference
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private DepotEntryService _depotEntryService;
+
+	@Reference
+	private ObjectDefinitionService _objectDefinitionService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	private static class IncludeExcludeClauseImpl
+		implements IncludeExcludeClause {
+
+		public IncludeExcludeClauseImpl(
+			String includeRegex, String excludeRegex) {
+
+			_includeRegex = includeRegex;
+			_excludeRegex = excludeRegex;
+		}
+
+		@Override
+		public String[] getExcludedValues() {
+			return null;
+		}
+
+		@Override
+		public String getExcludeRegex() {
+			return _excludeRegex;
+		}
+
+		@Override
+		public String[] getIncludedValues() {
+			return null;
+		}
+
+		@Override
+		public String getIncludeRegex() {
+			return _includeRegex;
+		}
+
+		private final String _excludeRegex;
+		private final String _includeRegex;
+
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarAssetGroupResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarAssetGroupResourceFactoryImpl.java
@@ -1,0 +1,336 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0.factory;
+
+import com.liferay.headless.cms.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetGroupResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-cms/v1.0/SimilarAssetGroup",
+	service = SimilarAssetGroupResource.Factory.class
+)
+@Generated("")
+public class SimilarAssetGroupResourceFactoryImpl
+	implements SimilarAssetGroupResource.Factory {
+
+	@Override
+	public SimilarAssetGroupResource.Builder create() {
+		return new SimilarAssetGroupResource.Builder() {
+
+			@Override
+			public SimilarAssetGroupResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, SimilarAssetGroupResource>
+					similarAssetGroupResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_similarAssetGroupResourceProxyProviderFunction;
+
+				return similarAssetGroupResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public SimilarAssetGroupResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetGroupResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetGroupResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetGroupResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetGroupResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetGroupResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, SimilarAssetGroupResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			SimilarAssetGroupResource.class.getClassLoader(),
+			SimilarAssetGroupResource.class);
+
+		try {
+			Constructor<SimilarAssetGroupResource> constructor =
+				(Constructor<SimilarAssetGroupResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		SimilarAssetGroupResource similarAssetGroupResource =
+			_componentServiceObjects.getService();
+
+		similarAssetGroupResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		similarAssetGroupResource.setContextCompany(company);
+
+		similarAssetGroupResource.setContextHttpServletRequest(
+			httpServletRequest);
+		similarAssetGroupResource.setContextHttpServletResponse(
+			httpServletResponse);
+		similarAssetGroupResource.setContextUriInfo(uriInfo);
+		similarAssetGroupResource.setContextUser(user);
+		similarAssetGroupResource.setExpressionConvert(_expressionConvert);
+		similarAssetGroupResource.setFilterParserProvider(
+			_filterParserProvider);
+		similarAssetGroupResource.setGroupLocalService(_groupLocalService);
+		similarAssetGroupResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarAssetGroupResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarAssetGroupResource.setRoleLocalService(_roleLocalService);
+		similarAssetGroupResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(similarAssetGroupResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(similarAssetGroupResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarAssetGroupResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, SimilarAssetGroupResource>
+				_similarAssetGroupResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:723912047

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similar-asset-group.properties
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similar-asset-group.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.cms.dto.v1_0.SimilarAssetGroup
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.CMS)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarAssetGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarAssetGroupResourceTestCase.java
@@ -1,0 +1,961 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetGroup;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.SimilarAssetGroupResource;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetGroupSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.JAXRSWhiteboardTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public abstract class BaseSimilarAssetGroupResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		JAXRSWhiteboardTestUtil.ensureReady();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_similarAssetGroupResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		similarAssetGroupResource = SimilarAssetGroupResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarAssetGroup similarAssetGroup1 = randomSimilarAssetGroup();
+
+		String json = objectMapper.writeValueAsString(similarAssetGroup1);
+
+		SimilarAssetGroup similarAssetGroup2 = SimilarAssetGroupSerDes.toDTO(
+			json);
+
+		Assert.assertTrue(equals(similarAssetGroup1, similarAssetGroup2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarAssetGroup similarAssetGroup = randomSimilarAssetGroup();
+
+		String json1 = objectMapper.writeValueAsString(similarAssetGroup);
+		String json2 = SimilarAssetGroupSerDes.toJSON(similarAssetGroup);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		SimilarAssetGroup similarAssetGroup = randomSimilarAssetGroup();
+
+		String json = SimilarAssetGroupSerDes.toJSON(similarAssetGroup);
+
+		Assert.assertFalse(json.contains(regex));
+
+		similarAssetGroup = SimilarAssetGroupSerDes.toDTO(json);
+	}
+
+	@Test
+	public void testGetSimilarAssetGroupsPage() throws Exception {
+		Page<SimilarAssetGroup> page =
+			similarAssetGroupResource.getSimilarAssetGroupsPage(
+				null, Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		SimilarAssetGroup similarAssetGroup1 =
+			testGetSimilarAssetGroupsPage_addSimilarAssetGroup(
+				randomSimilarAssetGroup());
+
+		SimilarAssetGroup similarAssetGroup2 =
+			testGetSimilarAssetGroupsPage_addSimilarAssetGroup(
+				randomSimilarAssetGroup());
+
+		page = similarAssetGroupResource.getSimilarAssetGroupsPage(
+			null, Pagination.of(1, (int)totalCount + 2));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(
+			similarAssetGroup1, (List<SimilarAssetGroup>)page.getItems());
+		assertContains(
+			similarAssetGroup2, (List<SimilarAssetGroup>)page.getItems());
+		assertValid(page, testGetSimilarAssetGroupsPage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetSimilarAssetGroupsPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetSimilarAssetGroupsPageWithPagination() throws Exception {
+		Page<SimilarAssetGroup> similarAssetGroupsPage =
+			similarAssetGroupResource.getSimilarAssetGroupsPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			similarAssetGroupsPage.getTotalCount());
+
+		SimilarAssetGroup similarAssetGroup1 =
+			testGetSimilarAssetGroupsPage_addSimilarAssetGroup(
+				randomSimilarAssetGroup());
+
+		SimilarAssetGroup similarAssetGroup2 =
+			testGetSimilarAssetGroupsPage_addSimilarAssetGroup(
+				randomSimilarAssetGroup());
+
+		SimilarAssetGroup similarAssetGroup3 =
+			testGetSimilarAssetGroupsPage_addSimilarAssetGroup(
+				randomSimilarAssetGroup());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<SimilarAssetGroup> page1 =
+				similarAssetGroupResource.getSimilarAssetGroupsPage(
+					null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				similarAssetGroup1, (List<SimilarAssetGroup>)page1.getItems());
+
+			Page<SimilarAssetGroup> page2 =
+				similarAssetGroupResource.getSimilarAssetGroupsPage(
+					null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				similarAssetGroup2, (List<SimilarAssetGroup>)page2.getItems());
+
+			Page<SimilarAssetGroup> page3 =
+				similarAssetGroupResource.getSimilarAssetGroupsPage(
+					null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				similarAssetGroup3, (List<SimilarAssetGroup>)page3.getItems());
+		}
+		else {
+			Page<SimilarAssetGroup> page1 =
+				similarAssetGroupResource.getSimilarAssetGroupsPage(
+					null, Pagination.of(1, totalCount + 2));
+
+			List<SimilarAssetGroup> similarAssetGroups1 =
+				(List<SimilarAssetGroup>)page1.getItems();
+
+			Assert.assertEquals(
+				similarAssetGroups1.toString(), totalCount + 2,
+				similarAssetGroups1.size());
+
+			Page<SimilarAssetGroup> page2 =
+				similarAssetGroupResource.getSimilarAssetGroupsPage(
+					null, Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<SimilarAssetGroup> similarAssetGroups2 =
+				(List<SimilarAssetGroup>)page2.getItems();
+
+			Assert.assertEquals(
+				similarAssetGroups2.toString(), 1, similarAssetGroups2.size());
+
+			Page<SimilarAssetGroup> page3 =
+				similarAssetGroupResource.getSimilarAssetGroupsPage(
+					null, Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(
+				similarAssetGroup1, (List<SimilarAssetGroup>)page3.getItems());
+			assertContains(
+				similarAssetGroup2, (List<SimilarAssetGroup>)page3.getItems());
+			assertContains(
+				similarAssetGroup3, (List<SimilarAssetGroup>)page3.getItems());
+		}
+	}
+
+	protected SimilarAssetGroup
+			testGetSimilarAssetGroupsPage_addSimilarAssetGroup(
+				SimilarAssetGroup similarAssetGroup)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertContains(
+		SimilarAssetGroup similarAssetGroup,
+		List<SimilarAssetGroup> similarAssetGroups) {
+
+		boolean contains = false;
+
+		for (SimilarAssetGroup item : similarAssetGroups) {
+			if (equals(similarAssetGroup, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			similarAssetGroups + " does not contain " + similarAssetGroup,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		SimilarAssetGroup similarAssetGroup1,
+		SimilarAssetGroup similarAssetGroup2) {
+
+		Assert.assertTrue(
+			similarAssetGroup1 + " does not equal " + similarAssetGroup2,
+			equals(similarAssetGroup1, similarAssetGroup2));
+	}
+
+	protected void assertEquals(
+		List<SimilarAssetGroup> similarAssetGroups1,
+		List<SimilarAssetGroup> similarAssetGroups2) {
+
+		Assert.assertEquals(
+			similarAssetGroups1.size(), similarAssetGroups2.size());
+
+		for (int i = 0; i < similarAssetGroups1.size(); i++) {
+			SimilarAssetGroup similarAssetGroup1 = similarAssetGroups1.get(i);
+			SimilarAssetGroup similarAssetGroup2 = similarAssetGroups2.get(i);
+
+			assertEquals(similarAssetGroup1, similarAssetGroup2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<SimilarAssetGroup> similarAssetGroups1,
+		List<SimilarAssetGroup> similarAssetGroups2) {
+
+		Assert.assertEquals(
+			similarAssetGroups1.size(), similarAssetGroups2.size());
+
+		for (SimilarAssetGroup similarAssetGroup1 : similarAssetGroups1) {
+			boolean contains = false;
+
+			for (SimilarAssetGroup similarAssetGroup2 : similarAssetGroups2) {
+				if (equals(similarAssetGroup1, similarAssetGroup2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				similarAssetGroups2 + " does not contain " + similarAssetGroup1,
+				contains);
+		}
+	}
+
+	protected void assertValid(SimilarAssetGroup similarAssetGroup)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("similarAssets", additionalAssertFieldName)) {
+				if (similarAssetGroup.getSimilarAssets() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("size", additionalAssertFieldName)) {
+				if (similarAssetGroup.getSize() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<SimilarAssetGroup> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<SimilarAssetGroup> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<SimilarAssetGroup> similarAssetGroups =
+			page.getItems();
+
+		int size = similarAssetGroups.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.cms.dto.v1_0.SimilarAssetGroup.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		SimilarAssetGroup similarAssetGroup1,
+		SimilarAssetGroup similarAssetGroup2) {
+
+		if (similarAssetGroup1 == similarAssetGroup2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("similarAssets", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						similarAssetGroup1.getSimilarAssets(),
+						similarAssetGroup2.getSimilarAssets())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("size", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						similarAssetGroup1.getSize(),
+						similarAssetGroup2.getSize())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_similarAssetGroupResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_similarAssetGroupResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		SimilarAssetGroup similarAssetGroup) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("similarAssets")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("size")) {
+			sb.append(String.valueOf(similarAssetGroup.getSize()));
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected SimilarAssetGroup randomSimilarAssetGroup() throws Exception {
+		return new SimilarAssetGroup() {
+			{
+				size = RandomTestUtil.randomInt();
+			}
+		};
+	}
+
+	protected SimilarAssetGroup randomIrrelevantSimilarAssetGroup()
+		throws Exception {
+
+		SimilarAssetGroup randomIrrelevantSimilarAssetGroup =
+			randomSimilarAssetGroup();
+
+		return randomIrrelevantSimilarAssetGroup;
+	}
+
+	protected SimilarAssetGroup randomPatchSimilarAssetGroup()
+		throws Exception {
+
+		return randomSimilarAssetGroup();
+	}
+
+	protected SimilarAssetGroupResource similarAssetGroupResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSimilarAssetGroupResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.cms.resource.v1_0.SimilarAssetGroupResource
+		_similarAssetGroupResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-162978469

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarAssetGroupResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarAssetGroupResourceTest.java
@@ -1,0 +1,615 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetGroup;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.SimilarAssetGroupResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlag("LPD-82226")
+@RunWith(Arquillian.class)
+public class SimilarAssetGroupResourceTest
+	extends BaseSimilarAssetGroupResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetSimilarAssetGroupsPage() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		Page<SimilarAssetGroup> similarAssetGroupsPage =
+			_getSimilarAssetGroupsPage(groupId, null);
+
+		Assert.assertEquals(0, similarAssetGroupsPage.getTotalCount());
+
+		List<SimilarAssetGroup> similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 0, similarAssetGroups.size());
+
+		ObjectEntry duplicateObjectEntry1 = _addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT);
+		ObjectEntry duplicateObjectEntry2 = _addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT +
+				" You can also contact support for help.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT);
+
+		similarAssetGroupsPage = _getSimilarAssetGroupsPage(groupId, null);
+
+		Assert.assertEquals(2, similarAssetGroupsPage.getTotalCount());
+
+		similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 1, similarAssetGroups.size());
+
+		SimilarAssetGroup similarAssetGroup = similarAssetGroups.get(0);
+
+		Assert.assertEquals(
+			2, GetterUtil.getInteger(similarAssetGroup.getSize()));
+
+		SimilarAsset[] similarAssets = similarAssetGroup.getSimilarAssets();
+
+		Assert.assertEquals(
+			Arrays.toString(similarAssets), 2, similarAssets.length);
+
+		List<Long> objectEntryIds = new ArrayList<>();
+
+		for (SimilarAsset similarAssetGroupAsset : similarAssets) {
+			objectEntryIds.add(similarAssetGroupAsset.getId());
+
+			Assert.assertEquals(
+				_NEAR_DUPLICATE_TITLE, similarAssetGroupAsset.getTitle());
+			Assert.assertNotNull(similarAssetGroupAsset.getContentType());
+			Assert.assertNotNull(similarAssetGroupAsset.getDateModified());
+		}
+
+		Assert.assertTrue(
+			objectEntryIds.contains(duplicateObjectEntry1.getObjectEntryId()));
+		Assert.assertTrue(
+			objectEntryIds.contains(duplicateObjectEntry2.getObjectEntryId()));
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+
+		_testGetSimilarAssetGroupPermissions();
+		_testGetSimilarAssetGroupTranslation();
+	}
+
+	@Override
+	@Test
+	public void testGetSimilarAssetGroupsPageWithPagination() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		_addObjectEntries(depotEntry);
+
+		Page<SimilarAssetGroup> similarAssetGroupsPage =
+			_getSimilarAssetGroupsPage(groupId, Pagination.of(1, 2));
+
+		Assert.assertEquals(5, similarAssetGroupsPage.getTotalCount());
+
+		List<SimilarAssetGroup> similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 1, similarAssetGroups.size());
+
+		_assertSimilarAssetGroup(
+			similarAssetGroups.get(0), 3,
+			new String[] {"Big Summer Sale", "Summer Sale 2026"});
+
+		similarAssetGroupsPage = _getSimilarAssetGroupsPage(
+			groupId, Pagination.of(2, 2));
+
+		Assert.assertEquals(5, similarAssetGroupsPage.getTotalCount());
+
+		similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 2, similarAssetGroups.size());
+
+		_assertSimilarAssetGroup(
+			similarAssetGroups.get(0), 3,
+			new String[] {"Summer Sale Highlights"});
+		_assertSimilarAssetGroup(
+			similarAssetGroups.get(1), 2, new String[] {_PRODUCT_LAUNCH_TITLE});
+
+		similarAssetGroupsPage = _getSimilarAssetGroupsPage(
+			groupId, Pagination.of(3, 2));
+
+		Assert.assertEquals(5, similarAssetGroupsPage.getTotalCount());
+
+		similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 1, similarAssetGroups.size());
+
+		_assertSimilarAssetGroup(
+			similarAssetGroups.get(0), 2, new String[] {_PRODUCT_LAUNCH_TITLE});
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	@Test
+	public void testGraphQLGetSimilarAssetGroupsPage() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT +
+				" You can also contact support for help.");
+
+		GraphQLField graphQLField = new GraphQLField(
+			"similarAssetGroups",
+			HashMapBuilder.<String, Object>put(
+				"assetLibraryId", "\"" + depotEntry.getGroupId() + "\""
+			).build(),
+			new GraphQLField("items", new GraphQLField("size")),
+			new GraphQLField("totalCount"));
+
+		JSONObject similarAssetGroupsPageJSONObject =
+			JSONUtil.getValueAsJSONObject(
+				invokeGraphQLQuery(graphQLField), "JSONObject/data",
+				"JSONObject/similarAssetGroups");
+
+		Assert.assertEquals(
+			2, similarAssetGroupsPageJSONObject.getLong("totalCount"));
+
+		JSONArray similarAssetGroupsJSONArray =
+			similarAssetGroupsPageJSONObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			similarAssetGroupsJSONArray.toString(), 1,
+			similarAssetGroupsJSONArray.length());
+
+		JSONObject similarAssetGroupJSONObject =
+			similarAssetGroupsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(2, similarAssetGroupJSONObject.getInt("size"));
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private void _addObjectEntries(DepotEntry depotEntry) throws Exception {
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Big Summer Sale",
+			_SUMMER_SALE_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Summer Sale 2026",
+			_SUMMER_SALE_CONTENT + " The offer ends this Sunday.");
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Summer Sale Highlights",
+			_SUMMER_SALE_CONTENT +
+				" The offer ends this Sunday and stock is limited.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _PRODUCT_LAUNCH_TITLE,
+			_PRODUCT_LAUNCH_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, _PRODUCT_LAUNCH_TITLE,
+			_PRODUCT_LAUNCH_CONTENT +
+				" Contact the press office for further details.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT);
+	}
+
+	private ObjectEntry _addObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content)
+		throws Exception {
+
+		return _addObjectEntry(
+			depotEntry, objectDefinition, title, content,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content, ServiceContext serviceContext)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)content
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)title
+				).build()
+			).build(),
+			serviceContext);
+	}
+
+	private DepotEntry _addSpaceDepotEntry(ServiceContext serviceContext)
+		throws Exception {
+
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+	}
+
+	private ObjectEntry _addTranslatedObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content, String spanishTitle,
+			String spanishContent)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", content
+				).put(
+					"es_ES", spanishContent
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", title
+				).put(
+					"es_ES", spanishTitle
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertSimilarAssetGroup(
+		SimilarAssetGroup similarAssetGroup, int size, String[] titles) {
+
+		Assert.assertEquals(
+			size, GetterUtil.getInteger(similarAssetGroup.getSize()));
+
+		SimilarAsset[] similarAssets = similarAssetGroup.getSimilarAssets();
+
+		Assert.assertEquals(
+			Arrays.toString(similarAssets), titles.length,
+			similarAssets.length);
+
+		for (int i = 0; i < titles.length; i++) {
+			SimilarAsset similarAssetGroupAsset = similarAssets[i];
+
+			Assert.assertEquals(titles[i], similarAssetGroupAsset.getTitle());
+		}
+	}
+
+	private String _getAdminUserEmailAddress() throws Exception {
+		User user = UserTestUtil.getAdminUser(testCompany.getCompanyId());
+
+		return user.getEmailAddress();
+	}
+
+	private ObjectDefinition _getBasicWebContentObjectDefinition()
+		throws Exception {
+
+		Group cmsGroup = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+	}
+
+	private Page<SimilarAssetGroup> _getSimilarAssetGroupsPage(
+			long groupId, Pagination pagination)
+		throws Exception {
+
+		return similarAssetGroupResource.getSimilarAssetGroupsPage(
+			groupId, pagination);
+	}
+
+	private void _testGetSimilarAssetGroupPermissions() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT);
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT +
+				" You can also contact support for help.");
+
+		Page<SimilarAssetGroup> similarAssetGroupsPage =
+			_getSimilarAssetGroupsPage(groupId, null);
+
+		Assert.assertEquals(2, similarAssetGroupsPage.getTotalCount());
+
+		List<SimilarAssetGroup> similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		_assertSimilarAssetGroup(
+			similarAssetGroups.get(0), 2,
+			new String[] {_NEAR_DUPLICATE_TITLE, _NEAR_DUPLICATE_TITLE});
+
+		// The CMS grants VIEW on every content to the user role and to the
+		// space member role, so hiding one asset takes revoking both
+
+		for (String name :
+				new String[] {
+					DepotRolesConstants.ASSET_LIBRARY_MEMBER, RoleConstants.USER
+				}) {
+
+			Role role = _roleLocalService.getRole(
+				testCompany.getCompanyId(), name);
+
+			_resourcePermissionLocalService.setResourcePermissions(
+				testCompany.getCompanyId(), objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				role.getRoleId(), new String[0]);
+		}
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userLocalService.addGroupUser(groupId, user.getUserId());
+
+		SimilarAssetGroupResource userSimilarAssetGroupResource =
+			SimilarAssetGroupResource.builder(
+			).authentication(
+				user.getEmailAddress(), password
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		similarAssetGroupsPage =
+			userSimilarAssetGroupResource.getSimilarAssetGroupsPage(
+				groupId, null);
+
+		Assert.assertEquals(0, similarAssetGroupsPage.getTotalCount());
+
+		similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 0, similarAssetGroups.size());
+
+		_userLocalService.deleteUser(user);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private void _testGetSimilarAssetGroupTranslation() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addTranslatedObjectEntry(
+			depotEntry, objectDefinition, _NEAR_DUPLICATE_TITLE,
+			_NEAR_DUPLICATE_CONTENT, "Oferta de Verano Grande",
+			_SPANISH_SUMMER_SALE_CONTENT);
+		_addTranslatedObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT, "Oferta de Verano 2026",
+			_SPANISH_SUMMER_SALE_CONTENT + " La oferta acaba el domingo.");
+
+		SimilarAssetGroupResource spanishSimilarAssetGroupResource =
+			SimilarAssetGroupResource.builder(
+			).authentication(
+				_getAdminUserEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.SPAIN
+			).build();
+
+		Page<SimilarAssetGroup> similarAssetGroupsPage =
+			spanishSimilarAssetGroupResource.getSimilarAssetGroupsPage(
+				groupId, null);
+
+		Assert.assertEquals(2, similarAssetGroupsPage.getTotalCount());
+
+		List<SimilarAssetGroup> similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 1, similarAssetGroups.size());
+
+		_assertSimilarAssetGroup(
+			similarAssetGroups.get(0), 2,
+			new String[] {"Oferta de Verano Grande", "Oferta de Verano 2026"});
+
+		similarAssetGroupsPage = _getSimilarAssetGroupsPage(groupId, null);
+
+		Assert.assertEquals(0, similarAssetGroupsPage.getTotalCount());
+
+		similarAssetGroups =
+			(List<SimilarAssetGroup>)similarAssetGroupsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetGroups.toString(), 0, similarAssetGroups.size());
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private static final String _DISTINCT_CONTENT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market with product categories in retail and wholesale " +
+				"increasing during the last fiscal period.";
+
+	private static final String _NEAR_DUPLICATE_CONTENT =
+		"If you forgot your password go to the login page and click the " +
+			"forgot password link enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	private static final String _NEAR_DUPLICATE_TITLE = "Reset Your Password";
+
+	private static final String _PRODUCT_LAUNCH_CONTENT =
+		"The new generation of our platform is available today with a " +
+			"redesigned workspace faster search and a set of integrations " +
+				"that our customers have been asking for during this year.";
+
+	private static final String _PRODUCT_LAUNCH_TITLE =
+		"Product Launch Press Release";
+
+	private static final String _SPANISH_SUMMER_SALE_CONTENT =
+		"Nuestras rebajas de verano traen descuentos de hasta el cincuenta " +
+			"por ciento en toda la coleccion de exterior incluidas tiendas " +
+				"mochilas y botas de montana mientras queden existencias.";
+
+	private static final String _SUMMER_SALE_CONTENT =
+		"Our summer sale brings discounts of up to fifty percent on every " +
+			"outdoor collection including tents backpacks and hiking boots " +
+				"while stock lasts in all of our stores.";
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer/bnd.bnd
@@ -3,3 +3,4 @@ Bundle-SymbolicName: com.liferay.site.cms.site.initializer
 Bundle-Version: 1.0.37
 Web-ContextPath: /site-cms-site-initializer
 -dsannotations-options: inherit
+-fixupmessages: Classes found in the wrong directory: ...;is:=ignore

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileInclude group: "com.dynatrace.hash4j", name: "hash4j", version: "0.30.0"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractor.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.HtmlParser;
+
+import java.io.Serializable;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSContentSimilarAssetTextExtractor {
+
+	public CMSContentSimilarAssetTextExtractor(HtmlParser htmlParser) {
+		_htmlParser = htmlParser;
+	}
+
+	public Set<String> getLanguageIds(ObjectEntry objectEntry)
+		throws Exception {
+
+		Set<String> languageIds = new LinkedHashSet<>();
+
+		languageIds.add(objectEntry.getDefaultLanguageId());
+
+		Map<String, Serializable> indexedValues =
+			objectEntry.getIndexedValues();
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		for (ObjectField objectField :
+				_getSignatureObjectFields(objectDefinition)) {
+
+			if (!objectField.isLocalized()) {
+				continue;
+			}
+
+			Object localizedValues = indexedValues.get(
+				objectField.getI18nObjectFieldName());
+
+			if (!(localizedValues instanceof Map)) {
+				continue;
+			}
+
+			Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+			for (Object languageId : localizedValuesMap.keySet()) {
+				languageIds.add(String.valueOf(languageId));
+			}
+		}
+
+		return languageIds;
+	}
+
+	public String getText(String languageId, ObjectEntry objectEntry)
+		throws Exception {
+
+		Map<String, Serializable> indexedValues =
+			objectEntry.getIndexedValues();
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		StringBundler sb = new StringBundler();
+
+		for (ObjectField objectField :
+				_getSignatureObjectFields(objectDefinition)) {
+
+			Object indexedValue = null;
+
+			if (objectField.isLocalized()) {
+				Object localizedValues = indexedValues.get(
+					objectField.getI18nObjectFieldName());
+
+				if (localizedValues instanceof Map) {
+					Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+					indexedValue = localizedValuesMap.get(languageId);
+				}
+			}
+			else {
+				indexedValue = indexedValues.get(objectField.getName());
+			}
+
+			if (indexedValue == null) {
+				continue;
+			}
+
+			String indexedValueString = String.valueOf(indexedValue);
+
+			if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+				indexedValueString = _htmlParser.extractText(
+					indexedValueString);
+			}
+
+			sb.append(indexedValueString);
+			sb.append(CharPool.SPACE);
+		}
+
+		return sb.toString();
+	}
+
+	private Iterable<ObjectField> _getSignatureObjectFields(
+		ObjectDefinition objectDefinition) {
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		Set<ObjectField> objectFields = new LinkedHashSet<>();
+
+		for (ObjectField objectField :
+				objectFieldBag.getIndexedObjectFields()) {
+
+			if (_isTitleObjectField(objectDefinition, objectField)) {
+				continue;
+			}
+
+			if (_isTextObjectField(objectField)) {
+				objectFields.add(objectField);
+			}
+		}
+
+		return objectFields;
+	}
+
+	private boolean _isTextObjectField(ObjectField objectField) {
+		String businessType = objectField.getBusinessType();
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_TEXT) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isTitleObjectField(
+		ObjectDefinition objectDefinition, ObjectField objectField) {
+
+		if (objectField.getObjectFieldId() ==
+				objectDefinition.getTitleObjectFieldId()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private final HtmlParser _htmlParser;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtil.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.dynatrace.hash4j.hashing.Hasher64;
+import com.dynatrace.hash4j.hashing.Hashing;
+import com.dynatrace.hash4j.similarity.ElementHashProvider;
+import com.dynatrace.hash4j.similarity.SimilarityHashPolicy;
+import com.dynatrace.hash4j.similarity.SimilarityHashing;
+import com.dynatrace.hash4j.similarity.SuperMinHashVersion;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Mikel Lorza
+ */
+public class SimilarAssetUtil {
+
+	public static String[] getSimilarAssetBuckets(String text) {
+		if (text == null) {
+			return new String[0];
+		}
+
+		Set<String> wordSequences = _getWordSequences(text);
+
+		if (wordSequences.isEmpty()) {
+			return new String[0];
+		}
+
+		byte[] similarityHash = _similarityHashPolicy.createHasher(
+		).compute(
+			ElementHashProvider.ofCollection(
+				wordSequences, _hasher64::hashCharsToLong)
+		);
+
+		String[] similarAssetBuckets = new String[_SIMILAR_ASSET_BUCKETS];
+
+		for (int i = 0; i < _SIMILAR_ASSET_BUCKETS; i++) {
+			StringBundler sb = new StringBundler(
+				(_SAMPLES_PER_SIMILAR_ASSET_BUCKET * 2) + 2);
+
+			sb.append("b");
+			sb.append(i);
+
+			for (int j = 0; j < _SAMPLES_PER_SIMILAR_ASSET_BUCKET; j++) {
+				sb.append(StringPool.UNDERLINE);
+				sb.append(
+					_similarityHashPolicy.getComponent(
+						similarityHash,
+						(i * _SAMPLES_PER_SIMILAR_ASSET_BUCKET) + j));
+			}
+
+			similarAssetBuckets[i] = sb.toString();
+		}
+
+		return similarAssetBuckets;
+	}
+
+	private static Set<String> _getWordSequences(String text) {
+		Set<String> wordSequences = new HashSet<>();
+
+		String[] words = StringUtil.toLowerCase(
+			text, LocaleUtil.ENGLISH
+		).replaceAll(
+			"[^\\p{L}\\p{Nd}]+", " "
+		).trim(
+		).split(
+			"\\s+"
+		);
+
+		if ((words.length == 1) && words[0].isEmpty()) {
+			return wordSequences;
+		}
+
+		if (words.length < _WORD_SEQUENCE_SIZE) {
+			for (String word : words) {
+				wordSequences.add(word);
+			}
+
+			return wordSequences;
+		}
+
+		for (int i = 0; i <= (words.length - _WORD_SEQUENCE_SIZE); i++) {
+			StringBundler sb = new StringBundler();
+
+			for (int j = 0; j < _WORD_SEQUENCE_SIZE; j++) {
+				if (j > 0) {
+					sb.append(StringPool.SPACE);
+				}
+
+				sb.append(words[i + j]);
+			}
+
+			wordSequences.add(sb.toString());
+		}
+
+		return wordSequences;
+	}
+
+	private static final int _BITS_PER_SAMPLE = 8;
+
+	private static final int _SAMPLES_PER_SIMILAR_ASSET_BUCKET = 4;
+
+	private static final int _SIMILAR_ASSET_BUCKETS = 32;
+
+	private static final int _WORD_SEQUENCE_SIZE = 3;
+
+	private static final Hasher64 _hasher64 = Hashing.murmur3_128();
+	private static final SimilarityHashPolicy _similarityHashPolicy =
+		SimilarityHashing.superMinHash(
+			_SIMILAR_ASSET_BUCKETS * _SAMPLES_PER_SIMILAR_ASSET_BUCKET,
+			_BITS_PER_SAMPLE, SuperMinHashVersion.V1);
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributor.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.CompanyIndexConfigurationContributor;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.SettingsHelper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = CompanyIndexConfigurationContributor.class)
+public class CMSSimilarAssetCompanyIndexConfigurationContributor
+	implements CompanyIndexConfigurationContributor {
+
+	@Override
+	public void contributeMappings(
+		long companyId, MappingsHelper mappingsHelper) {
+
+		mappingsHelper.putMappings(
+			StringUtil.read(
+				getClass(), "dependencies/similar-asset-type-mappings.json"));
+	}
+
+	@Override
+	public void contributeSettings(
+		long companyId, SettingsHelper settingsHelper) {
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentSimilarAssetDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentSimilarAssetDocumentContributor.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentContributor;
+import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.site.cms.site.initializer.internal.search.similar.asset.CMSContentSimilarAssetTextExtractor;
+import com.liferay.site.cms.site.initializer.internal.search.similar.asset.SimilarAssetUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = DocumentContributor.class)
+public class CMSContentSimilarAssetDocumentContributor
+	implements DocumentContributor<ObjectEntry> {
+
+	@Override
+	public void contribute(
+		Document document, BaseModel<ObjectEntry> baseModel) {
+
+		if (!(baseModel instanceof ObjectEntry)) {
+			return;
+		}
+
+		ObjectEntry objectEntry = (ObjectEntry)baseModel;
+
+		try {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					objectEntry.getCompanyId(), "LPD-82226")) {
+
+				return;
+			}
+
+			ObjectDefinition objectDefinition =
+				objectEntry.getObjectDefinition();
+
+			if (!objectDefinition.isCMS()) {
+				return;
+			}
+
+			List<String> similarAssetBuckets = new ArrayList<>();
+
+			for (String languageId :
+					_cmsContentSimilarAssetTextExtractor.getLanguageIds(
+						objectEntry)) {
+
+				similarAssetBuckets.addAll(
+					TransformUtil.transformToList(
+						SimilarAssetUtil.getSimilarAssetBuckets(
+							_cmsContentSimilarAssetTextExtractor.getText(
+								languageId, objectEntry)),
+						similarAssetBucket -> StringBundler.concat(
+							languageId, StringPool.UNDERLINE,
+							similarAssetBucket)));
+			}
+
+			if (similarAssetBuckets.isEmpty()) {
+				return;
+			}
+
+			document.addKeyword(
+				"similarAssetBuckets",
+				similarAssetBuckets.toArray(new String[0]));
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to contribute similar asset buckets for object " +
+						"entry " + objectEntry.getObjectEntryId(),
+					exception);
+			}
+		}
+	}
+
+	@Activate
+	protected void activate() {
+		_cmsContentSimilarAssetTextExtractor =
+			new CMSContentSimilarAssetTextExtractor(_htmlParser);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CMSContentSimilarAssetDocumentContributor.class);
+
+	private CMSContentSimilarAssetTextExtractor
+		_cmsContentSimilarAssetTextExtractor;
+
+	@Reference
+	private HtmlParser _htmlParser;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/GovernanceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/GovernanceService.ts
@@ -49,13 +49,13 @@ async function getAssetStatistics(
 ) {
 	const scope = assetLibraryId ? `assetLibraryId=${assetLibraryId}&` : '';
 
-	const [statistics, similarityClusters] = await Promise.all([
+	const [statistics, similarAssetGroups] = await Promise.all([
 		ApiHelper.get<AssetStatistics>(
 			`/o/headless-cms/v1.0/asset-statistics?${scope}`,
 			signal
 		),
 		ApiHelper.get<{totalCount: number}>(
-			`/o/headless-cms/v1.0/similarity-clusters?${scope}pageSize=1`,
+			`/o/headless-cms/v1.0/similar-asset-groups?${scope}pageSize=1`,
 			signal
 		),
 	]);
@@ -68,7 +68,7 @@ async function getAssetStatistics(
 		...statistics,
 		data: {
 			...statistics.data,
-			duplicatedCount: similarityClusters.data?.totalCount,
+			duplicatedCount: similarAssetGroups.data?.totalCount,
 		},
 	};
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/similar-asset-type-mappings.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/similar-asset-type-mappings.json
@@ -1,0 +1,7 @@
+{
+	"properties": {
+		"similarAssetBuckets": {
+			"type": "keyword"
+		}
+	}
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractorTest.java
@@ -1,0 +1,267 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSContentSimilarAssetTextExtractorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		HtmlParser htmlParser = Mockito.mock(HtmlParser.class);
+
+		Mockito.when(
+			htmlParser.extractText(Mockito.anyString())
+		).thenAnswer(
+			invocation -> {
+				String html = invocation.getArgument(0, String.class);
+
+				return html.replaceAll("<[^>]+>", "");
+			}
+		);
+
+		_cmsContentSimilarAssetTextExtractor =
+			new CMSContentSimilarAssetTextExtractor(htmlParser);
+	}
+
+	@Test
+	public void testGetLanguageIds() throws Exception {
+		Assert.assertEquals(
+			Arrays.asList("en_US", "es_ES"),
+			ListUtil.fromCollection(
+				_cmsContentSimilarAssetTextExtractor.getLanguageIds(
+					_mockObjectEntry(
+						HashMapBuilder.<String, Serializable>put(
+							"i18nContent",
+							HashMapBuilder.put(
+								"en_US", "<p>Body</p>"
+							).put(
+								"es_ES", "<p>Cuerpo</p>"
+							).build()
+						).build()))));
+	}
+
+	@Test
+	public void testGetLanguageIdsWithTitleOnlyTranslation() throws Exception {
+		Assert.assertEquals(
+			Arrays.asList("en_US"),
+			ListUtil.fromCollection(
+				_cmsContentSimilarAssetTextExtractor.getLanguageIds(
+					_mockObjectEntry(
+						HashMapBuilder.<String, Serializable>put(
+							"i18nContent",
+							HashMapBuilder.put(
+								"en_US", "<p>Body</p>"
+							).build()
+						).put(
+							"i18nTitle",
+							HashMapBuilder.put(
+								"en_US", "Title"
+							).put(
+								"ja_JP", "タイトル"
+							).build()
+						).build()))));
+	}
+
+	@Test
+	public void testGetTextWithNonlocalizedField() throws Exception {
+		Assert.assertEquals(
+			"The body ACME-1234 ",
+			_cmsContentSimilarAssetTextExtractor.getText(
+				"en_US",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body</p>"
+						).build()
+					).put(
+						"reference", "ACME-1234"
+					).build())));
+	}
+
+	@Test
+	public void testGetTextWithoutTranslation() throws Exception {
+		Assert.assertEquals(
+			"",
+			_cmsContentSimilarAssetTextExtractor.getText(
+				"es_ES",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body</p>"
+						).build()
+					).put(
+						"i18nTitle",
+						HashMapBuilder.put(
+							"es_ES", "Solo el titulo"
+						).build()
+					).build())));
+	}
+
+	@Test
+	public void testGetTextWithTitle() throws Exception {
+		Assert.assertEquals(
+			"The body of the content ",
+			_cmsContentSimilarAssetTextExtractor.getText(
+				"en_US",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body of the content</p>"
+						).build()
+					).put(
+						"i18nTitle",
+						HashMapBuilder.put(
+							"en_US", "Zeta Quarterly Report Alpha"
+						).build()
+					).build())));
+	}
+
+	private ObjectEntry _mockObjectEntry(
+			Map<String, Serializable> indexedValues)
+		throws Exception {
+
+		ObjectField contentObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT, "i18nContent", true,
+			_OBJECT_FIELD_ID_CONTENT, "content");
+		ObjectField referenceObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, null, false,
+			_OBJECT_FIELD_ID_REFERENCE, "reference");
+		ObjectField titleObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, "i18nTitle", true,
+			_OBJECT_FIELD_ID_TITLE, "title");
+
+		List<ObjectField> objectFields = Arrays.asList(
+			contentObjectField, referenceObjectField, titleObjectField);
+
+		ObjectFieldBag objectFieldBag = new ObjectFieldBag(objectFields);
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getObjectFieldBag()
+		).thenReturn(
+			objectFieldBag
+		);
+
+		Mockito.when(
+			objectDefinition.getTitleObjectFieldId()
+		).thenReturn(
+			_OBJECT_FIELD_ID_TITLE
+		);
+
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			objectEntry.getDefaultLanguageId()
+		).thenReturn(
+			"en_US"
+		);
+
+		Mockito.when(
+			objectEntry.getIndexedValues()
+		).thenReturn(
+			indexedValues
+		);
+
+		Mockito.when(
+			objectEntry.getObjectDefinition()
+		).thenReturn(
+			objectDefinition
+		);
+
+		return objectEntry;
+	}
+
+	private ObjectField _mockObjectField(
+		String businessType, String i18nObjectFieldName, boolean localized,
+		long objectFieldId, String name) {
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getBusinessType()
+		).thenReturn(
+			businessType
+		);
+
+		Mockito.when(
+			objectField.getI18nObjectFieldName()
+		).thenReturn(
+			i18nObjectFieldName
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			objectField.getObjectFieldId()
+		).thenReturn(
+			objectFieldId
+		);
+
+		Mockito.when(
+			objectField.isIndexed()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			localized
+		);
+
+		return objectField;
+	}
+
+	private static final long _OBJECT_FIELD_ID_CONTENT = 2;
+
+	private static final long _OBJECT_FIELD_ID_REFERENCE = 3;
+
+	private static final long _OBJECT_FIELD_ID_TITLE = 1;
+
+	private CMSContentSimilarAssetTextExtractor
+		_cmsContentSimilarAssetTextExtractor;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtilTest.java
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Mikel Lorza
+ */
+public class SimilarAssetUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBlankTextYieldsNoSimilarAssetBuckets() {
+		Assert.assertEquals(
+			0, SimilarAssetUtil.getSimilarAssetBuckets(null).length);
+		Assert.assertEquals(
+			0, SimilarAssetUtil.getSimilarAssetBuckets("").length);
+		Assert.assertEquals(
+			0, SimilarAssetUtil.getSimilarAssetBuckets("   ").length);
+	}
+
+	@Test
+	public void testDeterministic() {
+		Assert.assertArrayEquals(
+			SimilarAssetUtil.getSimilarAssetBuckets(_A),
+			SimilarAssetUtil.getSimilarAssetBuckets(_A));
+	}
+
+	@Test
+	public void testDeterministicAcrossDefaultLocales() {
+		Locale defaultLocale = LocaleUtil.getDefault();
+
+		try {
+			LocaleUtil.setDefault("en", "US", null);
+
+			String[] similarAssetBuckets =
+				SimilarAssetUtil.getSimilarAssetBuckets(_TURKISH);
+
+			LocaleUtil.setDefault("tr", "TR", null);
+
+			Assert.assertArrayEquals(
+				similarAssetBuckets,
+				SimilarAssetUtil.getSimilarAssetBuckets(_TURKISH));
+		}
+		finally {
+			LocaleUtil.setDefault(
+				defaultLocale.getLanguage(), defaultLocale.getCountry(),
+				defaultLocale.getVariant());
+		}
+	}
+
+	@Test
+	public void testDistinctTextSharesNoSimilarAssetBuckets() {
+		Assert.assertEquals(
+			0, _getSharedSimilarAssetBucketCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testNearDuplicateSharesMoreThanDistinct() {
+		Assert.assertTrue(
+			_getSharedSimilarAssetBucketCount(_A, _A + " 2") >
+				_getSharedSimilarAssetBucketCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testNearDuplicateSharesMostSimilarAssetBuckets() {
+		Assert.assertTrue(
+			_getSharedSimilarAssetBucketCount(_A, _A + " 2") >= 20);
+	}
+
+	private int _getSharedSimilarAssetBucketCount(String text1, String text2) {
+		Set<String> similarAssetBuckets = new HashSet<>();
+
+		for (String similarAssetBucket :
+				SimilarAssetUtil.getSimilarAssetBuckets(text1)) {
+
+			similarAssetBuckets.add(similarAssetBucket);
+		}
+
+		int count = 0;
+
+		for (String similarAssetBucket :
+				SimilarAssetUtil.getSimilarAssetBuckets(text2)) {
+
+			if (similarAssetBuckets.contains(similarAssetBucket)) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	private static final String _A =
+		"If you forgot your password, go to the login page and click the " +
+			"forgot password link. Enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	private static final String _DISTINCT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market. Product categories in retail and wholesale " +
+				"increased during the last fiscal period.";
+
+	private static final String _TURKISH =
+		"KULLANICI ADINIZI VE \u0130NTERNET \u015E\u0130FREN\u0130Z\u0130 " +
+			"G\u0130R\u0130N VE OTURUM A\u00c7MAK \u0130\u00c7\u0130N " +
+				"\u0130LER\u0130 D\u00dc\u011eMES\u0130NE BASIN";
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributorTest.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSSimilarAssetCompanyIndexConfigurationContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContributeMappings() {
+		CMSSimilarAssetCompanyIndexConfigurationContributor
+			cmsSimilarAssetCompanyIndexConfigurationContributor =
+				new CMSSimilarAssetCompanyIndexConfigurationContributor();
+
+		MappingsHelper mappingsHelper = Mockito.mock(MappingsHelper.class);
+
+		cmsSimilarAssetCompanyIndexConfigurationContributor.contributeMappings(
+			RandomTestUtil.randomLong(), mappingsHelper);
+
+		ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			mappingsHelper
+		).putMappings(
+			argumentCaptor.capture()
+		);
+
+		Assert.assertEquals(
+			"{\"properties\": {\"similarAssetBuckets\": {\"type\": " +
+				"\"keyword\"}}}",
+			StringUtil.removeChars(
+				argumentCaptor.getValue(), CharPool.NEW_LINE, CharPool.RETURN,
+				CharPool.TAB));
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceService.test.ts
@@ -24,7 +24,7 @@ describe('GovernanceService.getAssetStatistics', () => {
 		);
 
 		expect(getSpy).toHaveBeenCalledWith(
-			'/o/headless-cms/v1.0/similarity-clusters?assetLibraryId=123&pageSize=1',
+			'/o/headless-cms/v1.0/similar-asset-groups?assetLibraryId=123&pageSize=1',
 			undefined
 		);
 	});
@@ -42,7 +42,7 @@ describe('GovernanceService.getAssetStatistics', () => {
 		);
 
 		expect(getSpy).toHaveBeenCalledWith(
-			'/o/headless-cms/v1.0/similarity-clusters?pageSize=1',
+			'/o/headless-cms/v1.0/similar-asset-groups?pageSize=1',
 			undefined
 		);
 	});
@@ -62,14 +62,14 @@ describe('GovernanceService.getAssetStatistics', () => {
 		);
 
 		expect(getSpy).toHaveBeenCalledWith(
-			'/o/headless-cms/v1.0/similarity-clusters?pageSize=1',
+			'/o/headless-cms/v1.0/similar-asset-groups?pageSize=1',
 			signal
 		);
 	});
 
 	it('counts the assets in similarity clusters as the duplicated count', async () => {
 		jest.spyOn(ApiHelper, 'get').mockImplementation(((url: string) => {
-			if (url.includes('similarity-clusters')) {
+			if (url.includes('similar-asset-groups')) {
 				return Promise.resolve({data: {totalCount: 5}, error: null});
 			}
 
@@ -83,7 +83,7 @@ describe('GovernanceService.getAssetStatistics', () => {
 
 	it('leaves the duplicated count unset when the clusters are unavailable', async () => {
 		jest.spyOn(ApiHelper, 'get').mockImplementation(((url: string) => {
-			if (url.includes('similarity-clusters')) {
+			if (url.includes('similar-asset-groups')) {
 				return Promise.resolve({data: null, error: 'Not Found'});
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97867

## What Is Being Fixed

The Content Governance Dashboard has to report which CMS contents are near duplicates of each other, and nothing in the index says how similar two contents are. Answering it at read time means one similarity query per document, which neither scales nor gives the same answer twice as the corpus grows.

## How It Is Being Fixed

Every CMS content is hashed when it is indexed, and the endpoint groups the contents whose hashes collide. This is the first of three slices, and it is end to end: it writes the field, reads it back, and answers with the groups, so the whole path can be exercised. Both paths are behind `LPD-82226`, the flag the rest of the governance feature ships under, so an instance that enables nothing pays neither the index cost nor an endpoint answering in this slice's shape.

On the write side, the text of a content — every indexed text, long text and rich text field except the title — is reduced to three word sequences and hashed with Dynatrace's hash4j, whose SuperMinHash produces 128 samples. The samples are split into 32 groups of 4, and each group becomes one indexed value, so two contents that fall into enough of the same buckets are near duplicate candidates. The algorithm version is pinned, because a library upgrade that moved it would silently change every indexed value.

The buckets are indexed as a multivalued keyword field, one value per language, because a field whose name ends in a language ID is claimed by the platform's dynamic template and mapped to analyzed text, which cannot back an aggregation. The mappings resource declares the field a keyword for the same reason, and a unit test asserts the contributor puts exactly that mapping — that is the drift that would otherwise fail silently, with no groups and no error.

On the read side, `GET /o/headless-cms/v1.0/similar-asset-groups` runs a flat terms aggregation over the field to find the buckets more than one content falls into, fetches those contents, and joins them with a union find. Both searches carry the caller's permissions, so a group never counts or shows content the caller cannot view. Groups come back biggest first, and a group split across a page boundary repeats in the next page carrying its full size.

Two contents are joined only once they share three buckets, not one. Grouping is transitive, so a single false link collapses hundreds of contents into one group. Measured over 50,000 documents and 1.25 billion pairs, the three bucket threshold produced no group that mixed unrelated contents. That sweep was run on hash4j's SuperMinHash with the version pinned, side by side with the hand written implementation it replaced, and both produced zero contaminated groups. A bucket shared by more than five hundred assets is treated as common rather than as pair evidence, and those assets are merged wholesale, which keeps a corpus of near identical content from enumerating tens of millions of pairs inside one request.

The aggregation is flat rather than nested for a measured reason: a nested aggregation creates a bucket per group member as well as per indexed value, and blows past Elasticsearch's own `search.max_buckets` ceiling once a Space holds a few thousand near duplicates — the endpoint then answers with zero groups and no error. Two limits bound the rest. The aggregation asks for 10,000 buckets, which is about 850 duplicate groups per language, and beyond that budget whole groups are dropped silently; raising it deserves its own ticket. The document search asks for 10,000 contents, which sits exactly on the default `index.max_result_window`.

The operation answers with `Page<SimilarAssetGroup>` rather than a hand rolled wrapper, so `totalCount` comes from the platform. Note that `totalCount` counts assets while the items are groups: the endpoint paginates by asset, so a group's size never depends on the requested page. That explanation also sits in the operation description, so it reaches the API consumer rather than only the reviewer.

hash4j is embedded with `compileInclude`, which is why `bnd.bnd` carries `-fixupmessages` for the wrong directory warning: the library is a multi release jar, and without that line the bundle does not build. Thirty nine other bundles under `modules` pair the two the same way.

The two slices still to come add each group's name, its representative and the similarity percentage — which is where the full hash and its reader arrive together, so a reindex is needed then — and after that the search, sort and dimension parameters.

## What Changed Since The Previous Pull Request

Supersedes #8867, whose forward (`brianchandotcom#180942`) was closed on two points. Both are applied exactly as written, and nothing else changed.

**`contextAcceptLanguage.getPreferredLanguageId()` no longer travels as a parameter.** It was read once into a `String languageId` local and threaded through three private methods to reach the three places that actually use it. The local and the parameter are gone; each of the three call sites reads the context directly, which is the field every other resource in this API reads.

**The two locals are declared in the order the guard below them reads.** `groupIds` now precedes `objectDefinitions`, matching the diff in the review comment.

## Test Execution

| Suite | Result |
| --- | --- |
| `SimilarAssetGroupResourceTest` (integration) | 6 tests, 0 failures |
| `site-cms-site-initializer` Java unit tests | 12 tests, 0 failures |
| `site-cms-site-initializer` Jest suite | 182 suites, 1053 tests, 0 failures |
| `ModulesStructureTest` | 8 tests, 0 failures |

The integration run was made against a bundle carrying this branch's `headless-cms-impl`, so the endpoint answering is the one with the parameter removed.

## PR Check

**pr-check: PASS** — tested on `a9845e00dd1d466f39b65e8d82a59c502b200997`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a9845e00dd1d466f39b65e8d82a59c502b200997"} -->
